### PR TITLE
chore(tsconfig): set removeComments to true

### DIFF
--- a/clients/client-s3/tsconfig.json
+++ b/clients/client-s3/tsconfig.json
@@ -12,6 +12,7 @@
     "incremental": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
+    "removeComments": true,
     "outDir": "dist-cjs",
     "types": ["mocha", "node"]
   },


### PR DESCRIPTION
*Description of changes:*
Experiment with tsconfig [removeComments](https://www.typescriptlang.org/tsconfig#removeComments)

We're not going ahead with this change, as TypeScript removes comments even from *.d.ts files.
We need comments in `*.d.ts` files, as they're used as an API Reference while coding - like in Intellisense.

Open feature request in TypeScript repo https://github.com/microsoft/TypeScript/issues/14619

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
