### PR TITLE
chore(tsconfig): remove sourceMap

### DIFF
--- a/clients/client-s3/tsconfig.json
+++ b/clients/client-s3/tsconfig.json
@@ -5,7 +5,6 @@
     "target": "ES2018",
     "module": "commonjs",
     "strict": true,
-    "sourceMap": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
As we're not publishing TypeScript source files anymore, we can remove sourceMaps too.

<details>
<summary>With sourceMaps</summary>

```console
package size:  438.4 kB
unpacked size: 5.3 MB
total files:   670
```

</details>

<details>
<summary>Without sourceMaps</summary>

```console
package size:  339.7 kB
unpacked size: 3.8 MB
total files:   448
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
