### PR TITLE
feat: add script to strip-comments from downlevel-dts code

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mocha": "^8.0.1",
     "prettier": "2.3.0",
     "puppeteer": "^4.0.0",
+    "strip-comments": "2.0.1",
     "ts-loader": "^7.0.5",
     "ts-mocha": "^8.0.0",
     "webpack": "^4.43.0",

--- a/scripts/strip-comments.js
+++ b/scripts/strip-comments.js
@@ -1,0 +1,37 @@
+const { readdirSync, readFileSync, statSync, writeFileSync } = require("fs");
+const { join } = require("path");
+const stripComments = require("strip-comments");
+
+const { packages } = JSON.parse(readFileSync(join(process.cwd(), "package.json"))).workspaces;
+
+const getAllFiles = (dirPath, arrayOfFiles) => {
+  files = readdirSync(dirPath);
+
+  arrayOfFiles = arrayOfFiles || [];
+
+  files.forEach((file) => {
+    if (statSync(dirPath + "/" + file).isDirectory()) {
+      arrayOfFiles = getAllFiles(dirPath + "/" + file, arrayOfFiles);
+    } else {
+      arrayOfFiles.push(join(dirPath, "/", file));
+    }
+  });
+
+  return arrayOfFiles;
+};
+
+packages
+  .map((dir) => dir.replace("/*", ""))
+  .forEach((workspacesDir) => {
+    // Process each workspace in workspace directory
+    readdirSync(join(process.cwd(), workspacesDir), { withFileTypes: true })
+      .filter((dirent) => dirent.isDirectory())
+      .map((dirent) => dirent.name)
+      .forEach((workspaceDir) => {
+        const downlevelDir = join(process.cwd(), workspacesDir, workspaceDir, "dist-types/ts3.4");
+        getAllFiles(downlevelDir).forEach((filepath) => {
+          const content = readFileSync(filepath, "utf8");
+          writeFileSync(filepath, stripComments(content));
+        });
+      });
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9797,6 +9797,11 @@ strip-bom@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
   integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
 
+strip-comments@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-comments/-/strip-comments-2.0.1.tgz#4ad11c3fbcac177a67a40ac224ca339ca1c1ba9b"
+  integrity sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==
+
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The script strips comments from all `.dts` files which are dowleveled.

<details>
<summary>Before stripping comments</summary>

```console
package size:  549.6 kB
unpacked size: 6.3 MB
total files:   670
```

</details>

<details>
<summary>After stripping comments</summary>

```console
package size:  438.4 kB
unpacked size: 5.3 MB
total files:   670
```

</details>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
