### PR TITLE
chore(client-s3): drop support for <ts3.7

### DIFF
--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -14,7 +14,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
-    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.4"
+    "downlevel-dts": "downlevel-dts dist-types dist-types/ts3.7 [--to=3.7]"
   },
   "main": "./dist-cjs/index.js",
   "types": "./dist-types/index.d.ts",
@@ -96,7 +96,7 @@
   "typesVersions": {
     "<4.0": {
       "dist-types/*": [
-        "dist-types/ts3.4/*"
+        "dist-types/ts3.7/*"
       ]
     }
   },


### PR DESCRIPTION
*Issue #, if available:*
DefinitelyTyped supports only 3.7+
https://github.com/DefinitelyTyped/DefinitelyTyped#support-window

*Description of changes:*
Drops support for <ts3.7
We're not going ahead with these changes, as it doesn't reduce the install size.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
