### PR TITLE
chore: use dist-* instead of dist/* for output folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+dist-*

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -14,11 +14,11 @@
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
-    "downlevel-dts": "downlevel-dts dist/types dist/types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
   },
-  "main": "./dist/cjs/index.js",
-  "types": "./dist/types/index.d.ts",
-  "module": "./dist/es/index.js",
+  "main": "./dist-cjs/index.js",
+  "types": "./dist-types/index.d.ts",
+  "module": "./dist-es/index.js",
   "browser": {
     "./runtimeConfig": "./runtimeConfig.browser"
   },
@@ -92,8 +92,8 @@
   },
   "typesVersions": {
     "<4.0": {
-      "dist/types/*": [
-        "dist/types/ts3.4/*"
+      "dist-types/*": [
+        "dist-types/ts3.4/*"
       ]
     }
   },

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -3,10 +3,9 @@
   "description": "Testing install size reduction in @aws-sdk/client-s3",
   "version": "0.0.2",
   "scripts": {
-    "clean": "yarn remove-definitions && yarn remove-dist && yarn remove-documentation",
+    "clean": "yarn remove-dist && yarn remove-documentation",
     "build-documentation": "yarn remove-documentation && typedoc ./",
-    "remove-definitions": "rimraf ./types",
-    "remove-dist": "rimraf ./dist",
+    "remove-dist": "rimraf ./dist-*",
     "remove-documentation": "rimraf ./docs",
     "test:unit": "ts-mocha src/**/*.spec.ts",
     "test:e2e": "ts-mocha test/**/*.ispec.ts && karma start karma.conf.js",

--- a/clients/client-s3/src/runtimeConfig.browser.ts
+++ b/clients/client-s3/src/runtimeConfig.browser.ts
@@ -1,3 +1,4 @@
+// @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";

--- a/clients/client-s3/src/runtimeConfig.ts
+++ b/clients/client-s3/src/runtimeConfig.ts
@@ -1,3 +1,4 @@
+// @ts-ignore: package.json will be imported from dist folders
 import packageInfo from "../package.json";
 
 import { decorateDefaultCredentialProvider } from "@aws-sdk/client-sts";

--- a/clients/client-s3/tsconfig.es.json
+++ b/clients/client-s3/tsconfig.es.json
@@ -5,8 +5,8 @@
     "module": "esnext",
     "moduleResolution": "node",
     "declaration": true,
-    "declarationDir": "./dist/types",
+    "declarationDir": "dist-types",
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
-    "outDir": "dist/es"
+    "outDir": "dist-es"
   }
 }

--- a/clients/client-s3/tsconfig.json
+++ b/clients/client-s3/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "rootDir": "./src",
     "alwaysStrict": true,
     "target": "ES2018",
     "module": "commonjs",
@@ -11,7 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "outDir": "dist/cjs",
+    "outDir": "dist-cjs",
     "types": ["mocha", "node"]
   },
   "typedocOptions": {
@@ -28,6 +29,5 @@
     "theme": "minimal",
     "plugin": ["@aws-sdk/client-documentation-generator"]
   },
-  "include": ["src/**/*", "./package.json"],
   "exclude": ["test/**/*"]
 }


### PR DESCRIPTION
Uses `dist-*` instead of `dist/*` for outDir.
This way package.json does not have to be copied, and dist folder will contain just src files.