### PR TITLE
chore: remove unnecessary whitespace from comments

### DIFF
--- a/clients/client-s3/src/S3.ts
+++ b/clients/client-s3/src/S3.ts
@@ -431,44 +431,44 @@ import { HttpHandlerOptions as __HttpHandlerOptions } from "@aws-sdk/types";
 export class S3 extends S3Client {
   /**
    * <p>This action aborts a multipart upload. After a multipart upload is aborted, no
-   *          additional parts can be uploaded using that upload ID. The storage consumed by any
-   *          previously uploaded parts will be freed. However, if any part uploads are currently in
-   *          progress, those part uploads might or might not succeed. As a result, it might be necessary
-   *          to abort a given multipart upload multiple times in order to completely free all storage
-   *          consumed by all parts. </p>
-   *          <p>To verify that all parts have been removed, so you don't get charged for the part
-   *          storage, you should call the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a> action and ensure that
-   *          the parts list is empty.</p>
-   *          <p>For information about permissions required to use the multipart upload, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
-   *          Permissions</a>.</p>
-   *          <p>The following operations are related to <code>AbortMultipartUpload</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * additional parts can be uploaded using that upload ID. The storage consumed by any
+   * previously uploaded parts will be freed. However, if any part uploads are currently in
+   * progress, those part uploads might or might not succeed. As a result, it might be necessary
+   * to abort a given multipart upload multiple times in order to completely free all storage
+   * consumed by all parts. </p>
+   * <p>To verify that all parts have been removed, so you don't get charged for the part
+   * storage, you should call the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a> action and ensure that
+   * the parts list is empty.</p>
+   * <p>For information about permissions required to use the multipart upload, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
+   * Permissions</a>.</p>
+   * <p>The following operations are related to <code>AbortMultipartUpload</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public abortMultipartUpload(
     args: AbortMultipartUploadCommandInput,
@@ -501,115 +501,115 @@ export class S3 extends S3Client {
 
   /**
    * <p>Completes a multipart upload by assembling previously uploaded parts.</p>
-   *          <p>You first initiate the multipart upload and then upload all parts using the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
-   *          operation. After successfully uploading all relevant parts of an upload, you call this
-   *          action to complete the upload. Upon receiving this request, Amazon S3 concatenates all
-   *          the parts in ascending order by part number to create a new object. In the Complete
-   *          Multipart Upload request, you must provide the parts list. You must ensure that the parts
-   *          list is complete. This action concatenates the parts that you provide in the list. For
-   *          each part in the list, you must provide the part number and the <code>ETag</code> value,
-   *          returned after that part was uploaded.</p>
-   *          <p>Processing of a Complete Multipart Upload request could take several minutes to
-   *          complete. After Amazon S3 begins processing the request, it sends an HTTP response header that
-   *          specifies a 200 OK response. While processing is in progress, Amazon S3 periodically sends white
-   *          space characters to keep the connection from timing out. Because a request could fail after
-   *          the initial 200 OK response has been sent, it is important that you check the response body
-   *          to determine whether the request succeeded.</p>
-   *          <p>Note that if <code>CompleteMultipartUpload</code> fails, applications should be prepared
-   *          to retry the failed requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ErrorBestPractices.html">Amazon S3 Error Best Practices</a>.</p>
-   *          <p>For more information about multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
-   *             Upload</a>.</p>
-   *          <p>For information about permissions required to use the multipart upload API, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
-   *          Permissions</a>.</p>
+   * <p>You first initiate the multipart upload and then upload all parts using the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+   * operation. After successfully uploading all relevant parts of an upload, you call this
+   * action to complete the upload. Upon receiving this request, Amazon S3 concatenates all
+   * the parts in ascending order by part number to create a new object. In the Complete
+   * Multipart Upload request, you must provide the parts list. You must ensure that the parts
+   * list is complete. This action concatenates the parts that you provide in the list. For
+   * each part in the list, you must provide the part number and the <code>ETag</code> value,
+   * returned after that part was uploaded.</p>
+   * <p>Processing of a Complete Multipart Upload request could take several minutes to
+   * complete. After Amazon S3 begins processing the request, it sends an HTTP response header that
+   * specifies a 200 OK response. While processing is in progress, Amazon S3 periodically sends white
+   * space characters to keep the connection from timing out. Because a request could fail after
+   * the initial 200 OK response has been sent, it is important that you check the response body
+   * to determine whether the request succeeded.</p>
+   * <p>Note that if <code>CompleteMultipartUpload</code> fails, applications should be prepared
+   * to retry the failed requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ErrorBestPractices.html">Amazon S3 Error Best Practices</a>.</p>
+   * <p>For more information about multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
+   *    Upload</a>.</p>
+   * <p>For information about permissions required to use the multipart upload API, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
+   * Permissions</a>.</p>
    *
    *
-   *          <p>
-   *             <code>CompleteMultipartUpload</code> has the following special errors:</p>
-   *          <ul>
-   *             <li>
-   *                <p>Error code: <code>EntityTooSmall</code>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>Description: Your proposed upload is smaller than the minimum allowed object
-   *                      size. Each part must be at least 5 MB in size, except the last part.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>400 Bad Request</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <p>Error code: <code>InvalidPart</code>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>Description: One or more of the specified parts could not be found. The part
-   *                      might not have been uploaded, or the specified entity tag might not have
-   *                      matched the part's entity tag.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>400 Bad Request</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <p>Error code: <code>InvalidPartOrder</code>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>Description: The list of parts was not in ascending order. The parts list
-   *                      must be specified in order by part number.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>400 Bad Request</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <p>Error code: <code>NoSuchUpload</code>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>Description: The specified multipart upload does not exist. The upload ID
-   *                      might be invalid, or the multipart upload might have been aborted or
-   *                      completed.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>404 Not Found</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *          </ul>
+   * <p>
+   *    <code>CompleteMultipartUpload</code> has the following special errors:</p>
+   * <ul>
+   *    <li>
+   *       <p>Error code: <code>EntityTooSmall</code>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>Description: Your proposed upload is smaller than the minimum allowed object
+   *             size. Each part must be at least 5 MB in size, except the last part.</p>
+   *          </li>
+   *          <li>
+   *             <p>400 Bad Request</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <p>Error code: <code>InvalidPart</code>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>Description: One or more of the specified parts could not be found. The part
+   *             might not have been uploaded, or the specified entity tag might not have
+   *             matched the part's entity tag.</p>
+   *          </li>
+   *          <li>
+   *             <p>400 Bad Request</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <p>Error code: <code>InvalidPartOrder</code>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>Description: The list of parts was not in ascending order. The parts list
+   *             must be specified in order by part number.</p>
+   *          </li>
+   *          <li>
+   *             <p>400 Bad Request</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <p>Error code: <code>NoSuchUpload</code>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>Description: The specified multipart upload does not exist. The upload ID
+   *             might be invalid, or the multipart upload might have been aborted or
+   *             completed.</p>
+   *          </li>
+   *          <li>
+   *             <p>404 Not Found</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   * </ul>
    *
-   *          <p>The following operations are related to <code>CompleteMultipartUpload</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>CompleteMultipartUpload</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public completeMultipartUpload(
     args: CompleteMultipartUploadCommandInput,
@@ -642,175 +642,175 @@ export class S3 extends S3Client {
 
   /**
    * <p>Creates a copy of an object that is already stored in Amazon S3.</p>
-   *          <note>
-   *             <p>You can store individual objects of up to 5 TB in Amazon S3. You create a copy of your
-   *             object up to 5 GB in size in a single atomic action using this API. However, to copy
-   *             an object greater than 5 GB, you must use the multipart upload Upload Part - Copy API.
-   *             For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjctsUsingRESTMPUapi.html">Copy Object Using the REST Multipart Upload API</a>.</p>
-   *          </note>
-   *          <p>All copy requests must be authenticated. Additionally, you must have
-   *             <i>read</i> access to the source object and <i>write</i>
-   *          access to the destination bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html">REST Authentication</a>. Both the Region
-   *          that you want to copy the object from and the Region that you want to copy the object to
-   *          must be enabled for your account.</p>
-   *          <p>A copy request might return an error when Amazon S3 receives the copy request or while Amazon S3
-   *          is copying the files. If the error occurs before the copy action starts, you receive a
-   *          standard Amazon S3 error. If the error occurs during the copy operation, the error response is
-   *          embedded in the <code>200 OK</code> response. This means that a <code>200 OK</code>
-   *          response can contain either a success or an error. Design your application to parse the
-   *          contents of the response and handle it appropriately.</p>
-   *          <p>If the copy is successful, you receive a response with information about the copied
-   *          object.</p>
-   *          <note>
-   *             <p>If the request is an HTTP 1.1 request, the response is chunk encoded. If it were not,
-   *             it would not contain the content-length, and you would need to read the entire
-   *             body.</p>
-   *          </note>
-   *          <p>The copy request charge is based on the storage class and Region that you specify for
-   *          the destination object. For pricing information, see <a href="http://aws.amazon.com/s3/pricing/">Amazon S3 pricing</a>.</p>
-   *          <important>
-   *             <p>Amazon S3 transfer acceleration does not support cross-Region copies. If you request a
-   *             cross-Region copy using a transfer acceleration endpoint, you get a 400 <code>Bad
-   *                Request</code> error. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html">Transfer Acceleration</a>.</p>
-   *          </important>
-   *          <p>
-   *             <b>Metadata</b>
-   *          </p>
-   *          <p>When copying an object, you can preserve all metadata (default) or specify new metadata.
-   *          However, the ACL is not preserved and is set to private for the user making the request. To
-   *          override the default ACL setting, specify a new ACL when generating a copy request. For
-   *          more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. </p>
-   *          <p>To specify whether you want the object metadata copied from the source object or
-   *          replaced with metadata provided in the request, you can optionally add the
-   *             <code>x-amz-metadata-directive</code> header. When you grant permissions, you can use
-   *          the <code>s3:x-amz-metadata-directive</code> condition key to enforce certain metadata
-   *          behavior when objects are uploaded. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html">Specifying Conditions in a
-   *             Policy</a> in the <i>Amazon S3 User Guide</i>. For a complete list of
-   *          Amazon S3-specific condition keys, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/list_amazons3.html">Actions, Resources, and Condition Keys for
-   *             Amazon S3</a>.</p>
-   *          <p>
-   *             <b>
-   *                <code>x-amz-copy-source-if</code> Headers</b>
-   *          </p>
-   *          <p>To only copy an object under certain conditions, such as whether the <code>Etag</code>
-   *          matches or whether the object was modified before or after a specified date, use the
-   *          following request parameters:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <code>x-amz-copy-source-if-match</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>x-amz-copy-source-if-none-match</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>x-amz-copy-source-if-unmodified-since</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>x-amz-copy-source-if-modified-since</code>
-   *                </p>
-   *             </li>
-   *          </ul>
-   *          <p> If both the <code>x-amz-copy-source-if-match</code> and
-   *             <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request
-   *          and evaluate as follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <code>x-amz-copy-source-if-match</code> condition evaluates to true</p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to
-   *                false</p>
-   *             </li>
-   *          </ul>
+   * <note>
+   *    <p>You can store individual objects of up to 5 TB in Amazon S3. You create a copy of your
+   *    object up to 5 GB in size in a single atomic action using this API. However, to copy
+   *    an object greater than 5 GB, you must use the multipart upload Upload Part - Copy API.
+   *    For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjctsUsingRESTMPUapi.html">Copy Object Using the REST Multipart Upload API</a>.</p>
+   * </note>
+   * <p>All copy requests must be authenticated. Additionally, you must have
+   *    <i>read</i> access to the source object and <i>write</i>
+   * access to the destination bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html">REST Authentication</a>. Both the Region
+   * that you want to copy the object from and the Region that you want to copy the object to
+   * must be enabled for your account.</p>
+   * <p>A copy request might return an error when Amazon S3 receives the copy request or while Amazon S3
+   * is copying the files. If the error occurs before the copy action starts, you receive a
+   * standard Amazon S3 error. If the error occurs during the copy operation, the error response is
+   * embedded in the <code>200 OK</code> response. This means that a <code>200 OK</code>
+   * response can contain either a success or an error. Design your application to parse the
+   * contents of the response and handle it appropriately.</p>
+   * <p>If the copy is successful, you receive a response with information about the copied
+   * object.</p>
+   * <note>
+   *    <p>If the request is an HTTP 1.1 request, the response is chunk encoded. If it were not,
+   *    it would not contain the content-length, and you would need to read the entire
+   *    body.</p>
+   * </note>
+   * <p>The copy request charge is based on the storage class and Region that you specify for
+   * the destination object. For pricing information, see <a href="http://aws.amazon.com/s3/pricing/">Amazon S3 pricing</a>.</p>
+   * <important>
+   *    <p>Amazon S3 transfer acceleration does not support cross-Region copies. If you request a
+   *    cross-Region copy using a transfer acceleration endpoint, you get a 400 <code>Bad
+   *       Request</code> error. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html">Transfer Acceleration</a>.</p>
+   * </important>
+   * <p>
+   *    <b>Metadata</b>
+   * </p>
+   * <p>When copying an object, you can preserve all metadata (default) or specify new metadata.
+   * However, the ACL is not preserved and is set to private for the user making the request. To
+   * override the default ACL setting, specify a new ACL when generating a copy request. For
+   * more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. </p>
+   * <p>To specify whether you want the object metadata copied from the source object or
+   * replaced with metadata provided in the request, you can optionally add the
+   *    <code>x-amz-metadata-directive</code> header. When you grant permissions, you can use
+   * the <code>s3:x-amz-metadata-directive</code> condition key to enforce certain metadata
+   * behavior when objects are uploaded. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html">Specifying Conditions in a
+   *    Policy</a> in the <i>Amazon S3 User Guide</i>. For a complete list of
+   * Amazon S3-specific condition keys, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/list_amazons3.html">Actions, Resources, and Condition Keys for
+   *    Amazon S3</a>.</p>
+   * <p>
+   *    <b>
+   *       <code>x-amz-copy-source-if</code> Headers</b>
+   * </p>
+   * <p>To only copy an object under certain conditions, such as whether the <code>Etag</code>
+   * matches or whether the object was modified before or after a specified date, use the
+   * following request parameters:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <code>x-amz-copy-source-if-match</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>x-amz-copy-source-if-none-match</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>x-amz-copy-source-if-unmodified-since</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>x-amz-copy-source-if-modified-since</code>
+   *       </p>
+   *    </li>
+   * </ul>
+   * <p> If both the <code>x-amz-copy-source-if-match</code> and
+   *    <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request
+   * and evaluate as follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <code>x-amz-copy-source-if-match</code> condition evaluates to true</p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to
+   *       false</p>
+   *    </li>
+   * </ul>
    *
-   *          <p>If both the <code>x-amz-copy-source-if-none-match</code> and
-   *             <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and
-   *          evaluate as follows, Amazon S3 returns the <code>412 Precondition Failed</code> response
-   *          code:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <code>x-amz-copy-source-if-none-match</code> condition evaluates to false</p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>x-amz-copy-source-if-modified-since</code> condition evaluates to
-   *                true</p>
-   *             </li>
-   *          </ul>
+   * <p>If both the <code>x-amz-copy-source-if-none-match</code> and
+   *    <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and
+   * evaluate as follows, Amazon S3 returns the <code>412 Precondition Failed</code> response
+   * code:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <code>x-amz-copy-source-if-none-match</code> condition evaluates to false</p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>x-amz-copy-source-if-modified-since</code> condition evaluates to
+   *       true</p>
+   *    </li>
+   * </ul>
    *
-   *          <note>
-   *             <p>All headers with the <code>x-amz-</code> prefix, including
-   *                <code>x-amz-copy-source</code>, must be signed.</p>
-   *          </note>
-   *          <p>
-   *             <b>Server-side encryption</b>
-   *          </p>
-   *          <p>When you perform a CopyObject operation, you can optionally use the appropriate encryption-related
-   *          headers to encrypt the object using server-side encryption with Amazon Web Services managed encryption keys
-   *          (SSE-S3 or SSE-KMS) or a customer-provided encryption key. With server-side encryption, Amazon S3
-   *          encrypts your data as it writes it to disks in its data centers and decrypts the data when
-   *          you access it. For more information about server-side encryption, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Using
-   *          Server-Side Encryption</a>.</p>
-   *          <p>If a target object uses SSE-KMS, you can enable an S3 Bucket Key for the object. For more
-   *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>
-   *             <b>Access Control List (ACL)-Specific Request
-   *          Headers</b>
-   *          </p>
-   *          <p>When copying an object, you can optionally use headers to grant ACL-based permissions.
-   *          By default, all objects are private. Only the owner has full access control. When adding a
-   *          new object, you can grant permissions to individual Amazon Web Services accounts or to predefined groups
-   *          defined by Amazon S3. These permissions are then added to the ACL on the object. For more
-   *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL) Overview</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-using-rest-api.html">Managing ACLs Using the REST
-   *             API</a>. </p>
+   * <note>
+   *    <p>All headers with the <code>x-amz-</code> prefix, including
+   *       <code>x-amz-copy-source</code>, must be signed.</p>
+   * </note>
+   * <p>
+   *    <b>Server-side encryption</b>
+   * </p>
+   * <p>When you perform a CopyObject operation, you can optionally use the appropriate encryption-related
+   * headers to encrypt the object using server-side encryption with Amazon Web Services managed encryption keys
+   * (SSE-S3 or SSE-KMS) or a customer-provided encryption key. With server-side encryption, Amazon S3
+   * encrypts your data as it writes it to disks in its data centers and decrypts the data when
+   * you access it. For more information about server-side encryption, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Using
+   * Server-Side Encryption</a>.</p>
+   * <p>If a target object uses SSE-KMS, you can enable an S3 Bucket Key for the object. For more
+   * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>
+   *    <b>Access Control List (ACL)-Specific Request
+   * Headers</b>
+   * </p>
+   * <p>When copying an object, you can optionally use headers to grant ACL-based permissions.
+   * By default, all objects are private. Only the owner has full access control. When adding a
+   * new object, you can grant permissions to individual Amazon Web Services accounts or to predefined groups
+   * defined by Amazon S3. These permissions are then added to the ACL on the object. For more
+   * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL) Overview</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-using-rest-api.html">Managing ACLs Using the REST
+   *    API</a>. </p>
    *
-   *          <p>
-   *             <b>Storage Class Options</b>
-   *          </p>
-   *          <p>You can use the <code>CopyObject</code> action to change the storage class of an
-   *          object that is already stored in Amazon S3 using the <code>StorageClass</code> parameter. For
-   *          more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage
-   *             Classes</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>
-   *             <b>Versioning</b>
-   *          </p>
-   *          <p>By default, <code>x-amz-copy-source</code> identifies the current version of an object
-   *          to copy. If the current version is a delete marker, Amazon S3 behaves as if the object was
-   *          deleted. To copy a different version, use the <code>versionId</code> subresource.</p>
-   *          <p>If you enable versioning on the target bucket, Amazon S3 generates a unique version ID for
-   *          the object being copied. This version ID is different from the version ID of the source
-   *          object. Amazon S3 returns the version ID of the copied object in the
-   *             <code>x-amz-version-id</code> response header in the response.</p>
-   *          <p>If you do not enable versioning or suspend it on the target bucket, the version ID that
-   *          Amazon S3 generates is always null.</p>
-   *          <p>If the source object's storage class is GLACIER, you must restore a copy of this object
-   *          before you can use it as a source object for the copy operation. For more information, see
-   *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a>.</p>
-   *          <p>The following operations are related to <code>CopyObject</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
-   *                </p>
-   *             </li>
-   *          </ul>
-   *          <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html">Copying
-   *             Objects</a>.</p>
+   * <p>
+   *    <b>Storage Class Options</b>
+   * </p>
+   * <p>You can use the <code>CopyObject</code> action to change the storage class of an
+   * object that is already stored in Amazon S3 using the <code>StorageClass</code> parameter. For
+   * more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage
+   *    Classes</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>
+   *    <b>Versioning</b>
+   * </p>
+   * <p>By default, <code>x-amz-copy-source</code> identifies the current version of an object
+   * to copy. If the current version is a delete marker, Amazon S3 behaves as if the object was
+   * deleted. To copy a different version, use the <code>versionId</code> subresource.</p>
+   * <p>If you enable versioning on the target bucket, Amazon S3 generates a unique version ID for
+   * the object being copied. This version ID is different from the version ID of the source
+   * object. Amazon S3 returns the version ID of the copied object in the
+   *    <code>x-amz-version-id</code> response header in the response.</p>
+   * <p>If you do not enable versioning or suspend it on the target bucket, the version ID that
+   * Amazon S3 generates is always null.</p>
+   * <p>If the source object's storage class is GLACIER, you must restore a copy of this object
+   * before you can use it as a source object for the copy operation. For more information, see
+   *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a>.</p>
+   * <p>The following operations are related to <code>CopyObject</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+   *       </p>
+   *    </li>
+   * </ul>
+   * <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html">Copying
+   *    Objects</a>.</p>
    */
   public copyObject(args: CopyObjectCommandInput, options?: __HttpHandlerOptions): Promise<CopyObjectCommandOutput>;
   public copyObject(args: CopyObjectCommandInput, cb: (err: any, data?: CopyObjectCommandOutput) => void): void;
@@ -837,124 +837,124 @@ export class S3 extends S3Client {
 
   /**
    * <p>Creates a new S3 bucket. To create a bucket, you must register with Amazon S3 and have a
-   *          valid Amazon Web Services Access Key ID to authenticate requests. Anonymous requests are never allowed to
-   *          create buckets. By creating the bucket, you become the bucket owner.</p>
-   *          <p>Not every string is an acceptable bucket name. For information about bucket naming
-   *          restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html">Bucket naming rules</a>.</p>
-   *          <p>If you want to create an Amazon S3 on Outposts bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_CreateBucket.html">Create Bucket</a>. </p>
-   *          <p>By default, the bucket is created in the US East (N. Virginia) Region. You can
-   *          optionally specify a Region in the request body. You might choose a Region to optimize
-   *          latency, minimize costs, or address regulatory requirements. For example, if you reside in
-   *          Europe, you will probably find it advantageous to create buckets in the Europe (Ireland)
-   *          Region. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro">Accessing a
-   *          bucket</a>.</p>
-   *          <note>
-   *             <p>If you send your create bucket request to the <code>s3.amazonaws.com</code> endpoint,
-   *             the request goes to the us-east-1 Region. Accordingly, the signature calculations in
-   *             Signature Version 4 must use us-east-1 as the Region, even if the location constraint in
-   *             the request specifies another Region where the bucket is to be created. If you create a
-   *             bucket in a Region other than US East (N. Virginia), your application must be able to
-   *             handle 307 redirect. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html">Virtual hosting of buckets</a>.</p>
-   *          </note>
-   *          <p>When creating a bucket using this operation, you can optionally specify the accounts or
-   *          groups that should be granted specific permissions on the bucket. There are two ways to
-   *          grant the appropriate permissions using the request headers.</p>
-   *          <ul>
-   *             <li>
-   *                <p>Specify a canned ACL using the <code>x-amz-acl</code> request header. Amazon S3
-   *                supports a set of predefined ACLs, known as <i>canned ACLs</i>. Each
-   *                canned ACL has a predefined set of grantees and permissions. For more information,
-   *                see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
-   *             </li>
-   *             <li>
-   *                <p>Specify access permissions explicitly using the <code>x-amz-grant-read</code>,
-   *                   <code>x-amz-grant-write</code>, <code>x-amz-grant-read-acp</code>,
-   *                   <code>x-amz-grant-write-acp</code>, and <code>x-amz-grant-full-control</code>
-   *                headers. These headers map to the set of permissions Amazon S3 supports in an ACL. For
-   *                more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access control list
-   *                   (ACL) overview</a>.</p>
-   *                <p>You specify each grantee as a type=value pair, where the type is one of the
-   *                following:</p>
+   * valid Amazon Web Services Access Key ID to authenticate requests. Anonymous requests are never allowed to
+   * create buckets. By creating the bucket, you become the bucket owner.</p>
+   * <p>Not every string is an acceptable bucket name. For information about bucket naming
+   * restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html">Bucket naming rules</a>.</p>
+   * <p>If you want to create an Amazon S3 on Outposts bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_CreateBucket.html">Create Bucket</a>. </p>
+   * <p>By default, the bucket is created in the US East (N. Virginia) Region. You can
+   * optionally specify a Region in the request body. You might choose a Region to optimize
+   * latency, minimize costs, or address regulatory requirements. For example, if you reside in
+   * Europe, you will probably find it advantageous to create buckets in the Europe (Ireland)
+   * Region. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro">Accessing a
+   * bucket</a>.</p>
+   * <note>
+   *    <p>If you send your create bucket request to the <code>s3.amazonaws.com</code> endpoint,
+   *    the request goes to the us-east-1 Region. Accordingly, the signature calculations in
+   *    Signature Version 4 must use us-east-1 as the Region, even if the location constraint in
+   *    the request specifies another Region where the bucket is to be created. If you create a
+   *    bucket in a Region other than US East (N. Virginia), your application must be able to
+   *    handle 307 redirect. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html">Virtual hosting of buckets</a>.</p>
+   * </note>
+   * <p>When creating a bucket using this operation, you can optionally specify the accounts or
+   * groups that should be granted specific permissions on the bucket. There are two ways to
+   * grant the appropriate permissions using the request headers.</p>
+   * <ul>
+   *    <li>
+   *       <p>Specify a canned ACL using the <code>x-amz-acl</code> request header. Amazon S3
+   *       supports a set of predefined ACLs, known as <i>canned ACLs</i>. Each
+   *       canned ACL has a predefined set of grantees and permissions. For more information,
+   *       see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
+   *    </li>
+   *    <li>
+   *       <p>Specify access permissions explicitly using the <code>x-amz-grant-read</code>,
+   *          <code>x-amz-grant-write</code>, <code>x-amz-grant-read-acp</code>,
+   *          <code>x-amz-grant-write-acp</code>, and <code>x-amz-grant-full-control</code>
+   *       headers. These headers map to the set of permissions Amazon S3 supports in an ACL. For
+   *       more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access control list
+   *          (ACL) overview</a>.</p>
+   *       <p>You specify each grantee as a type=value pair, where the type is one of the
+   *       following:</p>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <code>id</code> – if the value specified is the canonical user ID of an Amazon Web Services account</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <code>uri</code> – if you are granting permissions to a predefined
+   *             group</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <code>emailAddress</code> – if the value specified is the email address of
+   *             an Amazon Web Services account</p>
+   *             <note>
+   *                <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
    *                <ul>
    *                   <li>
-   *                      <p>
-   *                         <code>id</code> – if the value specified is the canonical user ID of an Amazon Web Services account</p>
+   *                      <p>US East (N. Virginia)</p>
    *                   </li>
    *                   <li>
-   *                      <p>
-   *                         <code>uri</code> – if you are granting permissions to a predefined
-   *                      group</p>
+   *                      <p>US West (N. California)</p>
    *                   </li>
    *                   <li>
-   *                      <p>
-   *                         <code>emailAddress</code> – if the value specified is the email address of
-   *                      an Amazon Web Services account</p>
-   *                      <note>
-   *                         <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
-   *                         <ul>
-   *                            <li>
-   *                               <p>US East (N. Virginia)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>US West (N. California)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p> US West (Oregon)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p> Asia Pacific (Singapore)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>Asia Pacific (Sydney)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>Asia Pacific (Tokyo)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>Europe (Ireland)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>South America (São Paulo)</p>
-   *                            </li>
-   *                         </ul>
-   *                         <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
-   *                      </note>
+   *                      <p> US West (Oregon)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p> Asia Pacific (Singapore)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p>Asia Pacific (Sydney)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p>Asia Pacific (Tokyo)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p>Europe (Ireland)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p>South America (São Paulo)</p>
    *                   </li>
    *                </ul>
-   *                <p>For example, the following <code>x-amz-grant-read</code> header grants the Amazon Web Services accounts identified by account IDs permissions to read object data and its metadata:</p>
-   *                <p>
-   *                   <code>x-amz-grant-read: id="11112222333", id="444455556666" </code>
-   *                </p>
-   *             </li>
-   *          </ul>
-   *          <note>
-   *             <p>You can use either a canned ACL or specify access permissions explicitly. You cannot
-   *             do both.</p>
-   *          </note>
+   *                <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
+   *             </note>
+   *          </li>
+   *       </ul>
+   *       <p>For example, the following <code>x-amz-grant-read</code> header grants the Amazon Web Services accounts identified by account IDs permissions to read object data and its metadata:</p>
+   *       <p>
+   *          <code>x-amz-grant-read: id="11112222333", id="444455556666" </code>
+   *       </p>
+   *    </li>
+   * </ul>
+   * <note>
+   *    <p>You can use either a canned ACL or specify access permissions explicitly. You cannot
+   *    do both.</p>
+   * </note>
    *
-   *          <p>
-   *             <b>Permissions</b>
-   *          </p>
-   *          <p>If your <code>CreateBucket</code> request specifies ACL permissions and the ACL is public-read, public-read-write,
-   *          authenticated-read, or if you specify access permissions explicitly through any other ACL, both
-   *          <code>s3:CreateBucket</code> and <code>s3:PutBucketAcl</code> permissions are needed. If the ACL the
-   *          <code>CreateBucket</code> request is private, only <code>s3:CreateBucket</code> permission is needed. </p>
-   *          <p>If <code>ObjectLockEnabledForBucket</code> is set to true in your <code>CreateBucket</code> request,
-   *          <code>s3:PutBucketObjectLockConfiguration</code> and <code>s3:PutBucketVersioning</code> permissions are required.</p>
+   * <p>
+   *    <b>Permissions</b>
+   * </p>
+   * <p>If your <code>CreateBucket</code> request specifies ACL permissions and the ACL is public-read, public-read-write,
+   * authenticated-read, or if you specify access permissions explicitly through any other ACL, both
+   * <code>s3:CreateBucket</code> and <code>s3:PutBucketAcl</code> permissions are needed. If the ACL the
+   * <code>CreateBucket</code> request is private, only <code>s3:CreateBucket</code> permission is needed. </p>
+   * <p>If <code>ObjectLockEnabledForBucket</code> is set to true in your <code>CreateBucket</code> request,
+   * <code>s3:PutBucketObjectLockConfiguration</code> and <code>s3:PutBucketVersioning</code> permissions are required.</p>
    *
-   *          <p>The following operations are related to <code>CreateBucket</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>CreateBucket</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public createBucket(
     args: CreateBucketCommandInput,
@@ -984,266 +984,266 @@ export class S3 extends S3Client {
 
   /**
    * <p>This action initiates a multipart upload and returns an upload ID. This upload ID is
-   *          used to associate all of the parts in the specific multipart upload. You specify this
-   *          upload ID in each of your subsequent upload part requests (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>). You also include this
-   *          upload ID in the final request to either complete or abort the multipart upload
-   *          request.</p>
+   * used to associate all of the parts in the specific multipart upload. You specify this
+   * upload ID in each of your subsequent upload part requests (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>). You also include this
+   * upload ID in the final request to either complete or abort the multipart upload
+   * request.</p>
    *
-   *          <p>For more information about multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html">Multipart Upload Overview</a>.</p>
+   * <p>For more information about multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html">Multipart Upload Overview</a>.</p>
    *
-   *          <p>If you have configured a lifecycle rule to abort incomplete multipart uploads, the
-   *          upload must complete within the number of days specified in the bucket lifecycle
-   *          configuration. Otherwise, the incomplete multipart upload becomes eligible for an abort
-   *          action and Amazon S3 aborts the multipart upload. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config">Aborting
-   *             Incomplete Multipart Uploads Using a Bucket Lifecycle Policy</a>.</p>
+   * <p>If you have configured a lifecycle rule to abort incomplete multipart uploads, the
+   * upload must complete within the number of days specified in the bucket lifecycle
+   * configuration. Otherwise, the incomplete multipart upload becomes eligible for an abort
+   * action and Amazon S3 aborts the multipart upload. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config">Aborting
+   *    Incomplete Multipart Uploads Using a Bucket Lifecycle Policy</a>.</p>
    *
-   *          <p>For information about the permissions required to use the multipart upload API, see
-   *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
-   *             Permissions</a>.</p>
+   * <p>For information about the permissions required to use the multipart upload API, see
+   *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
+   *    Permissions</a>.</p>
    *
-   *          <p>For request signing, multipart upload is just a series of regular requests. You initiate
-   *          a multipart upload, send one or more requests to upload parts, and then complete the
-   *          multipart upload process. You sign each request individually. There is nothing special
-   *          about signing multipart upload requests. For more information about signing, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html">Authenticating
-   *             Requests (Amazon Web Services Signature Version 4)</a>.</p>
+   * <p>For request signing, multipart upload is just a series of regular requests. You initiate
+   * a multipart upload, send one or more requests to upload parts, and then complete the
+   * multipart upload process. You sign each request individually. There is nothing special
+   * about signing multipart upload requests. For more information about signing, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html">Authenticating
+   *    Requests (Amazon Web Services Signature Version 4)</a>.</p>
    *
-   *          <note>
-   *             <p> After you initiate a multipart upload and upload one or more parts, to stop being
-   *             charged for storing the uploaded parts, you must either complete or abort the multipart
-   *             upload. Amazon S3 frees up the space used to store the parts and stop charging you for
-   *             storing them only after you either complete or abort a multipart upload. </p>
-   *          </note>
+   * <note>
+   *    <p> After you initiate a multipart upload and upload one or more parts, to stop being
+   *    charged for storing the uploaded parts, you must either complete or abort the multipart
+   *    upload. Amazon S3 frees up the space used to store the parts and stop charging you for
+   *    storing them only after you either complete or abort a multipart upload. </p>
+   * </note>
    *
-   *          <p>You can optionally request server-side encryption. For server-side encryption, Amazon S3
-   *          encrypts your data as it writes it to disks in its data centers and decrypts it when you
-   *          access it. You can provide your own encryption key, or use Amazon Web Services Key Management Service (Amazon Web Services
-   *          KMS) customer master keys (CMKs) or Amazon S3-managed encryption keys. If you choose to provide
-   *          your own encryption key, the request headers you provide in <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html">UploadPartCopy</a> requests must match the headers you used in the request to
-   *          initiate the upload by using <code>CreateMultipartUpload</code>. </p>
-   *          <p>To perform a multipart upload with encryption using an Amazon Web Services KMS CMK, the requester must
-   *          have permission to the <code>kms:Decrypt</code> and <code>kms:GenerateDataKey*</code>
-   *          actions on the key. These permissions are required because Amazon S3 must decrypt and read data
-   *          from the encrypted file parts before it completes the multipart upload. For more
-   *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html#mpuAndPermissions">Multipart upload API
-   *             and permissions</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>You can optionally request server-side encryption. For server-side encryption, Amazon S3
+   * encrypts your data as it writes it to disks in its data centers and decrypts it when you
+   * access it. You can provide your own encryption key, or use Amazon Web Services Key Management Service (Amazon Web Services
+   * KMS) customer master keys (CMKs) or Amazon S3-managed encryption keys. If you choose to provide
+   * your own encryption key, the request headers you provide in <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html">UploadPartCopy</a> requests must match the headers you used in the request to
+   * initiate the upload by using <code>CreateMultipartUpload</code>. </p>
+   * <p>To perform a multipart upload with encryption using an Amazon Web Services KMS CMK, the requester must
+   * have permission to the <code>kms:Decrypt</code> and <code>kms:GenerateDataKey*</code>
+   * actions on the key. These permissions are required because Amazon S3 must decrypt and read data
+   * from the encrypted file parts before it completes the multipart upload. For more
+   * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html#mpuAndPermissions">Multipart upload API
+   *    and permissions</a> in the <i>Amazon S3 User Guide</i>.</p>
    *
-   *          <p>If your Identity and Access Management (IAM) user or role is in the same Amazon Web Services account
-   *          as the Amazon Web Services KMS CMK, then you must have these permissions on the key policy. If your IAM
-   *          user or role belongs to a different account than the key, then you must have the
-   *          permissions on both the key policy and your IAM user or role.</p>
+   * <p>If your Identity and Access Management (IAM) user or role is in the same Amazon Web Services account
+   * as the Amazon Web Services KMS CMK, then you must have these permissions on the key policy. If your IAM
+   * user or role belongs to a different account than the key, then you must have the
+   * permissions on both the key policy and your IAM user or role.</p>
    *
    *
-   *          <p> For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Protecting
-   *             Data Using Server-Side Encryption</a>.</p>
+   * <p> For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Protecting
+   *    Data Using Server-Side Encryption</a>.</p>
    *
-   *          <dl>
-   *             <dt>Access Permissions</dt>
-   *             <dd>
-   *                <p>When copying an object, you can optionally specify the accounts or groups that
-   *                   should be granted specific permissions on the new object. There are two ways to
-   *                   grant the permissions using the request headers:</p>
-   *                <ul>
-   *                   <li>
-   *                      <p>Specify a canned ACL with the <code>x-amz-acl</code> request header. For
-   *                         more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>Specify access permissions explicitly with the
-   *                            <code>x-amz-grant-read</code>, <code>x-amz-grant-read-acp</code>,
-   *                            <code>x-amz-grant-write-acp</code>, and
-   *                            <code>x-amz-grant-full-control</code> headers. These parameters map to
-   *                         the set of permissions that Amazon S3 supports in an ACL. For more information,
-   *                         see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL)
-   *                            Overview</a>.</p>
-   *                   </li>
-   *                </ul>
-   *                <p>You can use either a canned ACL or specify access permissions explicitly. You
-   *                   cannot do both.</p>
-   *             </dd>
-   *             <dt>Server-Side- Encryption-Specific Request Headers</dt>
-   *             <dd>
-   *                <p>You can optionally tell Amazon S3 to encrypt data at rest using server-side
-   *                   encryption. Server-side encryption is for data encryption at rest. Amazon S3 encrypts
-   *                   your data as it writes it to disks in its data centers and decrypts it when you
-   *                   access it. The option you use depends on whether you want to use Amazon Web Services managed
-   *                   encryption keys or provide your own encryption key. </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>Use encryption keys managed by Amazon S3 or customer master keys (CMKs) stored
-   *                         in Amazon Web Services Key Management Service (Amazon Web Services KMS) – If you want Amazon Web Services to manage the keys
-   *                         used to encrypt data, specify the following headers in the request.</p>
+   * <dl>
+   *    <dt>Access Permissions</dt>
+   *    <dd>
+   *       <p>When copying an object, you can optionally specify the accounts or groups that
+   *          should be granted specific permissions on the new object. There are two ways to
+   *          grant the permissions using the request headers:</p>
+   *       <ul>
+   *          <li>
+   *             <p>Specify a canned ACL with the <code>x-amz-acl</code> request header. For
+   *                more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
+   *          </li>
+   *          <li>
+   *             <p>Specify access permissions explicitly with the
+   *                   <code>x-amz-grant-read</code>, <code>x-amz-grant-read-acp</code>,
+   *                   <code>x-amz-grant-write-acp</code>, and
+   *                   <code>x-amz-grant-full-control</code> headers. These parameters map to
+   *                the set of permissions that Amazon S3 supports in an ACL. For more information,
+   *                see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL)
+   *                   Overview</a>.</p>
+   *          </li>
+   *       </ul>
+   *       <p>You can use either a canned ACL or specify access permissions explicitly. You
+   *          cannot do both.</p>
+   *    </dd>
+   *    <dt>Server-Side- Encryption-Specific Request Headers</dt>
+   *    <dd>
+   *       <p>You can optionally tell Amazon S3 to encrypt data at rest using server-side
+   *          encryption. Server-side encryption is for data encryption at rest. Amazon S3 encrypts
+   *          your data as it writes it to disks in its data centers and decrypts it when you
+   *          access it. The option you use depends on whether you want to use Amazon Web Services managed
+   *          encryption keys or provide your own encryption key. </p>
+   *       <ul>
+   *          <li>
+   *             <p>Use encryption keys managed by Amazon S3 or customer master keys (CMKs) stored
+   *                in Amazon Web Services Key Management Service (Amazon Web Services KMS) – If you want Amazon Web Services to manage the keys
+   *                used to encrypt data, specify the following headers in the request.</p>
+   *             <ul>
+   *                <li>
+   *                   <p>x-amz-server-side-encryption</p>
+   *                </li>
+   *                <li>
+   *                   <p>x-amz-server-side-encryption-aws-kms-key-id</p>
+   *                </li>
+   *                <li>
+   *                   <p>x-amz-server-side-encryption-context</p>
+   *                </li>
+   *             </ul>
+   *             <note>
+   *                <p>If you specify <code>x-amz-server-side-encryption:aws:kms</code>, but
+   *                   don't provide <code>x-amz-server-side-encryption-aws-kms-key-id</code>,
+   *                   Amazon S3 uses the Amazon Web Services managed CMK in Amazon Web Services KMS to protect the data.</p>
+   *             </note>
+   *             <important>
+   *                <p>All GET and PUT requests for an object protected by Amazon Web Services KMS fail if
+   *                   you don't make them with SSL or by using SigV4.</p>
+   *             </important>
+   *             <p>For more information about server-side encryption with CMKs stored in Amazon Web Services
+   *                KMS (SSE-KMS), see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html">Protecting Data Using Server-Side Encryption with CMKs stored in Amazon Web Services
+   *                   KMS</a>.</p>
+   *          </li>
+   *          <li>
+   *             <p>Use customer-provided encryption keys – If you want to manage your own
+   *                encryption keys, provide all the following headers in the request.</p>
+   *             <ul>
+   *                <li>
+   *                   <p>x-amz-server-side-encryption-customer-algorithm</p>
+   *                </li>
+   *                <li>
+   *                   <p>x-amz-server-side-encryption-customer-key</p>
+   *                </li>
+   *                <li>
+   *                   <p>x-amz-server-side-encryption-customer-key-MD5</p>
+   *                </li>
+   *             </ul>
+   *             <p>For more information about server-side encryption with CMKs stored in Amazon Web Services
+   *                KMS (SSE-KMS), see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html">Protecting Data Using Server-Side Encryption with CMKs stored in Amazon Web Services
+   *                   KMS</a>.</p>
+   *          </li>
+   *       </ul>
+   *    </dd>
+   *    <dt>Access-Control-List (ACL)-Specific Request Headers</dt>
+   *    <dd>
+   *       <p>You also can use the following access control–related headers with this
+   *          operation. By default, all objects are private. Only the owner has full access
+   *          control. When adding a new object, you can grant permissions to individual Amazon Web Services accounts or to predefined groups defined by Amazon S3. These permissions are then added
+   *          to the access control list (ACL) on the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. With this
+   *          operation, you can grant access permissions using one of the following two
+   *          methods:</p>
+   *       <ul>
+   *          <li>
+   *             <p>Specify a canned ACL (<code>x-amz-acl</code>) — Amazon S3 supports a set of
+   *                predefined ACLs, known as <i>canned ACLs</i>. Each canned ACL
+   *                has a predefined set of grantees and permissions. For more information, see
+   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned
+   *                ACL</a>.</p>
+   *          </li>
+   *          <li>
+   *             <p>Specify access permissions explicitly — To explicitly grant access
+   *                permissions to specific Amazon Web Services accounts or groups, use the following headers.
+   *                Each header maps to specific permissions that Amazon S3 supports in an ACL. For
+   *                more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access
+   *                   Control List (ACL) Overview</a>. In the header, you specify a list of
+   *                grantees who get the specific permission. To grant permissions explicitly,
+   *                use:</p>
+   *             <ul>
+   *                <li>
+   *                   <p>x-amz-grant-read</p>
+   *                </li>
+   *                <li>
+   *                   <p>x-amz-grant-write</p>
+   *                </li>
+   *                <li>
+   *                   <p>x-amz-grant-read-acp</p>
+   *                </li>
+   *                <li>
+   *                   <p>x-amz-grant-write-acp</p>
+   *                </li>
+   *                <li>
+   *                   <p>x-amz-grant-full-control</p>
+   *                </li>
+   *             </ul>
+   *             <p>You specify each grantee as a type=value pair, where the type is one of
+   *                the following:</p>
+   *             <ul>
+   *                <li>
+   *                   <p>
+   *                      <code>id</code> – if the value specified is the canonical user ID
+   *                      of an Amazon Web Services account</p>
+   *                </li>
+   *                <li>
+   *                   <p>
+   *                      <code>uri</code> – if you are granting permissions to a predefined
+   *                      group</p>
+   *                </li>
+   *                <li>
+   *                   <p>
+   *                      <code>emailAddress</code> – if the value specified is the email
+   *                      address of an Amazon Web Services account</p>
+   *                   <note>
+   *                      <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
    *                      <ul>
    *                         <li>
-   *                            <p>x-amz-server-side-encryption</p>
+   *                            <p>US East (N. Virginia)</p>
    *                         </li>
    *                         <li>
-   *                            <p>x-amz-server-side-encryption-aws-kms-key-id</p>
+   *                            <p>US West (N. California)</p>
    *                         </li>
    *                         <li>
-   *                            <p>x-amz-server-side-encryption-context</p>
+   *                            <p> US West (Oregon)</p>
+   *                         </li>
+   *                         <li>
+   *                            <p> Asia Pacific (Singapore)</p>
+   *                         </li>
+   *                         <li>
+   *                            <p>Asia Pacific (Sydney)</p>
+   *                         </li>
+   *                         <li>
+   *                            <p>Asia Pacific (Tokyo)</p>
+   *                         </li>
+   *                         <li>
+   *                            <p>Europe (Ireland)</p>
+   *                         </li>
+   *                         <li>
+   *                            <p>South America (São Paulo)</p>
    *                         </li>
    *                      </ul>
-   *                      <note>
-   *                         <p>If you specify <code>x-amz-server-side-encryption:aws:kms</code>, but
-   *                            don't provide <code>x-amz-server-side-encryption-aws-kms-key-id</code>,
-   *                            Amazon S3 uses the Amazon Web Services managed CMK in Amazon Web Services KMS to protect the data.</p>
-   *                      </note>
-   *                      <important>
-   *                         <p>All GET and PUT requests for an object protected by Amazon Web Services KMS fail if
-   *                            you don't make them with SSL or by using SigV4.</p>
-   *                      </important>
-   *                      <p>For more information about server-side encryption with CMKs stored in Amazon Web Services
-   *                         KMS (SSE-KMS), see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html">Protecting Data Using Server-Side Encryption with CMKs stored in Amazon Web Services
-   *                            KMS</a>.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>Use customer-provided encryption keys – If you want to manage your own
-   *                         encryption keys, provide all the following headers in the request.</p>
-   *                      <ul>
-   *                         <li>
-   *                            <p>x-amz-server-side-encryption-customer-algorithm</p>
-   *                         </li>
-   *                         <li>
-   *                            <p>x-amz-server-side-encryption-customer-key</p>
-   *                         </li>
-   *                         <li>
-   *                            <p>x-amz-server-side-encryption-customer-key-MD5</p>
-   *                         </li>
-   *                      </ul>
-   *                      <p>For more information about server-side encryption with CMKs stored in Amazon Web Services
-   *                         KMS (SSE-KMS), see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html">Protecting Data Using Server-Side Encryption with CMKs stored in Amazon Web Services
-   *                            KMS</a>.</p>
-   *                   </li>
-   *                </ul>
-   *             </dd>
-   *             <dt>Access-Control-List (ACL)-Specific Request Headers</dt>
-   *             <dd>
-   *                <p>You also can use the following access control–related headers with this
-   *                   operation. By default, all objects are private. Only the owner has full access
-   *                   control. When adding a new object, you can grant permissions to individual Amazon Web Services accounts or to predefined groups defined by Amazon S3. These permissions are then added
-   *                   to the access control list (ACL) on the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. With this
-   *                   operation, you can grant access permissions using one of the following two
-   *                   methods:</p>
-   *                <ul>
-   *                   <li>
-   *                      <p>Specify a canned ACL (<code>x-amz-acl</code>) — Amazon S3 supports a set of
-   *                         predefined ACLs, known as <i>canned ACLs</i>. Each canned ACL
-   *                         has a predefined set of grantees and permissions. For more information, see
-   *                            <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned
-   *                         ACL</a>.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>Specify access permissions explicitly — To explicitly grant access
-   *                         permissions to specific Amazon Web Services accounts or groups, use the following headers.
-   *                         Each header maps to specific permissions that Amazon S3 supports in an ACL. For
-   *                         more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access
-   *                            Control List (ACL) Overview</a>. In the header, you specify a list of
-   *                         grantees who get the specific permission. To grant permissions explicitly,
-   *                         use:</p>
-   *                      <ul>
-   *                         <li>
-   *                            <p>x-amz-grant-read</p>
-   *                         </li>
-   *                         <li>
-   *                            <p>x-amz-grant-write</p>
-   *                         </li>
-   *                         <li>
-   *                            <p>x-amz-grant-read-acp</p>
-   *                         </li>
-   *                         <li>
-   *                            <p>x-amz-grant-write-acp</p>
-   *                         </li>
-   *                         <li>
-   *                            <p>x-amz-grant-full-control</p>
-   *                         </li>
-   *                      </ul>
-   *                      <p>You specify each grantee as a type=value pair, where the type is one of
-   *                         the following:</p>
-   *                      <ul>
-   *                         <li>
-   *                            <p>
-   *                               <code>id</code> – if the value specified is the canonical user ID
-   *                               of an Amazon Web Services account</p>
-   *                         </li>
-   *                         <li>
-   *                            <p>
-   *                               <code>uri</code> – if you are granting permissions to a predefined
-   *                               group</p>
-   *                         </li>
-   *                         <li>
-   *                            <p>
-   *                               <code>emailAddress</code> – if the value specified is the email
-   *                               address of an Amazon Web Services account</p>
-   *                            <note>
-   *                               <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
-   *                               <ul>
-   *                                  <li>
-   *                                     <p>US East (N. Virginia)</p>
-   *                                  </li>
-   *                                  <li>
-   *                                     <p>US West (N. California)</p>
-   *                                  </li>
-   *                                  <li>
-   *                                     <p> US West (Oregon)</p>
-   *                                  </li>
-   *                                  <li>
-   *                                     <p> Asia Pacific (Singapore)</p>
-   *                                  </li>
-   *                                  <li>
-   *                                     <p>Asia Pacific (Sydney)</p>
-   *                                  </li>
-   *                                  <li>
-   *                                     <p>Asia Pacific (Tokyo)</p>
-   *                                  </li>
-   *                                  <li>
-   *                                     <p>Europe (Ireland)</p>
-   *                                  </li>
-   *                                  <li>
-   *                                     <p>South America (São Paulo)</p>
-   *                                  </li>
-   *                               </ul>
-   *                               <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
-   *                            </note>
-   *                         </li>
-   *                      </ul>
-   *                      <p>For example, the following <code>x-amz-grant-read</code> header grants the Amazon Web Services accounts identified by account IDs permissions to read object data and its metadata:</p>
-   *                      <p>
-   *                         <code>x-amz-grant-read: id="11112222333", id="444455556666" </code>
-   *                      </p>
-   *                   </li>
-   *                </ul>
+   *                      <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
+   *                   </note>
+   *                </li>
+   *             </ul>
+   *             <p>For example, the following <code>x-amz-grant-read</code> header grants the Amazon Web Services accounts identified by account IDs permissions to read object data and its metadata:</p>
+   *             <p>
+   *                <code>x-amz-grant-read: id="11112222333", id="444455556666" </code>
+   *             </p>
+   *          </li>
+   *       </ul>
    *
-   *             </dd>
-   *          </dl>
+   *    </dd>
+   * </dl>
    *
-   *          <p>The following operations are related to <code>CreateMultipartUpload</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>CreateMultipartUpload</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public createMultipartUpload(
     args: CreateMultipartUploadCommandInput,
@@ -1276,23 +1276,23 @@ export class S3 extends S3Client {
 
   /**
    * <p>Deletes the S3 bucket. All objects (including all object versions and delete markers) in
-   *          the bucket must be deleted before the bucket itself can be deleted.</p>
+   * the bucket must be deleted before the bucket itself can be deleted.</p>
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteBucket(
     args: DeleteBucketCommandInput,
@@ -1322,35 +1322,35 @@ export class S3 extends S3Client {
 
   /**
    * <p>Deletes an analytics configuration for the bucket (specified by the analytics
-   *          configuration ID).</p>
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:PutAnalyticsConfiguration</code> action. The bucket owner has this permission
-   *          by default. The bucket owner can grant this permission to others. For more information
-   *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
+   * configuration ID).</p>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:PutAnalyticsConfiguration</code> action. The bucket owner has this permission
+   * by default. The bucket owner can grant this permission to others. For more information
+   * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
    *
-   *          <p>For information about the Amazon S3 analytics feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
-   *             Analysis</a>. </p>
+   * <p>For information about the Amazon S3 analytics feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
+   *    Analysis</a>. </p>
    *
-   *          <p>The following operations are related to
-   *          <code>DeleteBucketAnalyticsConfiguration</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAnalyticsConfiguration.html">GetBucketAnalyticsConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketAnalyticsConfigurations.html">ListBucketAnalyticsConfigurations</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html">PutBucketAnalyticsConfiguration</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to
+   * <code>DeleteBucketAnalyticsConfiguration</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAnalyticsConfiguration.html">GetBucketAnalyticsConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketAnalyticsConfigurations.html">ListBucketAnalyticsConfigurations</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html">PutBucketAnalyticsConfiguration</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteBucketAnalyticsConfiguration(
     args: DeleteBucketAnalyticsConfigurationCommandInput,
@@ -1383,27 +1383,27 @@ export class S3 extends S3Client {
 
   /**
    * <p>Deletes the <code>cors</code> configuration information set for the bucket.</p>
-   *          <p>To use this operation, you must have permission to perform the
-   *             <code>s3:PutBucketCORS</code> action. The bucket owner has this permission by default
-   *          and can grant this permission to others. </p>
-   *          <p>For information about <code>cors</code>, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html">Enabling
-   *             Cross-Origin Resource Sharing</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>To use this operation, you must have permission to perform the
+   *    <code>s3:PutBucketCORS</code> action. The bucket owner has this permission by default
+   * and can grant this permission to others. </p>
+   * <p>For information about <code>cors</code>, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html">Enabling
+   *    Cross-Origin Resource Sharing</a> in the <i>Amazon S3 User Guide</i>.</p>
    *
-   *          <p class="title">
-   *             <b>Related Resources:</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketCors.html">PutBucketCors</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTOPTIONSobject.html">RESTOPTIONSobject</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p class="title">
+   *    <b>Related Resources:</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketCors.html">PutBucketCors</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTOPTIONSobject.html">RESTOPTIONSobject</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteBucketCors(
     args: DeleteBucketCorsCommandInput,
@@ -1436,29 +1436,29 @@ export class S3 extends S3Client {
 
   /**
    * <p>This implementation of the DELETE action removes default encryption from the bucket.
-   *          For information about the Amazon S3 default encryption feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html">Amazon S3 Default Bucket Encryption</a> in the
-   *             <i>Amazon S3 User Guide</i>.</p>
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:PutEncryptionConfiguration</code> action. The bucket owner has this permission
-   *          by default. The bucket owner can grant this permission to others. For more information
-   *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to your Amazon S3
-   *             Resources</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * For information about the Amazon S3 default encryption feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html">Amazon S3 Default Bucket Encryption</a> in the
+   *    <i>Amazon S3 User Guide</i>.</p>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:PutEncryptionConfiguration</code> action. The bucket owner has this permission
+   * by default. The bucket owner can grant this permission to others. For more information
+   * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to your Amazon S3
+   *    Resources</a> in the <i>Amazon S3 User Guide</i>.</p>
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html">PutBucketEncryption</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html">GetBucketEncryption</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html">PutBucketEncryption</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html">GetBucketEncryption</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteBucketEncryption(
     args: DeleteBucketEncryptionCommandInput,
@@ -1491,28 +1491,28 @@ export class S3 extends S3Client {
 
   /**
    * <p>Deletes the S3 Intelligent-Tiering configuration from the specified bucket.</p>
-   *          <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
-   *          <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
-   *          <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
-   *          <p>Operations related to
-   *             <code>DeleteBucketIntelligentTieringConfiguration</code> include: </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html">GetBucketIntelligentTieringConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html">PutBucketIntelligentTieringConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html">ListBucketIntelligentTieringConfigurations</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
+   * <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
+   * <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
+   * <p>Operations related to
+   *    <code>DeleteBucketIntelligentTieringConfiguration</code> include: </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html">GetBucketIntelligentTieringConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html">PutBucketIntelligentTieringConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html">ListBucketIntelligentTieringConfigurations</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteBucketIntelligentTieringConfiguration(
     args: DeleteBucketIntelligentTieringConfigurationCommandInput,
@@ -1547,31 +1547,31 @@ export class S3 extends S3Client {
 
   /**
    * <p>Deletes an inventory configuration (identified by the inventory ID) from the
-   *          bucket.</p>
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:PutInventoryConfiguration</code> action. The bucket owner has this permission
-   *          by default. The bucket owner can grant this permission to others. For more information
-   *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
-   *          <p>For information about the Amazon S3 inventory feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3 Inventory</a>.</p>
-   *          <p>Operations related to <code>DeleteBucketInventoryConfiguration</code> include: </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketInventoryConfiguration.html">GetBucketInventoryConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html">PutBucketInventoryConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketInventoryConfigurations.html">ListBucketInventoryConfigurations</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * bucket.</p>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:PutInventoryConfiguration</code> action. The bucket owner has this permission
+   * by default. The bucket owner can grant this permission to others. For more information
+   * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
+   * <p>For information about the Amazon S3 inventory feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3 Inventory</a>.</p>
+   * <p>Operations related to <code>DeleteBucketInventoryConfiguration</code> include: </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketInventoryConfiguration.html">GetBucketInventoryConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html">PutBucketInventoryConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketInventoryConfigurations.html">ListBucketInventoryConfigurations</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteBucketInventoryConfiguration(
     args: DeleteBucketInventoryConfigurationCommandInput,
@@ -1604,31 +1604,31 @@ export class S3 extends S3Client {
 
   /**
    * <p>Deletes the lifecycle configuration from the specified bucket. Amazon S3 removes all the
-   *          lifecycle configuration rules in the lifecycle subresource associated with the bucket. Your
-   *          objects never expire, and Amazon S3 no longer automatically deletes any objects on the basis of
-   *          rules contained in the deleted lifecycle configuration.</p>
-   *          <p>To use this operation, you must have permission to perform the
-   *             <code>s3:PutLifecycleConfiguration</code> action. By default, the bucket owner has this
-   *          permission and the bucket owner can grant this permission to others.</p>
+   * lifecycle configuration rules in the lifecycle subresource associated with the bucket. Your
+   * objects never expire, and Amazon S3 no longer automatically deletes any objects on the basis of
+   * rules contained in the deleted lifecycle configuration.</p>
+   * <p>To use this operation, you must have permission to perform the
+   *    <code>s3:PutLifecycleConfiguration</code> action. By default, the bucket owner has this
+   * permission and the bucket owner can grant this permission to others.</p>
    *
-   *          <p>There is usually some time lag before lifecycle configuration deletion is fully
-   *          propagated to all the Amazon S3 systems.</p>
+   * <p>There is usually some time lag before lifecycle configuration deletion is fully
+   * propagated to all the Amazon S3 systems.</p>
    *
-   *          <p>For more information about the object expiration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#intro-lifecycle-rules-actions">Elements to
-   *             Describe Lifecycle Actions</a>.</p>
-   *          <p>Related actions include:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html">GetBucketLifecycleConfiguration</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>For more information about the object expiration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#intro-lifecycle-rules-actions">Elements to
+   *    Describe Lifecycle Actions</a>.</p>
+   * <p>Related actions include:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html">GetBucketLifecycleConfiguration</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteBucketLifecycle(
     args: DeleteBucketLifecycleCommandInput,
@@ -1661,41 +1661,41 @@ export class S3 extends S3Client {
 
   /**
    * <p>Deletes a metrics configuration for the Amazon CloudWatch request metrics (specified by the
-   *          metrics configuration ID) from the bucket. Note that this doesn't include the daily storage
-   *          metrics.</p>
+   * metrics configuration ID) from the bucket. Note that this doesn't include the daily storage
+   * metrics.</p>
    *
-   *          <p> To use this operation, you must have permissions to perform the
-   *             <code>s3:PutMetricsConfiguration</code> action. The bucket owner has this permission by
-   *          default. The bucket owner can grant this permission to others. For more information about
-   *          permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
+   * <p> To use this operation, you must have permissions to perform the
+   *    <code>s3:PutMetricsConfiguration</code> action. The bucket owner has this permission by
+   * default. The bucket owner can grant this permission to others. For more information about
+   * permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
    *
-   *          <p>For information about CloudWatch request metrics for Amazon S3, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon CloudWatch</a>. </p>
-   *          <p>The following operations are related to
-   *          <code>DeleteBucketMetricsConfiguration</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetricsConfiguration.html">GetBucketMetricsConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketMetricsConfigurations.html">ListBucketMetricsConfigurations</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
-   *                   CloudWatch</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>For information about CloudWatch request metrics for Amazon S3, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon CloudWatch</a>. </p>
+   * <p>The following operations are related to
+   * <code>DeleteBucketMetricsConfiguration</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetricsConfiguration.html">GetBucketMetricsConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketMetricsConfigurations.html">ListBucketMetricsConfigurations</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
+   *          CloudWatch</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteBucketMetricsConfiguration(
     args: DeleteBucketMetricsConfigurationCommandInput,
@@ -1728,24 +1728,24 @@ export class S3 extends S3Client {
 
   /**
    * <p>Removes <code>OwnershipControls</code> for an Amazon S3 bucket. To use this operation, you
-   *          must have the <code>s3:PutBucketOwnershipControls</code> permission. For more information
-   *          about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying
-   *             Permissions in a Policy</a>.</p>
-   *          <p>For information about Amazon S3 Object Ownership, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html">Using Object Ownership</a>. </p>
-   *          <p>The following operations are related to
-   *          <code>DeleteBucketOwnershipControls</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a>GetBucketOwnershipControls</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a>PutBucketOwnershipControls</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * must have the <code>s3:PutBucketOwnershipControls</code> permission. For more information
+   * about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying
+   *    Permissions in a Policy</a>.</p>
+   * <p>For information about Amazon S3 Object Ownership, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html">Using Object Ownership</a>. </p>
+   * <p>The following operations are related to
+   * <code>DeleteBucketOwnershipControls</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a>GetBucketOwnershipControls</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a>PutBucketOwnershipControls</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteBucketOwnershipControls(
     args: DeleteBucketOwnershipControlsCommandInput,
@@ -1778,38 +1778,38 @@ export class S3 extends S3Client {
 
   /**
    * <p>This implementation of the DELETE action uses the policy subresource to delete the
-   *          policy of a specified bucket. If you are using an identity other than the root user of the
-   *          Amazon Web Services account that owns the bucket, the calling identity must have the
-   *             <code>DeleteBucketPolicy</code> permissions on the specified bucket and belong to the
-   *          bucket owner's account to use this operation. </p>
+   * policy of a specified bucket. If you are using an identity other than the root user of the
+   * Amazon Web Services account that owns the bucket, the calling identity must have the
+   *    <code>DeleteBucketPolicy</code> permissions on the specified bucket and belong to the
+   * bucket owner's account to use this operation. </p>
    *
-   *          <p>If you don't have <code>DeleteBucketPolicy</code> permissions, Amazon S3 returns a <code>403
-   *             Access Denied</code> error. If you have the correct permissions, but you're not using an
-   *          identity that belongs to the bucket owner's account, Amazon S3 returns a <code>405 Method Not
-   *             Allowed</code> error. </p>
+   * <p>If you don't have <code>DeleteBucketPolicy</code> permissions, Amazon S3 returns a <code>403
+   *    Access Denied</code> error. If you have the correct permissions, but you're not using an
+   * identity that belongs to the bucket owner's account, Amazon S3 returns a <code>405 Method Not
+   *    Allowed</code> error. </p>
    *
-   *          <important>
-   *             <p>As a security precaution, the root user of the Amazon Web Services account that owns a bucket can
-   *             always use this operation, even if the policy explicitly denies the root user the
-   *             ability to perform this action.</p>
-   *          </important>
+   * <important>
+   *    <p>As a security precaution, the root user of the Amazon Web Services account that owns a bucket can
+   *    always use this operation, even if the policy explicitly denies the root user the
+   *    ability to perform this action.</p>
+   * </important>
    *
-   *          <p>For more information about bucket policies, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies and
-   *             UserPolicies</a>. </p>
-   *          <p>The following operations are related to <code>DeleteBucketPolicy</code>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>For more information about bucket policies, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies and
+   *    UserPolicies</a>. </p>
+   * <p>The following operations are related to <code>DeleteBucketPolicy</code>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteBucketPolicy(
     args: DeleteBucketPolicyCommandInput,
@@ -1842,31 +1842,31 @@ export class S3 extends S3Client {
 
   /**
    * <p> Deletes the replication configuration from the bucket.</p>
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:PutReplicationConfiguration</code> action. The bucket owner has these
-   *          permissions by default and can grant it to others. For more information about permissions,
-   *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>. </p>
-   *          <note>
-   *             <p>It can take a while for the deletion of a replication configuration to fully
-   *             propagate.</p>
-   *          </note>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:PutReplicationConfiguration</code> action. The bucket owner has these
+   * permissions by default and can grant it to others. For more information about permissions,
+   * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>. </p>
+   * <note>
+   *    <p>It can take a while for the deletion of a replication configuration to fully
+   *    propagate.</p>
+   * </note>
    *
-   *          <p> For information about replication configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html">Replication</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p> For information about replication configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html">Replication</a> in the <i>Amazon S3 User Guide</i>.</p>
    *
-   *          <p>The following operations are related to <code>DeleteBucketReplication</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html">PutBucketReplication</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketReplication.html">GetBucketReplication</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>DeleteBucketReplication</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html">PutBucketReplication</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketReplication.html">GetBucketReplication</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteBucketReplication(
     args: DeleteBucketReplicationCommandInput,
@@ -1900,22 +1900,22 @@ export class S3 extends S3Client {
   /**
    * <p>Deletes the tags from the bucket.</p>
    *
-   *          <p>To use this operation, you must have permission to perform the
-   *             <code>s3:PutBucketTagging</code> action. By default, the bucket owner has this
-   *          permission and can grant this permission to others. </p>
-   *          <p>The following operations are related to <code>DeleteBucketTagging</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html">GetBucketTagging</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketTagging.html">PutBucketTagging</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>To use this operation, you must have permission to perform the
+   *    <code>s3:PutBucketTagging</code> action. By default, the bucket owner has this
+   * permission and can grant this permission to others. </p>
+   * <p>The following operations are related to <code>DeleteBucketTagging</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html">GetBucketTagging</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketTagging.html">PutBucketTagging</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteBucketTagging(
     args: DeleteBucketTaggingCommandInput,
@@ -1948,32 +1948,32 @@ export class S3 extends S3Client {
 
   /**
    * <p>This action removes the website configuration for a bucket. Amazon S3 returns a <code>200
-   *             OK</code> response upon successfully deleting a website configuration on the specified
-   *          bucket. You will get a <code>200 OK</code> response if the website configuration you are
-   *          trying to delete does not exist on the bucket. Amazon S3 returns a <code>404</code> response if
-   *          the bucket specified in the request does not exist.</p>
+   *    OK</code> response upon successfully deleting a website configuration on the specified
+   * bucket. You will get a <code>200 OK</code> response if the website configuration you are
+   * trying to delete does not exist on the bucket. Amazon S3 returns a <code>404</code> response if
+   * the bucket specified in the request does not exist.</p>
    *
-   *          <p>This DELETE action requires the <code>S3:DeleteBucketWebsite</code> permission. By
-   *          default, only the bucket owner can delete the website configuration attached to a bucket.
-   *          However, bucket owners can grant other users permission to delete the website configuration
-   *          by writing a bucket policy granting them the <code>S3:DeleteBucketWebsite</code>
-   *          permission. </p>
+   * <p>This DELETE action requires the <code>S3:DeleteBucketWebsite</code> permission. By
+   * default, only the bucket owner can delete the website configuration attached to a bucket.
+   * However, bucket owners can grant other users permission to delete the website configuration
+   * by writing a bucket policy granting them the <code>S3:DeleteBucketWebsite</code>
+   * permission. </p>
    *
-   *          <p>For more information about hosting websites, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html">Hosting Websites on Amazon S3</a>. </p>
+   * <p>For more information about hosting websites, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html">Hosting Websites on Amazon S3</a>. </p>
    *
-   *          <p>The following operations are related to <code>DeleteBucketWebsite</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketWebsite.html">GetBucketWebsite</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketWebsite.html">PutBucketWebsite</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>DeleteBucketWebsite</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketWebsite.html">GetBucketWebsite</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketWebsite.html">PutBucketWebsite</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteBucketWebsite(
     args: DeleteBucketWebsiteCommandInput,
@@ -2006,36 +2006,36 @@ export class S3 extends S3Client {
 
   /**
    * <p>Removes the null version (if there is one) of an object and inserts a delete marker,
-   *          which becomes the latest version of the object. If there isn't a null version, Amazon S3 does
-   *          not remove any objects but will still respond that the command was successful.</p>
+   * which becomes the latest version of the object. If there isn't a null version, Amazon S3 does
+   * not remove any objects but will still respond that the command was successful.</p>
    *
-   *          <p>To remove a specific version, you must be the bucket owner and you must use the version
-   *          Id subresource. Using this subresource permanently deletes the version. If the object
-   *          deleted is a delete marker, Amazon S3 sets the response header,
-   *          <code>x-amz-delete-marker</code>, to true. </p>
+   * <p>To remove a specific version, you must be the bucket owner and you must use the version
+   * Id subresource. Using this subresource permanently deletes the version. If the object
+   * deleted is a delete marker, Amazon S3 sets the response header,
+   * <code>x-amz-delete-marker</code>, to true. </p>
    *
-   *          <p>If the object you want to delete is in a bucket where the bucket versioning
-   *          configuration is MFA Delete enabled, you must include the <code>x-amz-mfa</code> request
-   *          header in the DELETE <code>versionId</code> request. Requests that include
-   *             <code>x-amz-mfa</code> must use HTTPS. </p>
+   * <p>If the object you want to delete is in a bucket where the bucket versioning
+   * configuration is MFA Delete enabled, you must include the <code>x-amz-mfa</code> request
+   * header in the DELETE <code>versionId</code> request. Requests that include
+   *    <code>x-amz-mfa</code> must use HTTPS. </p>
    *
-   *          <p> For more information about MFA Delete, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMFADelete.html">Using MFA Delete</a>. To see sample requests that use versioning, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html#ExampleVersionObjectDelete">Sample Request</a>. </p>
+   * <p> For more information about MFA Delete, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMFADelete.html">Using MFA Delete</a>. To see sample requests that use versioning, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html#ExampleVersionObjectDelete">Sample Request</a>. </p>
    *
-   *          <p>You can delete objects by explicitly calling DELETE Object or configure its
-   *          lifecycle (<a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html">PutBucketLifecycle</a>) to
-   *          enable Amazon S3 to remove them for you. If you want to block users or accounts from removing or
-   *          deleting objects from your bucket, you must deny them the <code>s3:DeleteObject</code>,
-   *             <code>s3:DeleteObjectVersion</code>, and <code>s3:PutLifeCycleConfiguration</code>
-   *          actions. </p>
+   * <p>You can delete objects by explicitly calling DELETE Object or configure its
+   * lifecycle (<a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html">PutBucketLifecycle</a>) to
+   * enable Amazon S3 to remove them for you. If you want to block users or accounts from removing or
+   * deleting objects from your bucket, you must deny them the <code>s3:DeleteObject</code>,
+   *    <code>s3:DeleteObjectVersion</code>, and <code>s3:PutLifeCycleConfiguration</code>
+   * actions. </p>
    *
-   *          <p>The following action is related to <code>DeleteObject</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following action is related to <code>DeleteObject</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteObject(
     args: DeleteObjectCommandInput,
@@ -2065,62 +2065,62 @@ export class S3 extends S3Client {
 
   /**
    * <p>This action enables you to delete multiple objects from a bucket using a single HTTP
-   *          request. If you know the object keys that you want to delete, then this action provides
-   *          a suitable alternative to sending individual delete requests, reducing per-request
-   *          overhead.</p>
+   * request. If you know the object keys that you want to delete, then this action provides
+   * a suitable alternative to sending individual delete requests, reducing per-request
+   * overhead.</p>
    *
-   *          <p>The request contains a list of up to 1000 keys that you want to delete. In the XML, you
-   *          provide the object key names, and optionally, version IDs if you want to delete a specific
-   *          version of the object from a versioning-enabled bucket. For each key, Amazon S3 performs a
-   *          delete action and returns the result of that delete, success, or failure, in the
-   *          response. Note that if the object specified in the request is not found, Amazon S3 returns the
-   *          result as deleted.</p>
+   * <p>The request contains a list of up to 1000 keys that you want to delete. In the XML, you
+   * provide the object key names, and optionally, version IDs if you want to delete a specific
+   * version of the object from a versioning-enabled bucket. For each key, Amazon S3 performs a
+   * delete action and returns the result of that delete, success, or failure, in the
+   * response. Note that if the object specified in the request is not found, Amazon S3 returns the
+   * result as deleted.</p>
    *
-   *          <p> The action supports two modes for the response: verbose and quiet. By default, the
-   *          action uses verbose mode in which the response includes the result of deletion of each
-   *          key in your request. In quiet mode the response includes only keys where the delete
-   *          action encountered an error. For a successful deletion, the action does not return
-   *          any information about the delete in the response body.</p>
+   * <p> The action supports two modes for the response: verbose and quiet. By default, the
+   * action uses verbose mode in which the response includes the result of deletion of each
+   * key in your request. In quiet mode the response includes only keys where the delete
+   * action encountered an error. For a successful deletion, the action does not return
+   * any information about the delete in the response body.</p>
    *
-   *          <p>When performing this action on an MFA Delete enabled bucket, that attempts to delete
-   *          any versioned objects, you must include an MFA token. If you do not provide one, the entire
-   *          request will fail, even if there are non-versioned objects you are trying to delete. If you
-   *          provide an invalid token, whether there are versioned keys in the request or not, the
-   *          entire Multi-Object Delete request will fail. For information about MFA Delete, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html#MultiFactorAuthenticationDelete"> MFA
-   *          Delete</a>.</p>
+   * <p>When performing this action on an MFA Delete enabled bucket, that attempts to delete
+   * any versioned objects, you must include an MFA token. If you do not provide one, the entire
+   * request will fail, even if there are non-versioned objects you are trying to delete. If you
+   * provide an invalid token, whether there are versioned keys in the request or not, the
+   * entire Multi-Object Delete request will fail. For information about MFA Delete, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html#MultiFactorAuthenticationDelete"> MFA
+   * Delete</a>.</p>
    *
-   *          <p>Finally, the Content-MD5 header is required for all Multi-Object Delete requests. Amazon
-   *          S3 uses the header value to ensure that your request body has not been altered in
-   *          transit.</p>
+   * <p>Finally, the Content-MD5 header is required for all Multi-Object Delete requests. Amazon
+   * S3 uses the header value to ensure that your request body has not been altered in
+   * transit.</p>
    *
-   *          <p>The following operations are related to <code>DeleteObjects</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>DeleteObjects</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteObjects(
     args: DeleteObjectsCommandInput,
@@ -2153,30 +2153,30 @@ export class S3 extends S3Client {
 
   /**
    * <p>Removes the entire tag set from the specified object. For more information about
-   *          managing object tags, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html"> Object
-   *             Tagging</a>.</p>
+   * managing object tags, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html"> Object
+   *    Tagging</a>.</p>
    *
-   *          <p>To use this operation, you must have permission to perform the
-   *             <code>s3:DeleteObjectTagging</code> action.</p>
+   * <p>To use this operation, you must have permission to perform the
+   *    <code>s3:DeleteObjectTagging</code> action.</p>
    *
-   *          <p>To delete tags of a specific object version, add the <code>versionId</code> query
-   *          parameter in the request. You will need permission for the
-   *             <code>s3:DeleteObjectVersionTagging</code> action.</p>
+   * <p>To delete tags of a specific object version, add the <code>versionId</code> query
+   * parameter in the request. You will need permission for the
+   *    <code>s3:DeleteObjectVersionTagging</code> action.</p>
    *
-   *          <p>The following operations are related to
-   *          <code>DeleteBucketMetricsConfiguration</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectTagging.html">PutObjectTagging</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to
+   * <code>DeleteBucketMetricsConfiguration</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectTagging.html">PutObjectTagging</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deleteObjectTagging(
     args: DeleteObjectTaggingCommandInput,
@@ -2209,34 +2209,34 @@ export class S3 extends S3Client {
 
   /**
    * <p>Removes the <code>PublicAccessBlock</code> configuration for an Amazon S3 bucket. To use this
-   *          operation, you must have the <code>s3:PutBucketPublicAccessBlock</code> permission. For
-   *          more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
+   * operation, you must have the <code>s3:PutBucketPublicAccessBlock</code> permission. For
+   * more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
    *
-   *          <p>The following operations are related to <code>DeletePublicAccessBlock</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
-   *                   Public Access</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutPublicAccessBlock.html">PutPublicAccessBlock</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicyStatus.html">GetBucketPolicyStatus</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>DeletePublicAccessBlock</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
+   *          Public Access</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutPublicAccessBlock.html">PutPublicAccessBlock</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicyStatus.html">GetBucketPolicyStatus</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public deletePublicAccessBlock(
     args: DeletePublicAccessBlockCommandInput,
@@ -2269,32 +2269,32 @@ export class S3 extends S3Client {
 
   /**
    * <p>This implementation of the GET action uses the <code>accelerate</code> subresource to
-   *          return the Transfer Acceleration state of a bucket, which is either <code>Enabled</code> or
-   *             <code>Suspended</code>. Amazon S3 Transfer Acceleration is a bucket-level feature that
-   *          enables you to perform faster data transfers to and from Amazon S3.</p>
-   *          <p>To use this operation, you must have permission to perform the
-   *             <code>s3:GetAccelerateConfiguration</code> action. The bucket owner has this permission
-   *          by default. The bucket owner can grant this permission to others. For more information
-   *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to your Amazon S3
-   *             Resources</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>You set the Transfer Acceleration state of an existing bucket to <code>Enabled</code> or
-   *             <code>Suspended</code> by using the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAccelerateConfiguration.html">PutBucketAccelerateConfiguration</a> operation. </p>
-   *          <p>A GET <code>accelerate</code> request does not return a state value for a bucket that
-   *          has no transfer acceleration state. A bucket has no Transfer Acceleration state if a state
-   *          has never been set on the bucket. </p>
+   * return the Transfer Acceleration state of a bucket, which is either <code>Enabled</code> or
+   *    <code>Suspended</code>. Amazon S3 Transfer Acceleration is a bucket-level feature that
+   * enables you to perform faster data transfers to and from Amazon S3.</p>
+   * <p>To use this operation, you must have permission to perform the
+   *    <code>s3:GetAccelerateConfiguration</code> action. The bucket owner has this permission
+   * by default. The bucket owner can grant this permission to others. For more information
+   * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to your Amazon S3
+   *    Resources</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>You set the Transfer Acceleration state of an existing bucket to <code>Enabled</code> or
+   *    <code>Suspended</code> by using the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAccelerateConfiguration.html">PutBucketAccelerateConfiguration</a> operation. </p>
+   * <p>A GET <code>accelerate</code> request does not return a state value for a bucket that
+   * has no transfer acceleration state. A bucket has no Transfer Acceleration state if a state
+   * has never been set on the bucket. </p>
    *
-   *          <p>For more information about transfer acceleration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html">Transfer Acceleration</a> in the
-   *          Amazon S3 User Guide.</p>
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAccelerateConfiguration.html">PutBucketAccelerateConfiguration</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>For more information about transfer acceleration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html">Transfer Acceleration</a> in the
+   * Amazon S3 User Guide.</p>
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAccelerateConfiguration.html">PutBucketAccelerateConfiguration</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketAccelerateConfiguration(
     args: GetBucketAccelerateConfigurationCommandInput,
@@ -2327,21 +2327,21 @@ export class S3 extends S3Client {
 
   /**
    * <p>This implementation of the <code>GET</code> action uses the <code>acl</code>
-   *          subresource to return the access control list (ACL) of a bucket. To use <code>GET</code> to
-   *          return the ACL of the bucket, you must have <code>READ_ACP</code> access to the bucket. If
-   *             <code>READ_ACP</code> permission is granted to the anonymous user, you can return the
-   *          ACL of the bucket without using an authorization header.</p>
+   * subresource to return the access control list (ACL) of a bucket. To use <code>GET</code> to
+   * return the ACL of the bucket, you must have <code>READ_ACP</code> access to the bucket. If
+   *    <code>READ_ACP</code> permission is granted to the anonymous user, you can return the
+   * ACL of the bucket without using an authorization header.</p>
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketAcl(
     args: GetBucketAclCommandInput,
@@ -2371,35 +2371,35 @@ export class S3 extends S3Client {
 
   /**
    * <p>This implementation of the GET action returns an analytics configuration (identified
-   *          by the analytics configuration ID) from the bucket.</p>
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:GetAnalyticsConfiguration</code> action. The bucket owner has this permission
-   *          by default. The bucket owner can grant this permission to others. For more information
-   *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources"> Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a> in the <i>Amazon S3 User Guide</i>. </p>
-   *          <p>For information about Amazon S3 analytics feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
-   *             Analysis</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * by the analytics configuration ID) from the bucket.</p>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:GetAnalyticsConfiguration</code> action. The bucket owner has this permission
+   * by default. The bucket owner can grant this permission to others. For more information
+   * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources"> Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a> in the <i>Amazon S3 User Guide</i>. </p>
+   * <p>For information about Amazon S3 analytics feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
+   *    Analysis</a> in the <i>Amazon S3 User Guide</i>.</p>
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketAnalyticsConfiguration.html">DeleteBucketAnalyticsConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketAnalyticsConfigurations.html">ListBucketAnalyticsConfigurations</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html">PutBucketAnalyticsConfiguration</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketAnalyticsConfiguration.html">DeleteBucketAnalyticsConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketAnalyticsConfigurations.html">ListBucketAnalyticsConfigurations</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html">PutBucketAnalyticsConfiguration</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketAnalyticsConfiguration(
     args: GetBucketAnalyticsConfigurationCommandInput,
@@ -2433,25 +2433,25 @@ export class S3 extends S3Client {
   /**
    * <p>Returns the cors configuration information set for the bucket.</p>
    *
-   *          <p> To use this operation, you must have permission to perform the s3:GetBucketCORS action.
-   *          By default, the bucket owner has this permission and can grant it to others.</p>
+   * <p> To use this operation, you must have permission to perform the s3:GetBucketCORS action.
+   * By default, the bucket owner has this permission and can grant it to others.</p>
    *
-   *          <p> For more information about cors, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html"> Enabling
-   *             Cross-Origin Resource Sharing</a>.</p>
+   * <p> For more information about cors, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html"> Enabling
+   *    Cross-Origin Resource Sharing</a>.</p>
    *
-   *          <p>The following operations are related to <code>GetBucketCors</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketCors.html">PutBucketCors</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketCors.html">DeleteBucketCors</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>GetBucketCors</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketCors.html">PutBucketCors</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketCors.html">DeleteBucketCors</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketCors(
     args: GetBucketCorsCommandInput,
@@ -2484,27 +2484,27 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns the default encryption configuration for an Amazon S3 bucket. If the bucket does not
-   *          have a default encryption configuration, GetBucketEncryption returns
-   *          <code>ServerSideEncryptionConfigurationNotFoundError</code>. </p>
-   *          <p>For information about the Amazon S3 default encryption feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html">Amazon S3 Default Bucket Encryption</a>.</p>
-   *          <p> To use this operation, you must have permission to perform the
-   *             <code>s3:GetEncryptionConfiguration</code> action. The bucket owner has this permission
-   *          by default. The bucket owner can grant this permission to others. For more information
-   *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
-   *          <p>The following operations are related to <code>GetBucketEncryption</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html">PutBucketEncryption</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketEncryption.html">DeleteBucketEncryption</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * have a default encryption configuration, GetBucketEncryption returns
+   * <code>ServerSideEncryptionConfigurationNotFoundError</code>. </p>
+   * <p>For information about the Amazon S3 default encryption feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html">Amazon S3 Default Bucket Encryption</a>.</p>
+   * <p> To use this operation, you must have permission to perform the
+   *    <code>s3:GetEncryptionConfiguration</code> action. The bucket owner has this permission
+   * by default. The bucket owner can grant this permission to others. For more information
+   * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
+   * <p>The following operations are related to <code>GetBucketEncryption</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html">PutBucketEncryption</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketEncryption.html">DeleteBucketEncryption</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketEncryption(
     args: GetBucketEncryptionCommandInput,
@@ -2537,28 +2537,28 @@ export class S3 extends S3Client {
 
   /**
    * <p>Gets the S3 Intelligent-Tiering configuration from the specified bucket.</p>
-   *          <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
-   *          <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
-   *          <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
-   *          <p>Operations related to
-   *             <code>GetBucketIntelligentTieringConfiguration</code> include: </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketIntelligentTieringConfiguration.html">DeleteBucketIntelligentTieringConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html">PutBucketIntelligentTieringConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html">ListBucketIntelligentTieringConfigurations</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
+   * <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
+   * <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
+   * <p>Operations related to
+   *    <code>GetBucketIntelligentTieringConfiguration</code> include: </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketIntelligentTieringConfiguration.html">DeleteBucketIntelligentTieringConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html">PutBucketIntelligentTieringConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html">ListBucketIntelligentTieringConfigurations</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketIntelligentTieringConfiguration(
     args: GetBucketIntelligentTieringConfigurationCommandInput,
@@ -2593,35 +2593,35 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns an inventory configuration (identified by the inventory configuration ID) from
-   *          the bucket.</p>
+   * the bucket.</p>
    *
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:GetInventoryConfiguration</code> action. The bucket owner has this permission
-   *          by default and can grant this permission to others. For more information about permissions,
-   *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:GetInventoryConfiguration</code> action. The bucket owner has this permission
+   * by default and can grant this permission to others. For more information about permissions,
+   * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
    *
-   *          <p>For information about the Amazon S3 inventory feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3 Inventory</a>.</p>
+   * <p>For information about the Amazon S3 inventory feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3 Inventory</a>.</p>
    *
-   *          <p>The following operations are related to
-   *          <code>GetBucketInventoryConfiguration</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketInventoryConfiguration.html">DeleteBucketInventoryConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketInventoryConfigurations.html">ListBucketInventoryConfigurations</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html">PutBucketInventoryConfiguration</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to
+   * <code>GetBucketInventoryConfiguration</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketInventoryConfiguration.html">DeleteBucketInventoryConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketInventoryConfigurations.html">ListBucketInventoryConfigurations</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html">PutBucketInventoryConfiguration</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketInventoryConfiguration(
     args: GetBucketInventoryConfigurationCommandInput,
@@ -2654,61 +2654,61 @@ export class S3 extends S3Client {
 
   /**
    * <note>
-   *             <p>Bucket lifecycle configuration now supports specifying a lifecycle rule using an
-   *             object key name prefix, one or more object tags, or a combination of both. Accordingly,
-   *             this section describes the latest API. The response describes the new filter element
-   *             that you can use to specify a filter to select a subset of objects to which the rule
-   *             applies. If you are using a previous version of the lifecycle configuration, it still
-   *             works. For the earlier action, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycle.html">GetBucketLifecycle</a>.</p>
-   *          </note>
-   *          <p>Returns the lifecycle configuration information set on the bucket. For information about
-   *          lifecycle configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Object
-   *             Lifecycle Management</a>.</p>
+   *    <p>Bucket lifecycle configuration now supports specifying a lifecycle rule using an
+   *    object key name prefix, one or more object tags, or a combination of both. Accordingly,
+   *    this section describes the latest API. The response describes the new filter element
+   *    that you can use to specify a filter to select a subset of objects to which the rule
+   *    applies. If you are using a previous version of the lifecycle configuration, it still
+   *    works. For the earlier action, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycle.html">GetBucketLifecycle</a>.</p>
+   * </note>
+   * <p>Returns the lifecycle configuration information set on the bucket. For information about
+   * lifecycle configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Object
+   *    Lifecycle Management</a>.</p>
    *
-   *          <p>To use this operation, you must have permission to perform the
-   *             <code>s3:GetLifecycleConfiguration</code> action. The bucket owner has this permission,
-   *          by default. The bucket owner can grant this permission to others. For more information
-   *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
+   * <p>To use this operation, you must have permission to perform the
+   *    <code>s3:GetLifecycleConfiguration</code> action. The bucket owner has this permission,
+   * by default. The bucket owner can grant this permission to others. For more information
+   * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
    *
-   *          <p>
-   *             <code>GetBucketLifecycleConfiguration</code> has the following special error:</p>
-   *          <ul>
-   *             <li>
-   *                <p>Error code: <code>NoSuchLifecycleConfiguration</code>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>Description: The lifecycle configuration does not exist.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>HTTP Status Code: 404 Not Found</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>SOAP Fault Code Prefix: Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *          </ul>
-   *          <p>The following operations are related to
-   *          <code>GetBucketLifecycleConfiguration</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycle.html">GetBucketLifecycle</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html">PutBucketLifecycle</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketLifecycle.html">DeleteBucketLifecycle</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>
+   *    <code>GetBucketLifecycleConfiguration</code> has the following special error:</p>
+   * <ul>
+   *    <li>
+   *       <p>Error code: <code>NoSuchLifecycleConfiguration</code>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>Description: The lifecycle configuration does not exist.</p>
+   *          </li>
+   *          <li>
+   *             <p>HTTP Status Code: 404 Not Found</p>
+   *          </li>
+   *          <li>
+   *             <p>SOAP Fault Code Prefix: Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   * </ul>
+   * <p>The following operations are related to
+   * <code>GetBucketLifecycleConfiguration</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycle.html">GetBucketLifecycle</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html">PutBucketLifecycle</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketLifecycle.html">DeleteBucketLifecycle</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketLifecycleConfiguration(
     args: GetBucketLifecycleConfigurationCommandInput,
@@ -2741,26 +2741,26 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns the Region the bucket resides in. You set the bucket's Region using the
-   *             <code>LocationConstraint</code> request parameter in a <code>CreateBucket</code>
-   *          request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>.</p>
+   *    <code>LocationConstraint</code> request parameter in a <code>CreateBucket</code>
+   * request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>.</p>
    *
-   *          <p>To use this implementation of the operation, you must be the bucket owner.</p>
+   * <p>To use this implementation of the operation, you must be the bucket owner.</p>
    *
-   *          <p>To use this API against an access point, provide the alias of the access point in place of the bucket name.</p>
+   * <p>To use this API against an access point, provide the alias of the access point in place of the bucket name.</p>
    *
-   *          <p>The following operations are related to <code>GetBucketLocation</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>GetBucketLocation</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketLocation(
     args: GetBucketLocationCommandInput,
@@ -2793,21 +2793,21 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns the logging status of a bucket and the permissions users have to view and modify
-   *          that status. To use GET, you must be the bucket owner.</p>
+   * that status. To use GET, you must be the bucket owner.</p>
    *
-   *          <p>The following operations are related to <code>GetBucketLogging</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLogging.html">PutBucketLogging</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>GetBucketLogging</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLogging.html">PutBucketLogging</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketLogging(
     args: GetBucketLoggingCommandInput,
@@ -2840,42 +2840,42 @@ export class S3 extends S3Client {
 
   /**
    * <p>Gets a metrics configuration (specified by the metrics configuration ID) from the
-   *          bucket. Note that this doesn't include the daily storage metrics.</p>
+   * bucket. Note that this doesn't include the daily storage metrics.</p>
    *
-   *          <p> To use this operation, you must have permissions to perform the
-   *             <code>s3:GetMetricsConfiguration</code> action. The bucket owner has this permission by
-   *          default. The bucket owner can grant this permission to others. For more information about
-   *          permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
+   * <p> To use this operation, you must have permissions to perform the
+   *    <code>s3:GetMetricsConfiguration</code> action. The bucket owner has this permission by
+   * default. The bucket owner can grant this permission to others. For more information about
+   * permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
    *
-   *          <p> For information about CloudWatch request metrics for Amazon S3, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
-   *             CloudWatch</a>.</p>
+   * <p> For information about CloudWatch request metrics for Amazon S3, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
+   *    CloudWatch</a>.</p>
    *
-   *          <p>The following operations are related to
-   *          <code>GetBucketMetricsConfiguration</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html">DeleteBucketMetricsConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketMetricsConfigurations.html">ListBucketMetricsConfigurations</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
-   *                   CloudWatch</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to
+   * <code>GetBucketMetricsConfiguration</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html">DeleteBucketMetricsConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketMetricsConfigurations.html">ListBucketMetricsConfigurations</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
+   *          CloudWatch</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketMetricsConfiguration(
     args: GetBucketMetricsConfigurationCommandInput,
@@ -2908,26 +2908,26 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns the notification configuration of a bucket.</p>
-   *          <p>If notifications are not enabled on the bucket, the action returns an empty
-   *             <code>NotificationConfiguration</code> element.</p>
+   * <p>If notifications are not enabled on the bucket, the action returns an empty
+   *    <code>NotificationConfiguration</code> element.</p>
    *
-   *          <p>By default, you must be the bucket owner to read the notification configuration of a
-   *          bucket. However, the bucket owner can use a bucket policy to grant permission to other
-   *          users to read this configuration with the <code>s3:GetBucketNotification</code>
-   *          permission.</p>
+   * <p>By default, you must be the bucket owner to read the notification configuration of a
+   * bucket. However, the bucket owner can use a bucket policy to grant permission to other
+   * users to read this configuration with the <code>s3:GetBucketNotification</code>
+   * permission.</p>
    *
-   *          <p>For more information about setting and reading the notification configuration on a
-   *          bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Setting Up Notification of
-   *             Bucket Events</a>. For more information about bucket policies, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies</a>.</p>
+   * <p>For more information about setting and reading the notification configuration on a
+   * bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Setting Up Notification of
+   *    Bucket Events</a>. For more information about bucket policies, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies</a>.</p>
    *
-   *          <p>The following action is related to <code>GetBucketNotification</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketNotification.html">PutBucketNotification</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following action is related to <code>GetBucketNotification</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketNotification.html">PutBucketNotification</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketNotificationConfiguration(
     args: GetBucketNotificationConfigurationCommandInput,
@@ -2960,23 +2960,23 @@ export class S3 extends S3Client {
 
   /**
    * <p>Retrieves <code>OwnershipControls</code> for an Amazon S3 bucket. To use this operation, you
-   *          must have the <code>s3:GetBucketOwnershipControls</code> permission. For more information
-   *          about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying
-   *             Permissions in a Policy</a>. </p>
-   *          <p>For information about Amazon S3 Object Ownership, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html">Using Object Ownership</a>. </p>
-   *          <p>The following operations are related to <code>GetBucketOwnershipControls</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a>PutBucketOwnershipControls</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a>DeleteBucketOwnershipControls</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * must have the <code>s3:GetBucketOwnershipControls</code> permission. For more information
+   * about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying
+   *    Permissions in a Policy</a>. </p>
+   * <p>For information about Amazon S3 Object Ownership, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html">Using Object Ownership</a>. </p>
+   * <p>The following operations are related to <code>GetBucketOwnershipControls</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a>PutBucketOwnershipControls</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a>DeleteBucketOwnershipControls</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketOwnershipControls(
     args: GetBucketOwnershipControlsCommandInput,
@@ -3009,32 +3009,32 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns the policy of a specified bucket. If you are using an identity other than the
-   *          root user of the Amazon Web Services account that owns the bucket, the calling identity must have the
-   *             <code>GetBucketPolicy</code> permissions on the specified bucket and belong to the
-   *          bucket owner's account in order to use this operation.</p>
+   * root user of the Amazon Web Services account that owns the bucket, the calling identity must have the
+   *    <code>GetBucketPolicy</code> permissions on the specified bucket and belong to the
+   * bucket owner's account in order to use this operation.</p>
    *
-   *          <p>If you don't have <code>GetBucketPolicy</code> permissions, Amazon S3 returns a <code>403
-   *             Access Denied</code> error. If you have the correct permissions, but you're not using an
-   *          identity that belongs to the bucket owner's account, Amazon S3 returns a <code>405 Method Not
-   *             Allowed</code> error.</p>
+   * <p>If you don't have <code>GetBucketPolicy</code> permissions, Amazon S3 returns a <code>403
+   *    Access Denied</code> error. If you have the correct permissions, but you're not using an
+   * identity that belongs to the bucket owner's account, Amazon S3 returns a <code>405 Method Not
+   *    Allowed</code> error.</p>
    *
-   *          <important>
-   *             <p>As a security precaution, the root user of the Amazon Web Services account that owns a bucket can
-   *             always use this operation, even if the policy explicitly denies the root user the
-   *             ability to perform this action.</p>
-   *          </important>
+   * <important>
+   *    <p>As a security precaution, the root user of the Amazon Web Services account that owns a bucket can
+   *    always use this operation, even if the policy explicitly denies the root user the
+   *    ability to perform this action.</p>
+   * </important>
    *
-   *          <p>For more information about bucket policies, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies and User
-   *             Policies</a>.</p>
+   * <p>For more information about bucket policies, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies and User
+   *    Policies</a>.</p>
    *
-   *          <p>The following action is related to <code>GetBucketPolicy</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following action is related to <code>GetBucketPolicy</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketPolicy(
     args: GetBucketPolicyCommandInput,
@@ -3067,36 +3067,36 @@ export class S3 extends S3Client {
 
   /**
    * <p>Retrieves the policy status for an Amazon S3 bucket, indicating whether the bucket is public.
-   *          In order to use this operation, you must have the <code>s3:GetBucketPolicyStatus</code>
-   *          permission. For more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a
-   *          Policy</a>.</p>
+   * In order to use this operation, you must have the <code>s3:GetBucketPolicyStatus</code>
+   * permission. For more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a
+   * Policy</a>.</p>
    *
-   *          <p> For more information about when Amazon S3 considers a bucket public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a>. </p>
+   * <p> For more information about when Amazon S3 considers a bucket public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a>. </p>
    *
-   *          <p>The following operations are related to <code>GetBucketPolicyStatus</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
-   *                   Public Access</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutPublicAccessBlock.html">PutPublicAccessBlock</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletePublicAccessBlock.html">DeletePublicAccessBlock</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>GetBucketPolicyStatus</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
+   *          Public Access</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutPublicAccessBlock.html">PutPublicAccessBlock</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletePublicAccessBlock.html">DeletePublicAccessBlock</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketPolicyStatus(
     args: GetBucketPolicyStatusCommandInput,
@@ -3129,40 +3129,40 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns the replication configuration of a bucket.</p>
-   *          <note>
-   *             <p> It can take a while to propagate the put or delete a replication configuration to
-   *             all Amazon S3 systems. Therefore, a get request soon after put or delete can return a wrong
-   *             result. </p>
-   *          </note>
-   *          <p> For information about replication configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html">Replication</a> in the
-   *             <i>Amazon S3 User Guide</i>.</p>
+   * <note>
+   *    <p> It can take a while to propagate the put or delete a replication configuration to
+   *    all Amazon S3 systems. Therefore, a get request soon after put or delete can return a wrong
+   *    result. </p>
+   * </note>
+   * <p> For information about replication configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html">Replication</a> in the
+   *    <i>Amazon S3 User Guide</i>.</p>
    *
-   *          <p>This action requires permissions for the <code>s3:GetReplicationConfiguration</code>
-   *          action. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies and User
-   *             Policies</a>.</p>
+   * <p>This action requires permissions for the <code>s3:GetReplicationConfiguration</code>
+   * action. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies and User
+   *    Policies</a>.</p>
    *
-   *          <p>If you include the <code>Filter</code> element in a replication configuration, you must
-   *          also include the <code>DeleteMarkerReplication</code> and <code>Priority</code> elements.
-   *          The response also returns those elements.</p>
+   * <p>If you include the <code>Filter</code> element in a replication configuration, you must
+   * also include the <code>DeleteMarkerReplication</code> and <code>Priority</code> elements.
+   * The response also returns those elements.</p>
    *
-   *          <p>For information about <code>GetBucketReplication</code> errors, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ReplicationErrorCodeList">List of
-   *             replication-related error codes</a>
-   *          </p>
+   * <p>For information about <code>GetBucketReplication</code> errors, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ReplicationErrorCodeList">List of
+   *    replication-related error codes</a>
+   * </p>
    *
    *
-   *          <p>The following operations are related to <code>GetBucketReplication</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html">PutBucketReplication</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketReplication.html">DeleteBucketReplication</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>GetBucketReplication</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html">PutBucketReplication</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketReplication.html">DeleteBucketReplication</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketReplication(
     args: GetBucketReplicationCommandInput,
@@ -3195,16 +3195,16 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns the request payment configuration of a bucket. To use this version of the
-   *          operation, you must be the bucket owner. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html">Requester Pays Buckets</a>.</p>
+   * operation, you must be the bucket owner. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html">Requester Pays Buckets</a>.</p>
    *
-   *          <p>The following operations are related to <code>GetBucketRequestPayment</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>GetBucketRequestPayment</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketRequestPayment(
     args: GetBucketRequestPaymentCommandInput,
@@ -3237,37 +3237,37 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns the tag set associated with the bucket.</p>
-   *          <p>To use this operation, you must have permission to perform the
-   *             <code>s3:GetBucketTagging</code> action. By default, the bucket owner has this
-   *          permission and can grant this permission to others.</p>
+   * <p>To use this operation, you must have permission to perform the
+   *    <code>s3:GetBucketTagging</code> action. By default, the bucket owner has this
+   * permission and can grant this permission to others.</p>
    *
-   *          <p>
-   *             <code>GetBucketTagging</code> has the following special error:</p>
-   *          <ul>
-   *             <li>
-   *                <p>Error code: <code>NoSuchTagSetError</code>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>Description: There is no tag set associated with the bucket.</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *          </ul>
+   * <p>
+   *    <code>GetBucketTagging</code> has the following special error:</p>
+   * <ul>
+   *    <li>
+   *       <p>Error code: <code>NoSuchTagSetError</code>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>Description: There is no tag set associated with the bucket.</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   * </ul>
    *
-   *          <p>The following operations are related to <code>GetBucketTagging</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketTagging.html">PutBucketTagging</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketTagging.html">DeleteBucketTagging</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>GetBucketTagging</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketTagging.html">PutBucketTagging</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketTagging.html">DeleteBucketTagging</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketTagging(
     args: GetBucketTaggingCommandInput,
@@ -3300,30 +3300,30 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns the versioning state of a bucket.</p>
-   *          <p>To retrieve the versioning state of a bucket, you must be the bucket owner.</p>
+   * <p>To retrieve the versioning state of a bucket, you must be the bucket owner.</p>
    *
-   *          <p>This implementation also returns the MFA Delete status of the versioning state. If the
-   *          MFA Delete status is <code>enabled</code>, the bucket owner must use an authentication
-   *          device to change the versioning state of the bucket.</p>
+   * <p>This implementation also returns the MFA Delete status of the versioning state. If the
+   * MFA Delete status is <code>enabled</code>, the bucket owner must use an authentication
+   * device to change the versioning state of the bucket.</p>
    *
-   *          <p>The following operations are related to <code>GetBucketVersioning</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>GetBucketVersioning</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketVersioning(
     args: GetBucketVersioningCommandInput,
@@ -3356,26 +3356,26 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns the website configuration for a bucket. To host website on Amazon S3, you can
-   *          configure a bucket as website by adding a website configuration. For more information about
-   *          hosting websites, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html">Hosting Websites on
-   *             Amazon S3</a>. </p>
-   *          <p>This GET action requires the <code>S3:GetBucketWebsite</code> permission. By default,
-   *          only the bucket owner can read the bucket website configuration. However, bucket owners can
-   *          allow other users to read the website configuration by writing a bucket policy granting
-   *          them the <code>S3:GetBucketWebsite</code> permission.</p>
-   *          <p>The following operations are related to <code>DeleteBucketWebsite</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketWebsite.html">DeleteBucketWebsite</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketWebsite.html">PutBucketWebsite</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * configure a bucket as website by adding a website configuration. For more information about
+   * hosting websites, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html">Hosting Websites on
+   *    Amazon S3</a>. </p>
+   * <p>This GET action requires the <code>S3:GetBucketWebsite</code> permission. By default,
+   * only the bucket owner can read the bucket website configuration. However, bucket owners can
+   * allow other users to read the website configuration by writing a bucket policy granting
+   * them the <code>S3:GetBucketWebsite</code> permission.</p>
+   * <p>The following operations are related to <code>DeleteBucketWebsite</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketWebsite.html">DeleteBucketWebsite</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketWebsite.html">PutBucketWebsite</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getBucketWebsite(
     args: GetBucketWebsiteCommandInput,
@@ -3408,186 +3408,186 @@ export class S3 extends S3Client {
 
   /**
    * <p>Retrieves objects from Amazon S3. To use <code>GET</code>, you must have <code>READ</code>
-   *          access to the object. If you grant <code>READ</code> access to the anonymous user, you can
-   *          return the object without using an authorization header.</p>
+   * access to the object. If you grant <code>READ</code> access to the anonymous user, you can
+   * return the object without using an authorization header.</p>
    *
-   *          <p>An Amazon S3 bucket has no directory hierarchy such as you would find in a typical computer
-   *          file system. You can, however, create a logical hierarchy by using object key names that
-   *          imply a folder structure. For example, instead of naming an object <code>sample.jpg</code>,
-   *          you can name it <code>photos/2006/February/sample.jpg</code>.</p>
+   * <p>An Amazon S3 bucket has no directory hierarchy such as you would find in a typical computer
+   * file system. You can, however, create a logical hierarchy by using object key names that
+   * imply a folder structure. For example, instead of naming an object <code>sample.jpg</code>,
+   * you can name it <code>photos/2006/February/sample.jpg</code>.</p>
    *
-   *          <p>To get an object from such a logical hierarchy, specify the full key name for the object
-   *          in the <code>GET</code> operation. For a virtual hosted-style request example, if you have
-   *          the object <code>photos/2006/February/sample.jpg</code>, specify the resource as
-   *             <code>/photos/2006/February/sample.jpg</code>. For a path-style request example, if you
-   *          have the object <code>photos/2006/February/sample.jpg</code> in the bucket named
-   *             <code>examplebucket</code>, specify the resource as
-   *             <code>/examplebucket/photos/2006/February/sample.jpg</code>. For more information about
-   *          request types, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#VirtualHostingSpecifyBucket">HTTP Host Header Bucket Specification</a>.</p>
+   * <p>To get an object from such a logical hierarchy, specify the full key name for the object
+   * in the <code>GET</code> operation. For a virtual hosted-style request example, if you have
+   * the object <code>photos/2006/February/sample.jpg</code>, specify the resource as
+   *    <code>/photos/2006/February/sample.jpg</code>. For a path-style request example, if you
+   * have the object <code>photos/2006/February/sample.jpg</code> in the bucket named
+   *    <code>examplebucket</code>, specify the resource as
+   *    <code>/examplebucket/photos/2006/February/sample.jpg</code>. For more information about
+   * request types, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#VirtualHostingSpecifyBucket">HTTP Host Header Bucket Specification</a>.</p>
    *
-   *          <p>To distribute large files to many people, you can save bandwidth costs by using
-   *          BitTorrent. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3Torrent.html">Amazon S3
-   *             Torrent</a>. For more information about returning the ACL of an object, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html">GetObjectAcl</a>.</p>
+   * <p>To distribute large files to many people, you can save bandwidth costs by using
+   * BitTorrent. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3Torrent.html">Amazon S3
+   *    Torrent</a>. For more information about returning the ACL of an object, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html">GetObjectAcl</a>.</p>
    *
-   *          <p>If the object you are retrieving is stored in the S3 Glacier or
-   *          S3 Glacier Deep Archive storage class, or S3 Intelligent-Tiering Archive or
-   *          S3 Intelligent-Tiering Deep Archive tiers, before you can retrieve the object you must first restore a
-   *          copy using <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a>. Otherwise, this action returns an
-   *             <code>InvalidObjectStateError</code> error. For information about restoring archived
-   *          objects, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html">Restoring Archived
-   *             Objects</a>.</p>
+   * <p>If the object you are retrieving is stored in the S3 Glacier or
+   * S3 Glacier Deep Archive storage class, or S3 Intelligent-Tiering Archive or
+   * S3 Intelligent-Tiering Deep Archive tiers, before you can retrieve the object you must first restore a
+   * copy using <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a>. Otherwise, this action returns an
+   *    <code>InvalidObjectStateError</code> error. For information about restoring archived
+   * objects, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html">Restoring Archived
+   *    Objects</a>.</p>
    *
-   *          <p>Encryption request headers, like <code>x-amz-server-side-encryption</code>, should not
-   *          be sent for GET requests if your object uses server-side encryption with CMKs stored in Amazon Web Services
-   *          KMS (SSE-KMS) or server-side encryption with Amazon S3–managed encryption keys (SSE-S3). If your
-   *          object does use these types of keys, you’ll get an HTTP 400 BadRequest error.</p>
-   *          <p>If you encrypt an object by using server-side encryption with customer-provided
-   *          encryption keys (SSE-C) when you store the object in Amazon S3, then when you GET the object,
-   *          you must use the following headers:</p>
-   *          <ul>
-   *             <li>
-   *                <p>x-amz-server-side-encryption-customer-algorithm</p>
-   *             </li>
-   *             <li>
-   *                <p>x-amz-server-side-encryption-customer-key</p>
-   *             </li>
-   *             <li>
-   *                <p>x-amz-server-side-encryption-customer-key-MD5</p>
-   *             </li>
-   *          </ul>
-   *          <p>For more information about SSE-C, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html">Server-Side Encryption (Using
-   *             Customer-Provided Encryption Keys)</a>.</p>
+   * <p>Encryption request headers, like <code>x-amz-server-side-encryption</code>, should not
+   * be sent for GET requests if your object uses server-side encryption with CMKs stored in Amazon Web Services
+   * KMS (SSE-KMS) or server-side encryption with Amazon S3–managed encryption keys (SSE-S3). If your
+   * object does use these types of keys, you’ll get an HTTP 400 BadRequest error.</p>
+   * <p>If you encrypt an object by using server-side encryption with customer-provided
+   * encryption keys (SSE-C) when you store the object in Amazon S3, then when you GET the object,
+   * you must use the following headers:</p>
+   * <ul>
+   *    <li>
+   *       <p>x-amz-server-side-encryption-customer-algorithm</p>
+   *    </li>
+   *    <li>
+   *       <p>x-amz-server-side-encryption-customer-key</p>
+   *    </li>
+   *    <li>
+   *       <p>x-amz-server-side-encryption-customer-key-MD5</p>
+   *    </li>
+   * </ul>
+   * <p>For more information about SSE-C, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html">Server-Side Encryption (Using
+   *    Customer-Provided Encryption Keys)</a>.</p>
    *
-   *          <p>Assuming you have the relevant permission to read object tags, the response also returns the
-   *             <code>x-amz-tagging-count</code> header that provides the count of number of tags
-   *          associated with the object. You can use <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a> to retrieve
-   *          the tag set associated with an object.</p>
+   * <p>Assuming you have the relevant permission to read object tags, the response also returns the
+   *    <code>x-amz-tagging-count</code> header that provides the count of number of tags
+   * associated with the object. You can use <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a> to retrieve
+   * the tag set associated with an object.</p>
    *
-   *          <p>
-   *             <b>Permissions</b>
-   *          </p>
-   *          <p>You need the relevant read object (or version) permission for this operation. For more
-   *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions
-   *             in a Policy</a>. If the object you request does not exist, the error Amazon S3 returns
-   *          depends on whether you also have the <code>s3:ListBucket</code> permission.</p>
-   *          <ul>
-   *             <li>
-   *                <p>If you have the <code>s3:ListBucket</code> permission on the bucket, Amazon S3 will
-   *                return an HTTP status code 404 ("no such key") error.</p>
-   *             </li>
-   *             <li>
-   *                <p>If you don’t have the <code>s3:ListBucket</code> permission, Amazon S3 will return an
-   *                HTTP status code 403 ("access denied") error.</p>
-   *             </li>
-   *          </ul>
-   *
-   *
-   *          <p>
-   *             <b>Versioning</b>
-   *          </p>
-   *          <p>By default, the GET action returns the current version of an object. To return a
-   *          different version, use the <code>versionId</code> subresource.</p>
-   *
-   *          <note>
-   *             <ul>
-   *                <li>
-   *                   <p>You need the <code>s3:GetObjectVersion</code> permission to access a specific version of an object.
-   *             </p>
-   *                </li>
-   *                <li>
-   *                   <p>If the current version of the object is a delete marker, Amazon S3 behaves as if the
-   *             object was deleted and includes <code>x-amz-delete-marker: true</code> in the
-   *             response.</p>
-   *                </li>
-   *             </ul>
-   *          </note>
+   * <p>
+   *    <b>Permissions</b>
+   * </p>
+   * <p>You need the relevant read object (or version) permission for this operation. For more
+   * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions
+   *    in a Policy</a>. If the object you request does not exist, the error Amazon S3 returns
+   * depends on whether you also have the <code>s3:ListBucket</code> permission.</p>
+   * <ul>
+   *    <li>
+   *       <p>If you have the <code>s3:ListBucket</code> permission on the bucket, Amazon S3 will
+   *       return an HTTP status code 404 ("no such key") error.</p>
+   *    </li>
+   *    <li>
+   *       <p>If you don’t have the <code>s3:ListBucket</code> permission, Amazon S3 will return an
+   *       HTTP status code 403 ("access denied") error.</p>
+   *    </li>
+   * </ul>
    *
    *
-   *          <p>For more information about versioning, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html">PutBucketVersioning</a>. </p>
+   * <p>
+   *    <b>Versioning</b>
+   * </p>
+   * <p>By default, the GET action returns the current version of an object. To return a
+   * different version, use the <code>versionId</code> subresource.</p>
    *
-   *          <p>
-   *             <b>Overriding Response Header Values</b>
-   *          </p>
-   *          <p>There are times when you want to override certain response header values in a GET
-   *          response. For example, you might override the Content-Disposition response header value in
-   *          your GET request.</p>
+   * <note>
+   *    <ul>
+   *       <li>
+   *          <p>You need the <code>s3:GetObjectVersion</code> permission to access a specific version of an object.
+   *    </p>
+   *       </li>
+   *       <li>
+   *          <p>If the current version of the object is a delete marker, Amazon S3 behaves as if the
+   *    object was deleted and includes <code>x-amz-delete-marker: true</code> in the
+   *    response.</p>
+   *       </li>
+   *    </ul>
+   * </note>
    *
-   *          <p>You can override values for a set of response headers using the following query
-   *          parameters. These response header values are sent only on a successful request, that is,
-   *          when status code 200 OK is returned. The set of headers you can override using these
-   *          parameters is a subset of the headers that Amazon S3 accepts when you create an object. The
-   *          response headers that you can override for the GET response are <code>Content-Type</code>,
-   *             <code>Content-Language</code>, <code>Expires</code>, <code>Cache-Control</code>,
-   *             <code>Content-Disposition</code>, and <code>Content-Encoding</code>. To override these
-   *          header values in the GET response, you use the following request parameters.</p>
    *
-   *          <note>
-   *             <p>You must sign the request, either using an Authorization header or a presigned URL,
-   *             when using these parameters. They cannot be used with an unsigned (anonymous)
-   *             request.</p>
-   *          </note>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <code>response-content-type</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>response-content-language</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>response-expires</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>response-cache-control</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>response-content-disposition</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>response-content-encoding</code>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>For more information about versioning, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html">PutBucketVersioning</a>. </p>
    *
-   *          <p>
-   *             <b>Additional Considerations about Request Headers</b>
-   *          </p>
+   * <p>
+   *    <b>Overriding Response Header Values</b>
+   * </p>
+   * <p>There are times when you want to override certain response header values in a GET
+   * response. For example, you might override the Content-Disposition response header value in
+   * your GET request.</p>
    *
-   *          <p>If both of the <code>If-Match</code> and <code>If-Unmodified-Since</code> headers are
-   *          present in the request as follows: <code>If-Match</code> condition evaluates to
-   *             <code>true</code>, and; <code>If-Unmodified-Since</code> condition evaluates to
-   *             <code>false</code>; then, S3 returns 200 OK and the data requested. </p>
+   * <p>You can override values for a set of response headers using the following query
+   * parameters. These response header values are sent only on a successful request, that is,
+   * when status code 200 OK is returned. The set of headers you can override using these
+   * parameters is a subset of the headers that Amazon S3 accepts when you create an object. The
+   * response headers that you can override for the GET response are <code>Content-Type</code>,
+   *    <code>Content-Language</code>, <code>Expires</code>, <code>Cache-Control</code>,
+   *    <code>Content-Disposition</code>, and <code>Content-Encoding</code>. To override these
+   * header values in the GET response, you use the following request parameters.</p>
    *
-   *          <p>If both of the <code>If-None-Match</code> and <code>If-Modified-Since</code> headers are
-   *          present in the request as follows:<code> If-None-Match</code> condition evaluates to
-   *             <code>false</code>, and; <code>If-Modified-Since</code> condition evaluates to
-   *             <code>true</code>; then, S3 returns 304 Not Modified response code.</p>
+   * <note>
+   *    <p>You must sign the request, either using an Authorization header or a presigned URL,
+   *    when using these parameters. They cannot be used with an unsigned (anonymous)
+   *    request.</p>
+   * </note>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <code>response-content-type</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>response-content-language</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>response-expires</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>response-cache-control</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>response-content-disposition</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>response-content-encoding</code>
+   *       </p>
+   *    </li>
+   * </ul>
    *
-   *          <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+   * <p>
+   *    <b>Additional Considerations about Request Headers</b>
+   * </p>
    *
-   *          <p>The following operations are related to <code>GetObject</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html">ListBuckets</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html">GetObjectAcl</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>If both of the <code>If-Match</code> and <code>If-Unmodified-Since</code> headers are
+   * present in the request as follows: <code>If-Match</code> condition evaluates to
+   *    <code>true</code>, and; <code>If-Unmodified-Since</code> condition evaluates to
+   *    <code>false</code>; then, S3 returns 200 OK and the data requested. </p>
+   *
+   * <p>If both of the <code>If-None-Match</code> and <code>If-Modified-Since</code> headers are
+   * present in the request as follows:<code> If-None-Match</code> condition evaluates to
+   *    <code>false</code>, and; <code>If-Modified-Since</code> condition evaluates to
+   *    <code>true</code>; then, S3 returns 304 Not Modified response code.</p>
+   *
+   * <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+   *
+   * <p>The following operations are related to <code>GetObject</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html">ListBuckets</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html">GetObjectAcl</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getObject(args: GetObjectCommandInput, options?: __HttpHandlerOptions): Promise<GetObjectCommandOutput>;
   public getObject(args: GetObjectCommandInput, cb: (err: any, data?: GetObjectCommandOutput) => void): void;
@@ -3614,32 +3614,32 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns the access control list (ACL) of an object. To use this operation, you must have
-   *             <code>READ_ACP</code> access to the object.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
-   *             <p>
-   *             <b>Versioning</b>
-   *          </p>
-   *          <p>By default, GET returns ACL information about the current version of an object. To
-   *          return ACL information about a different version, use the versionId subresource.</p>
+   *    <code>READ_ACP</code> access to the object.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
+   *    <p>
+   *    <b>Versioning</b>
+   * </p>
+   * <p>By default, GET returns ACL information about the current version of an object. To
+   * return ACL information about a different version, use the versionId subresource.</p>
    *
-   *          <p>The following operations are related to <code>GetObjectAcl</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>GetObjectAcl</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getObjectAcl(
     args: GetObjectAclCommandInput,
@@ -3669,7 +3669,7 @@ export class S3 extends S3Client {
 
   /**
    * <p>Gets an object's current Legal Hold status. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking Objects</a>.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   public getObjectLegalHold(
     args: GetObjectLegalHoldCommandInput,
@@ -3702,9 +3702,9 @@ export class S3 extends S3Client {
 
   /**
    * <p>Gets the Object Lock configuration for a bucket. The rule specified in the Object Lock
-   *          configuration will be applied by default to every new object placed in the specified
-   *          bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking
-   *             Objects</a>.</p>
+   * configuration will be applied by default to every new object placed in the specified
+   * bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking
+   *    Objects</a>.</p>
    */
   public getObjectLockConfiguration(
     args: GetObjectLockConfigurationCommandInput,
@@ -3737,7 +3737,7 @@ export class S3 extends S3Client {
 
   /**
    * <p>Retrieves an object's retention settings. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking Objects</a>.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   public getObjectRetention(
     args: GetObjectRetentionCommandInput,
@@ -3770,33 +3770,33 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns the tag-set of an object. You send the GET request against the tagging
-   *          subresource associated with the object.</p>
+   * subresource associated with the object.</p>
    *
-   *          <p>To use this operation, you must have permission to perform the
-   *             <code>s3:GetObjectTagging</code> action. By default, the GET action returns
-   *          information about current version of an object. For a versioned bucket, you can have
-   *          multiple versions of an object in your bucket. To retrieve tags of any other version, use
-   *          the versionId query parameter. You also need permission for the
-   *             <code>s3:GetObjectVersionTagging</code> action.</p>
+   * <p>To use this operation, you must have permission to perform the
+   *    <code>s3:GetObjectTagging</code> action. By default, the GET action returns
+   * information about current version of an object. For a versioned bucket, you can have
+   * multiple versions of an object in your bucket. To retrieve tags of any other version, use
+   * the versionId query parameter. You also need permission for the
+   *    <code>s3:GetObjectVersionTagging</code> action.</p>
    *
-   *          <p> By default, the bucket owner has this permission and can grant this permission to
-   *          others.</p>
+   * <p> By default, the bucket owner has this permission and can grant this permission to
+   * others.</p>
    *
-   *          <p> For information about the Amazon S3 object tagging feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html">Object Tagging</a>.</p>
+   * <p> For information about the Amazon S3 object tagging feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html">Object Tagging</a>.</p>
    *
-   *          <p>The following action is related to <code>GetObjectTagging</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectTagging.html">PutObjectTagging</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectTagging.html">DeleteObjectTagging</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following action is related to <code>GetObjectTagging</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectTagging.html">PutObjectTagging</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectTagging.html">DeleteObjectTagging</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getObjectTagging(
     args: GetObjectTaggingCommandInput,
@@ -3829,22 +3829,22 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns torrent files from a bucket. BitTorrent can save you bandwidth when you're
-   *          distributing large files. For more information about BitTorrent, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3Torrent.html">Using BitTorrent with Amazon S3</a>.</p>
-   *          <note>
-   *             <p>You can get torrent only for objects that are less than 5 GB in size, and that are
-   *             not encrypted using server-side encryption with a customer-provided encryption
-   *             key.</p>
-   *          </note>
-   *          <p>To use GET, you must have READ access to the object.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
-   *          <p>The following action is related to <code>GetObjectTorrent</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * distributing large files. For more information about BitTorrent, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3Torrent.html">Using BitTorrent with Amazon S3</a>.</p>
+   * <note>
+   *    <p>You can get torrent only for objects that are less than 5 GB in size, and that are
+   *    not encrypted using server-side encryption with a customer-provided encryption
+   *    key.</p>
+   * </note>
+   * <p>To use GET, you must have READ access to the object.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>The following action is related to <code>GetObjectTorrent</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getObjectTorrent(
     args: GetObjectTorrentCommandInput,
@@ -3877,45 +3877,45 @@ export class S3 extends S3Client {
 
   /**
    * <p>Retrieves the <code>PublicAccessBlock</code> configuration for an Amazon S3 bucket. To use
-   *          this operation, you must have the <code>s3:GetBucketPublicAccessBlock</code> permission.
-   *          For more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a
-   *          Policy</a>.</p>
+   * this operation, you must have the <code>s3:GetBucketPublicAccessBlock</code> permission.
+   * For more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a
+   * Policy</a>.</p>
    *
-   *          <important>
-   *             <p>When Amazon S3 evaluates the <code>PublicAccessBlock</code> configuration for a bucket or
-   *             an object, it checks the <code>PublicAccessBlock</code> configuration for both the
-   *             bucket (or the bucket that contains the object) and the bucket owner's account. If the
-   *                <code>PublicAccessBlock</code> settings are different between the bucket and the
-   *             account, Amazon S3 uses the most restrictive combination of the bucket-level and
-   *             account-level settings.</p>
-   *          </important>
+   * <important>
+   *    <p>When Amazon S3 evaluates the <code>PublicAccessBlock</code> configuration for a bucket or
+   *    an object, it checks the <code>PublicAccessBlock</code> configuration for both the
+   *    bucket (or the bucket that contains the object) and the bucket owner's account. If the
+   *       <code>PublicAccessBlock</code> settings are different between the bucket and the
+   *    account, Amazon S3 uses the most restrictive combination of the bucket-level and
+   *    account-level settings.</p>
+   * </important>
    *
-   *          <p>For more information about when Amazon S3 considers a bucket or an object public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a>.</p>
+   * <p>For more information about when Amazon S3 considers a bucket or an object public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a>.</p>
    *
-   *          <p>The following operations are related to <code>GetPublicAccessBlock</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
-   *                   Public Access</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutPublicAccessBlock.html">PutPublicAccessBlock</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletePublicAccessBlock.html">DeletePublicAccessBlock</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>GetPublicAccessBlock</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
+   *          Public Access</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutPublicAccessBlock.html">PutPublicAccessBlock</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletePublicAccessBlock.html">DeletePublicAccessBlock</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public getPublicAccessBlock(
     args: GetPublicAccessBlockCommandInput,
@@ -3948,21 +3948,21 @@ export class S3 extends S3Client {
 
   /**
    * <p>This action is useful to determine if a bucket exists and you have permission to
-   *          access it. The action returns a <code>200 OK</code> if the bucket exists and you have
-   *          permission to access it.</p>
+   * access it. The action returns a <code>200 OK</code> if the bucket exists and you have
+   * permission to access it.</p>
    *
    *
-   *          <p>If the bucket does not exist or you do not have permission to access it, the <code>HEAD</code> request
-   *          returns a generic <code>404 Not Found</code> or <code>403 Forbidden</code> code. A message body is not
-   *          included, so you cannot determine the exception beyond these error codes.</p>
+   * <p>If the bucket does not exist or you do not have permission to access it, the <code>HEAD</code> request
+   * returns a generic <code>404 Not Found</code> or <code>403 Forbidden</code> code. A message body is not
+   * included, so you cannot determine the exception beyond these error codes.</p>
    *
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:ListBucket</code> action. The bucket owner has this permission by default and
-   *          can grant this permission to others. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:ListBucket</code> action. The bucket owner has this permission by default and
+   * can grant this permission to others. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
    *
    *
-   *          <p>To use this API against an access point, you must provide the alias of the access point in place of the bucket name or specify the access point ARN. When using the access point ARN, you must direct requests to the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com. When using the Amazon Web Services SDKs, you provide the ARN in place of the bucket name. For more information see, <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a>.</p>
+   * <p>To use this API against an access point, you must provide the alias of the access point in place of the bucket name or specify the access point ARN. When using the access point ARN, you must direct requests to the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com. When using the Amazon Web Services SDKs, you provide the ARN in place of the bucket name. For more information see, <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a>.</p>
    */
   public headBucket(args: HeadBucketCommandInput, options?: __HttpHandlerOptions): Promise<HeadBucketCommandOutput>;
   public headBucket(args: HeadBucketCommandInput, cb: (err: any, data?: HeadBucketCommandOutput) => void): void;
@@ -3989,117 +3989,117 @@ export class S3 extends S3Client {
 
   /**
    * <p>The HEAD action retrieves metadata from an object without returning the object
-   *          itself. This action is useful if you're only interested in an object's metadata. To use
-   *          HEAD, you must have READ access to the object.</p>
+   * itself. This action is useful if you're only interested in an object's metadata. To use
+   * HEAD, you must have READ access to the object.</p>
    *
-   *          <p>A <code>HEAD</code> request has the same options as a <code>GET</code> action on an
-   *          object. The response is identical to the <code>GET</code> response except that there is no
-   *          response body. Because of this, if the <code>HEAD</code> request generates an error, it
-   *          returns a generic <code>404 Not Found</code> or <code>403 Forbidden</code> code. It is not
-   *          possible to retrieve the exact exception beyond these error codes.</p>
+   * <p>A <code>HEAD</code> request has the same options as a <code>GET</code> action on an
+   * object. The response is identical to the <code>GET</code> response except that there is no
+   * response body. Because of this, if the <code>HEAD</code> request generates an error, it
+   * returns a generic <code>404 Not Found</code> or <code>403 Forbidden</code> code. It is not
+   * possible to retrieve the exact exception beyond these error codes.</p>
    *
-   *          <p>If you encrypt an object by using server-side encryption with customer-provided
-   *          encryption keys (SSE-C) when you store the object in Amazon S3, then when you retrieve the
-   *          metadata from the object, you must use the following headers:</p>
-   *          <ul>
-   *             <li>
-   *                <p>x-amz-server-side-encryption-customer-algorithm</p>
-   *             </li>
-   *             <li>
-   *                <p>x-amz-server-side-encryption-customer-key</p>
-   *             </li>
-   *             <li>
-   *                <p>x-amz-server-side-encryption-customer-key-MD5</p>
-   *             </li>
-   *          </ul>
-   *          <p>For more information about SSE-C, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html">Server-Side Encryption (Using
-   *             Customer-Provided Encryption Keys)</a>.</p>
-   *          <note>
-   *             <ul>
-   *                <li>
-   *                   <p>Encryption request headers, like <code>x-amz-server-side-encryption</code>, should
-   *             not be sent for GET requests if your object uses server-side encryption with CMKs stored
-   *             in Amazon Web Services KMS (SSE-KMS) or server-side encryption with Amazon S3–managed encryption keys
-   *             (SSE-S3). If your object does use these types of keys, you’ll get an HTTP 400 BadRequest
-   *             error.</p>
-   *                </li>
-   *                <li>
-   *                   <p>
-   *                The last modified property in this case is the creation date of the object.</p>
-   *                </li>
-   *             </ul>
-   *          </note>
-   *
-   *
-   *          <p>Request headers are limited to 8 KB in size. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonRequestHeaders.html">Common Request
-   *             Headers</a>.</p>
-   *          <p>Consider the following when using request headers:</p>
-   *          <ul>
-   *             <li>
-   *                <p> Consideration 1 – If both of the <code>If-Match</code> and
-   *                   <code>If-Unmodified-Since</code> headers are present in the request as
-   *                follows:</p>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <code>If-Match</code> condition evaluates to <code>true</code>, and;</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <code>If-Unmodified-Since</code> condition evaluates to
-   *                      <code>false</code>;</p>
-   *                   </li>
-   *                </ul>
-   *                <p>Then Amazon S3 returns <code>200 OK</code> and the data requested.</p>
-   *             </li>
-   *             <li>
-   *                <p> Consideration 2 – If both of the <code>If-None-Match</code> and
-   *                   <code>If-Modified-Since</code> headers are present in the request as
-   *                follows:</p>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <code>If-None-Match</code> condition evaluates to <code>false</code>,
-   *                      and;</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <code>If-Modified-Since</code> condition evaluates to
-   *                      <code>true</code>;</p>
-   *                   </li>
-   *                </ul>
-   *                <p>Then Amazon S3 returns the <code>304 Not Modified</code> response code.</p>
-   *             </li>
-   *          </ul>
-   *
-   *          <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
-   *
+   * <p>If you encrypt an object by using server-side encryption with customer-provided
+   * encryption keys (SSE-C) when you store the object in Amazon S3, then when you retrieve the
+   * metadata from the object, you must use the following headers:</p>
+   * <ul>
+   *    <li>
+   *       <p>x-amz-server-side-encryption-customer-algorithm</p>
+   *    </li>
+   *    <li>
+   *       <p>x-amz-server-side-encryption-customer-key</p>
+   *    </li>
+   *    <li>
+   *       <p>x-amz-server-side-encryption-customer-key-MD5</p>
+   *    </li>
+   * </ul>
+   * <p>For more information about SSE-C, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html">Server-Side Encryption (Using
+   *    Customer-Provided Encryption Keys)</a>.</p>
+   * <note>
+   *    <ul>
+   *       <li>
+   *          <p>Encryption request headers, like <code>x-amz-server-side-encryption</code>, should
+   *    not be sent for GET requests if your object uses server-side encryption with CMKs stored
+   *    in Amazon Web Services KMS (SSE-KMS) or server-side encryption with Amazon S3–managed encryption keys
+   *    (SSE-S3). If your object does use these types of keys, you’ll get an HTTP 400 BadRequest
+   *    error.</p>
+   *       </li>
+   *       <li>
    *          <p>
-   *             <b>Permissions</b>
-   *          </p>
-   *          <p>You need the relevant read object (or version) permission for this operation. For more
-   *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions
-   *             in a Policy</a>. If the object you request does not exist, the error Amazon S3 returns
-   *          depends on whether you also have the s3:ListBucket permission.</p>
-   *          <ul>
-   *             <li>
-   *                <p>If you have the <code>s3:ListBucket</code> permission on the bucket, Amazon S3 returns
-   *                an HTTP status code 404 ("no such key") error.</p>
-   *             </li>
-   *             <li>
-   *                <p>If you don’t have the <code>s3:ListBucket</code> permission, Amazon S3 returns an HTTP
-   *                status code 403 ("access denied") error.</p>
-   *             </li>
-   *          </ul>
+   *       The last modified property in this case is the creation date of the object.</p>
+   *       </li>
+   *    </ul>
+   * </note>
    *
-   *          <p>The following action is related to <code>HeadObject</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   *
+   * <p>Request headers are limited to 8 KB in size. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonRequestHeaders.html">Common Request
+   *    Headers</a>.</p>
+   * <p>Consider the following when using request headers:</p>
+   * <ul>
+   *    <li>
+   *       <p> Consideration 1 – If both of the <code>If-Match</code> and
+   *          <code>If-Unmodified-Since</code> headers are present in the request as
+   *       follows:</p>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <code>If-Match</code> condition evaluates to <code>true</code>, and;</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <code>If-Unmodified-Since</code> condition evaluates to
+   *             <code>false</code>;</p>
+   *          </li>
+   *       </ul>
+   *       <p>Then Amazon S3 returns <code>200 OK</code> and the data requested.</p>
+   *    </li>
+   *    <li>
+   *       <p> Consideration 2 – If both of the <code>If-None-Match</code> and
+   *          <code>If-Modified-Since</code> headers are present in the request as
+   *       follows:</p>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <code>If-None-Match</code> condition evaluates to <code>false</code>,
+   *             and;</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <code>If-Modified-Since</code> condition evaluates to
+   *             <code>true</code>;</p>
+   *          </li>
+   *       </ul>
+   *       <p>Then Amazon S3 returns the <code>304 Not Modified</code> response code.</p>
+   *    </li>
+   * </ul>
+   *
+   * <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+   *
+   * <p>
+   *    <b>Permissions</b>
+   * </p>
+   * <p>You need the relevant read object (or version) permission for this operation. For more
+   * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions
+   *    in a Policy</a>. If the object you request does not exist, the error Amazon S3 returns
+   * depends on whether you also have the s3:ListBucket permission.</p>
+   * <ul>
+   *    <li>
+   *       <p>If you have the <code>s3:ListBucket</code> permission on the bucket, Amazon S3 returns
+   *       an HTTP status code 404 ("no such key") error.</p>
+   *    </li>
+   *    <li>
+   *       <p>If you don’t have the <code>s3:ListBucket</code> permission, Amazon S3 returns an HTTP
+   *       status code 403 ("access denied") error.</p>
+   *    </li>
+   * </ul>
+   *
+   * <p>The following action is related to <code>HeadObject</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public headObject(args: HeadObjectCommandInput, options?: __HttpHandlerOptions): Promise<HeadObjectCommandOutput>;
   public headObject(args: HeadObjectCommandInput, cb: (err: any, data?: HeadObjectCommandOutput) => void): void;
@@ -4126,45 +4126,45 @@ export class S3 extends S3Client {
 
   /**
    * <p>Lists the analytics configurations for the bucket. You can have up to 1,000 analytics
-   *          configurations per bucket.</p>
+   * configurations per bucket.</p>
    *
-   *          <p>This action supports list pagination and does not return more than 100 configurations
-   *          at a time. You should always check the <code>IsTruncated</code> element in the response. If
-   *          there are no more configurations to list, <code>IsTruncated</code> is set to false. If
-   *          there are more configurations to list, <code>IsTruncated</code> is set to true, and there
-   *          will be a value in <code>NextContinuationToken</code>. You use the
-   *             <code>NextContinuationToken</code> value to continue the pagination of the list by
-   *          passing the value in continuation-token in the request to <code>GET</code> the next
-   *          page.</p>
+   * <p>This action supports list pagination and does not return more than 100 configurations
+   * at a time. You should always check the <code>IsTruncated</code> element in the response. If
+   * there are no more configurations to list, <code>IsTruncated</code> is set to false. If
+   * there are more configurations to list, <code>IsTruncated</code> is set to true, and there
+   * will be a value in <code>NextContinuationToken</code>. You use the
+   *    <code>NextContinuationToken</code> value to continue the pagination of the list by
+   * passing the value in continuation-token in the request to <code>GET</code> the next
+   * page.</p>
    *
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:GetAnalyticsConfiguration</code> action. The bucket owner has this permission
-   *          by default. The bucket owner can grant this permission to others. For more information
-   *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:GetAnalyticsConfiguration</code> action. The bucket owner has this permission
+   * by default. The bucket owner can grant this permission to others. For more information
+   * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
    *
-   *          <p>For information about Amazon S3 analytics feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
-   *             Analysis</a>. </p>
+   * <p>For information about Amazon S3 analytics feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
+   *    Analysis</a>. </p>
    *
-   *          <p>The following operations are related to
-   *          <code>ListBucketAnalyticsConfigurations</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAnalyticsConfiguration.html">GetBucketAnalyticsConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketAnalyticsConfiguration.html">DeleteBucketAnalyticsConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html">PutBucketAnalyticsConfiguration</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to
+   * <code>ListBucketAnalyticsConfigurations</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAnalyticsConfiguration.html">GetBucketAnalyticsConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketAnalyticsConfiguration.html">DeleteBucketAnalyticsConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html">PutBucketAnalyticsConfiguration</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public listBucketAnalyticsConfigurations(
     args: ListBucketAnalyticsConfigurationsCommandInput,
@@ -4197,28 +4197,28 @@ export class S3 extends S3Client {
 
   /**
    * <p>Lists the S3 Intelligent-Tiering configuration from the specified bucket.</p>
-   *          <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
-   *          <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
-   *          <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
-   *          <p>Operations related to
-   *             <code>ListBucketIntelligentTieringConfigurations</code> include: </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketIntelligentTieringConfiguration.html">DeleteBucketIntelligentTieringConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html">PutBucketIntelligentTieringConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html">GetBucketIntelligentTieringConfiguration</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
+   * <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
+   * <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
+   * <p>Operations related to
+   *    <code>ListBucketIntelligentTieringConfigurations</code> include: </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketIntelligentTieringConfiguration.html">DeleteBucketIntelligentTieringConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html">PutBucketIntelligentTieringConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html">GetBucketIntelligentTieringConfiguration</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public listBucketIntelligentTieringConfigurations(
     args: ListBucketIntelligentTieringConfigurationsCommandInput,
@@ -4253,44 +4253,44 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns a list of inventory configurations for the bucket. You can have up to 1,000
-   *          analytics configurations per bucket.</p>
+   * analytics configurations per bucket.</p>
    *
-   *          <p>This action supports list pagination and does not return more than 100 configurations
-   *          at a time. Always check the <code>IsTruncated</code> element in the response. If there are
-   *          no more configurations to list, <code>IsTruncated</code> is set to false. If there are more
-   *          configurations to list, <code>IsTruncated</code> is set to true, and there is a value in
-   *             <code>NextContinuationToken</code>. You use the <code>NextContinuationToken</code> value
-   *          to continue the pagination of the list by passing the value in continuation-token in the
-   *          request to <code>GET</code> the next page.</p>
+   * <p>This action supports list pagination and does not return more than 100 configurations
+   * at a time. Always check the <code>IsTruncated</code> element in the response. If there are
+   * no more configurations to list, <code>IsTruncated</code> is set to false. If there are more
+   * configurations to list, <code>IsTruncated</code> is set to true, and there is a value in
+   *    <code>NextContinuationToken</code>. You use the <code>NextContinuationToken</code> value
+   * to continue the pagination of the list by passing the value in continuation-token in the
+   * request to <code>GET</code> the next page.</p>
    *
-   *          <p> To use this operation, you must have permissions to perform the
-   *             <code>s3:GetInventoryConfiguration</code> action. The bucket owner has this permission
-   *          by default. The bucket owner can grant this permission to others. For more information
-   *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
+   * <p> To use this operation, you must have permissions to perform the
+   *    <code>s3:GetInventoryConfiguration</code> action. The bucket owner has this permission
+   * by default. The bucket owner can grant this permission to others. For more information
+   * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
    *
-   *          <p>For information about the Amazon S3 inventory feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3 Inventory</a>
-   *          </p>
+   * <p>For information about the Amazon S3 inventory feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3 Inventory</a>
+   * </p>
    *
-   *          <p>The following operations are related to
-   *          <code>ListBucketInventoryConfigurations</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketInventoryConfiguration.html">GetBucketInventoryConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketInventoryConfiguration.html">DeleteBucketInventoryConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html">PutBucketInventoryConfiguration</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to
+   * <code>ListBucketInventoryConfigurations</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketInventoryConfiguration.html">GetBucketInventoryConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketInventoryConfiguration.html">DeleteBucketInventoryConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html">PutBucketInventoryConfiguration</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public listBucketInventoryConfigurations(
     args: ListBucketInventoryConfigurationsCommandInput,
@@ -4323,46 +4323,46 @@ export class S3 extends S3Client {
 
   /**
    * <p>Lists the metrics configurations for the bucket. The metrics configurations are only for
-   *          the request metrics of the bucket and do not provide information on daily storage metrics.
-   *          You can have up to 1,000 configurations per bucket.</p>
+   * the request metrics of the bucket and do not provide information on daily storage metrics.
+   * You can have up to 1,000 configurations per bucket.</p>
    *
-   *          <p>This action supports list pagination and does not return more than 100 configurations
-   *          at a time. Always check the <code>IsTruncated</code> element in the response. If there are
-   *          no more configurations to list, <code>IsTruncated</code> is set to false. If there are more
-   *          configurations to list, <code>IsTruncated</code> is set to true, and there is a value in
-   *             <code>NextContinuationToken</code>. You use the <code>NextContinuationToken</code> value
-   *          to continue the pagination of the list by passing the value in
-   *             <code>continuation-token</code> in the request to <code>GET</code> the next page.</p>
+   * <p>This action supports list pagination and does not return more than 100 configurations
+   * at a time. Always check the <code>IsTruncated</code> element in the response. If there are
+   * no more configurations to list, <code>IsTruncated</code> is set to false. If there are more
+   * configurations to list, <code>IsTruncated</code> is set to true, and there is a value in
+   *    <code>NextContinuationToken</code>. You use the <code>NextContinuationToken</code> value
+   * to continue the pagination of the list by passing the value in
+   *    <code>continuation-token</code> in the request to <code>GET</code> the next page.</p>
    *
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:GetMetricsConfiguration</code> action. The bucket owner has this permission by
-   *          default. The bucket owner can grant this permission to others. For more information about
-   *          permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:GetMetricsConfiguration</code> action. The bucket owner has this permission by
+   * default. The bucket owner can grant this permission to others. For more information about
+   * permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
    *
-   *          <p>For more information about metrics configurations and CloudWatch request metrics, see
-   *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
-   *             CloudWatch</a>.</p>
+   * <p>For more information about metrics configurations and CloudWatch request metrics, see
+   *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
+   *    CloudWatch</a>.</p>
    *
-   *          <p>The following operations are related to
-   *          <code>ListBucketMetricsConfigurations</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetricsConfiguration.html">GetBucketMetricsConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html">DeleteBucketMetricsConfiguration</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to
+   * <code>ListBucketMetricsConfigurations</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetricsConfiguration.html">GetBucketMetricsConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html">DeleteBucketMetricsConfiguration</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public listBucketMetricsConfigurations(
     args: ListBucketMetricsConfigurationsCommandInput,
@@ -4421,56 +4421,56 @@ export class S3 extends S3Client {
 
   /**
    * <p>This action lists in-progress multipart uploads. An in-progress multipart upload is a
-   *          multipart upload that has been initiated using the Initiate Multipart Upload request, but
-   *          has not yet been completed or aborted.</p>
+   * multipart upload that has been initiated using the Initiate Multipart Upload request, but
+   * has not yet been completed or aborted.</p>
    *
-   *          <p>This action returns at most 1,000 multipart uploads in the response. 1,000 multipart
-   *          uploads is the maximum number of uploads a response can include, which is also the default
-   *          value. You can further limit the number of uploads in a response by specifying the
-   *             <code>max-uploads</code> parameter in the response. If additional multipart uploads
-   *          satisfy the list criteria, the response will contain an <code>IsTruncated</code> element
-   *          with the value true. To list the additional multipart uploads, use the
-   *             <code>key-marker</code> and <code>upload-id-marker</code> request parameters.</p>
+   * <p>This action returns at most 1,000 multipart uploads in the response. 1,000 multipart
+   * uploads is the maximum number of uploads a response can include, which is also the default
+   * value. You can further limit the number of uploads in a response by specifying the
+   *    <code>max-uploads</code> parameter in the response. If additional multipart uploads
+   * satisfy the list criteria, the response will contain an <code>IsTruncated</code> element
+   * with the value true. To list the additional multipart uploads, use the
+   *    <code>key-marker</code> and <code>upload-id-marker</code> request parameters.</p>
    *
-   *          <p>In the response, the uploads are sorted by key. If your application has initiated more
-   *          than one multipart upload using the same object key, then uploads in the response are first
-   *          sorted by key. Additionally, uploads are sorted in ascending order within each key by the
-   *          upload initiation time.</p>
+   * <p>In the response, the uploads are sorted by key. If your application has initiated more
+   * than one multipart upload using the same object key, then uploads in the response are first
+   * sorted by key. Additionally, uploads are sorted in ascending order within each key by the
+   * upload initiation time.</p>
    *
-   *          <p>For more information on multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
-   *             Upload</a>.</p>
+   * <p>For more information on multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
+   *    Upload</a>.</p>
    *
-   *          <p>For information on permissions required to use the multipart upload API, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
-   *          Permissions</a>.</p>
+   * <p>For information on permissions required to use the multipart upload API, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
+   * Permissions</a>.</p>
    *
-   *          <p>The following operations are related to <code>ListMultipartUploads</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>ListMultipartUploads</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public listMultipartUploads(
     args: ListMultipartUploadsCommandInput,
@@ -4503,43 +4503,43 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns some or all (up to 1,000) of the objects in a bucket. You can use the request
-   *          parameters as selection criteria to return a subset of the objects in a bucket. A 200 OK
-   *          response can contain valid or invalid XML. Be sure to design your application to parse the
-   *          contents of the response and handle it appropriately.</p>
-   *          <important>
-   *             <p>This action has been revised. We recommend that you use the newer version, <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjectsV2</a>, when developing applications. For backward compatibility,
-   *             Amazon S3 continues to support <code>ListObjects</code>.</p>
-   *          </important>
+   * parameters as selection criteria to return a subset of the objects in a bucket. A 200 OK
+   * response can contain valid or invalid XML. Be sure to design your application to parse the
+   * contents of the response and handle it appropriately.</p>
+   * <important>
+   *    <p>This action has been revised. We recommend that you use the newer version, <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjectsV2</a>, when developing applications. For backward compatibility,
+   *    Amazon S3 continues to support <code>ListObjects</code>.</p>
+   * </important>
    *
    *
-   *          <p>The following operations are related to <code>ListObjects</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjectsV2</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html">ListBuckets</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>ListObjects</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjectsV2</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html">ListBuckets</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public listObjects(args: ListObjectsCommandInput, options?: __HttpHandlerOptions): Promise<ListObjectsCommandOutput>;
   public listObjects(args: ListObjectsCommandInput, cb: (err: any, data?: ListObjectsCommandOutput) => void): void;
@@ -4566,47 +4566,47 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns some or all (up to 1,000) of the objects in a bucket with each request. You can use
-   *          the request parameters as selection criteria to return a subset of the objects in a bucket. A
-   *          <code>200 OK</code> response can contain valid or invalid XML. Make sure to design your
-   *          application to parse the contents of the response and handle it appropriately.
-   *          Objects are returned sorted in an ascending order of the respective key names in the list.
-   *          For more information about listing objects, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/ListingKeysUsingAPIs.html">Listing object keys
-   *             programmatically</a>
-   *          </p>
+   * the request parameters as selection criteria to return a subset of the objects in a bucket. A
+   * <code>200 OK</code> response can contain valid or invalid XML. Make sure to design your
+   * application to parse the contents of the response and handle it appropriately.
+   * Objects are returned sorted in an ascending order of the respective key names in the list.
+   * For more information about listing objects, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/ListingKeysUsingAPIs.html">Listing object keys
+   *    programmatically</a>
+   * </p>
    *
-   *          <p>To use this operation, you must have READ access to the bucket.</p>
+   * <p>To use this operation, you must have READ access to the bucket.</p>
    *
-   *          <p>To use this action in an Identity and Access Management (IAM) policy, you must
-   *          have permissions to perform the <code>s3:ListBucket</code> action. The bucket owner has
-   *          this permission by default and can grant this permission to others. For more information
-   *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
-   *          <important>
-   *             <p>This section describes the latest revision of this action. We recommend that you use this
-   *             revised API for application development. For backward compatibility, Amazon S3 continues to
-   *             support the prior version of this API, <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects</a>.</p>
-   *          </important>
+   * <p>To use this action in an Identity and Access Management (IAM) policy, you must
+   * have permissions to perform the <code>s3:ListBucket</code> action. The bucket owner has
+   * this permission by default and can grant this permission to others. For more information
+   * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
+   * <important>
+   *    <p>This section describes the latest revision of this action. We recommend that you use this
+   *    revised API for application development. For backward compatibility, Amazon S3 continues to
+   *    support the prior version of this API, <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects</a>.</p>
+   * </important>
    *
-   *          <p>To get a list of your buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html">ListBuckets</a>.</p>
+   * <p>To get a list of your buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html">ListBuckets</a>.</p>
    *
-   *          <p>The following operations are related to <code>ListObjectsV2</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>ListObjectsV2</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public listObjectsV2(
     args: ListObjectsV2CommandInput,
@@ -4639,44 +4639,44 @@ export class S3 extends S3Client {
 
   /**
    * <p>Returns metadata about all versions of the objects in a bucket. You can also use request
-   *          parameters as selection criteria to return metadata about a subset of all the object
-   *          versions.</p>
-   *          <important>
-   *             <p>
-   *             To use this operation, you must have permissions to perform the
-   *             <code>s3:ListBucketVersions</code> action. Be aware of the name difference.
-   *          </p>
-   *          </important>
-   *          <note>
-   *             <p> A 200 OK response can contain valid or invalid XML. Make sure to design your
-   *             application to parse the contents of the response and handle it appropriately.</p>
-   *          </note>
-   *          <p>To use this operation, you must have READ access to the bucket.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
-   *          <p>The following operations are related to
-   *             <code>ListObjectVersions</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjectsV2</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * parameters as selection criteria to return metadata about a subset of all the object
+   * versions.</p>
+   * <important>
+   *    <p>
+   *    To use this operation, you must have permissions to perform the
+   *    <code>s3:ListBucketVersions</code> action. Be aware of the name difference.
+   * </p>
+   * </important>
+   * <note>
+   *    <p> A 200 OK response can contain valid or invalid XML. Make sure to design your
+   *    application to parse the contents of the response and handle it appropriately.</p>
+   * </note>
+   * <p>To use this operation, you must have READ access to the bucket.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>The following operations are related to
+   *    <code>ListObjectVersions</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjectsV2</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public listObjectVersions(
     args: ListObjectVersionsCommandInput,
@@ -4709,50 +4709,50 @@ export class S3 extends S3Client {
 
   /**
    * <p>Lists the parts that have been uploaded for a specific multipart upload. This operation
-   *          must include the upload ID, which you obtain by sending the initiate multipart upload
-   *          request (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>).
-   *          This request returns a maximum of 1,000 uploaded parts. The default number of parts
-   *          returned is 1,000 parts. You can restrict the number of parts returned by specifying the
-   *             <code>max-parts</code> request parameter. If your multipart upload consists of more than
-   *          1,000 parts, the response returns an <code>IsTruncated</code> field with the value of true,
-   *          and a <code>NextPartNumberMarker</code> element. In subsequent <code>ListParts</code>
-   *          requests you can include the part-number-marker query string parameter and set its value to
-   *          the <code>NextPartNumberMarker</code> field value from the previous response.</p>
+   * must include the upload ID, which you obtain by sending the initiate multipart upload
+   * request (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>).
+   * This request returns a maximum of 1,000 uploaded parts. The default number of parts
+   * returned is 1,000 parts. You can restrict the number of parts returned by specifying the
+   *    <code>max-parts</code> request parameter. If your multipart upload consists of more than
+   * 1,000 parts, the response returns an <code>IsTruncated</code> field with the value of true,
+   * and a <code>NextPartNumberMarker</code> element. In subsequent <code>ListParts</code>
+   * requests you can include the part-number-marker query string parameter and set its value to
+   * the <code>NextPartNumberMarker</code> field value from the previous response.</p>
    *
-   *          <p>For more information on multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
-   *             Upload</a>.</p>
+   * <p>For more information on multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
+   *    Upload</a>.</p>
    *
-   *          <p>For information on permissions required to use the multipart upload API, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
-   *          Permissions</a>.</p>
+   * <p>For information on permissions required to use the multipart upload API, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
+   * Permissions</a>.</p>
    *
-   *          <p>The following operations are related to <code>ListParts</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>ListParts</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public listParts(args: ListPartsCommandInput, options?: __HttpHandlerOptions): Promise<ListPartsCommandOutput>;
   public listParts(args: ListPartsCommandInput, cb: (err: any, data?: ListPartsCommandOutput) => void): void;
@@ -4779,51 +4779,51 @@ export class S3 extends S3Client {
 
   /**
    * <p>Sets the accelerate configuration of an existing bucket. Amazon S3 Transfer Acceleration is a
-   *          bucket-level feature that enables you to perform faster data transfers to Amazon S3.</p>
+   * bucket-level feature that enables you to perform faster data transfers to Amazon S3.</p>
    *
-   *          <p> To use this operation, you must have permission to perform the
-   *          s3:PutAccelerateConfiguration action. The bucket owner has this permission by default. The
-   *          bucket owner can grant this permission to others. For more information about permissions,
-   *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
+   * <p> To use this operation, you must have permission to perform the
+   * s3:PutAccelerateConfiguration action. The bucket owner has this permission by default. The
+   * bucket owner can grant this permission to others. For more information about permissions,
+   * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
    *
-   *          <p> The Transfer Acceleration state of a bucket can be set to one of the following two
-   *          values:</p>
-   *          <ul>
-   *             <li>
-   *                <p> Enabled – Enables accelerated data transfers to the bucket.</p>
-   *             </li>
-   *             <li>
-   *                <p> Suspended – Disables accelerated data transfers to the bucket.</p>
-   *             </li>
-   *          </ul>
+   * <p> The Transfer Acceleration state of a bucket can be set to one of the following two
+   * values:</p>
+   * <ul>
+   *    <li>
+   *       <p> Enabled – Enables accelerated data transfers to the bucket.</p>
+   *    </li>
+   *    <li>
+   *       <p> Suspended – Disables accelerated data transfers to the bucket.</p>
+   *    </li>
+   * </ul>
    *
    *
-   *          <p>The <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAccelerateConfiguration.html">GetBucketAccelerateConfiguration</a> action returns the transfer acceleration
-   *          state of a bucket.</p>
+   * <p>The <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAccelerateConfiguration.html">GetBucketAccelerateConfiguration</a> action returns the transfer acceleration
+   * state of a bucket.</p>
    *
-   *          <p>After setting the Transfer Acceleration state of a bucket to Enabled, it might take up
-   *          to thirty minutes before the data transfer rates to the bucket increase.</p>
+   * <p>After setting the Transfer Acceleration state of a bucket to Enabled, it might take up
+   * to thirty minutes before the data transfer rates to the bucket increase.</p>
    *
-   *          <p> The name of the bucket used for Transfer Acceleration must be DNS-compliant and must
-   *          not contain periods (".").</p>
+   * <p> The name of the bucket used for Transfer Acceleration must be DNS-compliant and must
+   * not contain periods (".").</p>
    *
-   *          <p> For more information about transfer acceleration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html">Transfer Acceleration</a>.</p>
+   * <p> For more information about transfer acceleration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html">Transfer Acceleration</a>.</p>
    *
-   *          <p>The following operations are related to
-   *          <code>PutBucketAccelerateConfiguration</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAccelerateConfiguration.html">GetBucketAccelerateConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to
+   * <code>PutBucketAccelerateConfiguration</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAccelerateConfiguration.html">GetBucketAccelerateConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketAccelerateConfiguration(
     args: PutBucketAccelerateConfigurationCommandInput,
@@ -4856,195 +4856,195 @@ export class S3 extends S3Client {
 
   /**
    * <p>Sets the permissions on an existing bucket using access control lists (ACL). For more
-   *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. To set
-   *          the ACL of a bucket, you must have <code>WRITE_ACP</code> permission.</p>
+   * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. To set
+   * the ACL of a bucket, you must have <code>WRITE_ACP</code> permission.</p>
    *
-   *          <p>You can use one of the following two ways to set a bucket's permissions:</p>
-   *          <ul>
-   *             <li>
-   *                <p>Specify the ACL in the request body</p>
-   *             </li>
-   *             <li>
-   *                <p>Specify permissions using request headers</p>
-   *             </li>
-   *          </ul>
+   * <p>You can use one of the following two ways to set a bucket's permissions:</p>
+   * <ul>
+   *    <li>
+   *       <p>Specify the ACL in the request body</p>
+   *    </li>
+   *    <li>
+   *       <p>Specify permissions using request headers</p>
+   *    </li>
+   * </ul>
    *
-   *          <note>
-   *             <p>You cannot specify access permission using both the body and the request
-   *             headers.</p>
-   *          </note>
+   * <note>
+   *    <p>You cannot specify access permission using both the body and the request
+   *    headers.</p>
+   * </note>
    *
-   *          <p>Depending on your application needs, you may choose to set the ACL on a bucket using
-   *          either the request body or the headers. For example, if you have an existing application
-   *          that updates a bucket ACL using the request body, then you can continue to use that
-   *          approach.</p>
+   * <p>Depending on your application needs, you may choose to set the ACL on a bucket using
+   * either the request body or the headers. For example, if you have an existing application
+   * that updates a bucket ACL using the request body, then you can continue to use that
+   * approach.</p>
    *
    *
-   *          <p>
-   *             <b>Access Permissions</b>
-   *          </p>
-   *          <p>You can set access permissions using one of the following methods:</p>
-   *          <ul>
-   *             <li>
-   *                <p>Specify a canned ACL with the <code>x-amz-acl</code> request header. Amazon S3 supports
-   *                a set of predefined ACLs, known as <i>canned ACLs</i>. Each canned ACL
-   *                has a predefined set of grantees and permissions. Specify the canned ACL name as the
-   *                value of <code>x-amz-acl</code>. If you use this header, you cannot use other access
-   *                control-specific headers in your request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
-   *             </li>
-   *             <li>
-   *                <p>Specify access permissions explicitly with the <code>x-amz-grant-read</code>,
-   *                   <code>x-amz-grant-read-acp</code>, <code>x-amz-grant-write-acp</code>, and
-   *                   <code>x-amz-grant-full-control</code> headers. When using these headers, you
-   *                specify explicit access permissions and grantees (Amazon Web Services accounts or Amazon S3 groups) who
-   *                will receive the permission. If you use these ACL-specific headers, you cannot use
-   *                the <code>x-amz-acl</code> header to set a canned ACL. These parameters map to the
-   *                set of permissions that Amazon S3 supports in an ACL. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL)
-   *                Overview</a>.</p>
-   *                <p>You specify each grantee as a type=value pair, where the type is one of the
-   *                following:</p>
+   * <p>
+   *    <b>Access Permissions</b>
+   * </p>
+   * <p>You can set access permissions using one of the following methods:</p>
+   * <ul>
+   *    <li>
+   *       <p>Specify a canned ACL with the <code>x-amz-acl</code> request header. Amazon S3 supports
+   *       a set of predefined ACLs, known as <i>canned ACLs</i>. Each canned ACL
+   *       has a predefined set of grantees and permissions. Specify the canned ACL name as the
+   *       value of <code>x-amz-acl</code>. If you use this header, you cannot use other access
+   *       control-specific headers in your request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
+   *    </li>
+   *    <li>
+   *       <p>Specify access permissions explicitly with the <code>x-amz-grant-read</code>,
+   *          <code>x-amz-grant-read-acp</code>, <code>x-amz-grant-write-acp</code>, and
+   *          <code>x-amz-grant-full-control</code> headers. When using these headers, you
+   *       specify explicit access permissions and grantees (Amazon Web Services accounts or Amazon S3 groups) who
+   *       will receive the permission. If you use these ACL-specific headers, you cannot use
+   *       the <code>x-amz-acl</code> header to set a canned ACL. These parameters map to the
+   *       set of permissions that Amazon S3 supports in an ACL. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL)
+   *       Overview</a>.</p>
+   *       <p>You specify each grantee as a type=value pair, where the type is one of the
+   *       following:</p>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <code>id</code> – if the value specified is the canonical user ID of an Amazon Web Services account</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <code>uri</code> – if you are granting permissions to a predefined
+   *             group</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <code>emailAddress</code> – if the value specified is the email address of
+   *             an Amazon Web Services account</p>
+   *             <note>
+   *                <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
    *                <ul>
    *                   <li>
-   *                      <p>
-   *                         <code>id</code> – if the value specified is the canonical user ID of an Amazon Web Services account</p>
+   *                      <p>US East (N. Virginia)</p>
    *                   </li>
    *                   <li>
-   *                      <p>
-   *                         <code>uri</code> – if you are granting permissions to a predefined
-   *                      group</p>
+   *                      <p>US West (N. California)</p>
    *                   </li>
    *                   <li>
-   *                      <p>
-   *                         <code>emailAddress</code> – if the value specified is the email address of
-   *                      an Amazon Web Services account</p>
-   *                      <note>
-   *                         <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
-   *                         <ul>
-   *                            <li>
-   *                               <p>US East (N. Virginia)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>US West (N. California)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p> US West (Oregon)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p> Asia Pacific (Singapore)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>Asia Pacific (Sydney)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>Asia Pacific (Tokyo)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>Europe (Ireland)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>South America (São Paulo)</p>
-   *                            </li>
-   *                         </ul>
-   *                         <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
-   *                      </note>
+   *                      <p> US West (Oregon)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p> Asia Pacific (Singapore)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p>Asia Pacific (Sydney)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p>Asia Pacific (Tokyo)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p>Europe (Ireland)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p>South America (São Paulo)</p>
    *                   </li>
    *                </ul>
-   *                <p>For example, the following <code>x-amz-grant-write</code> header grants create,
-   *                overwrite, and delete objects permission to LogDelivery group predefined by Amazon S3 and
-   *                two Amazon Web Services accounts identified by their email addresses.</p>
-   *                <p>
-   *                   <code>x-amz-grant-write: uri="http://acs.amazonaws.com/groups/s3/LogDelivery",
-   *                   id="111122223333", id="555566667777" </code>
-   *                </p>
+   *                <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
+   *             </note>
+   *          </li>
+   *       </ul>
+   *       <p>For example, the following <code>x-amz-grant-write</code> header grants create,
+   *       overwrite, and delete objects permission to LogDelivery group predefined by Amazon S3 and
+   *       two Amazon Web Services accounts identified by their email addresses.</p>
+   *       <p>
+   *          <code>x-amz-grant-write: uri="http://acs.amazonaws.com/groups/s3/LogDelivery",
+   *          id="111122223333", id="555566667777" </code>
+   *       </p>
    *
-   *             </li>
-   *          </ul>
-   *          <p>You can use either a canned ACL or specify access permissions explicitly. You cannot do
-   *          both.</p>
-   *          <p>
-   *             <b>Grantee Values</b>
-   *          </p>
-   *          <p>You can specify the person (grantee) to whom you're assigning access rights (using
-   *          request elements) in the following ways:</p>
+   *    </li>
+   * </ul>
+   * <p>You can use either a canned ACL or specify access permissions explicitly. You cannot do
+   * both.</p>
+   * <p>
+   *    <b>Grantee Values</b>
+   * </p>
+   * <p>You can specify the person (grantee) to whom you're assigning access rights (using
+   * request elements) in the following ways:</p>
+   * <ul>
+   *    <li>
+   *       <p>By the person's ID:</p>
+   *       <p>
+   *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   *          xsi:type="CanonicalUser"><ID><>ID<></ID><DisplayName><>GranteesEmail<></DisplayName>
+   *          </Grantee></code>
+   *       </p>
+   *       <p>DisplayName is optional and ignored in the request</p>
+   *    </li>
+   *    <li>
+   *       <p>By URI:</p>
+   *       <p>
+   *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   *          xsi:type="Group"><URI><>http://acs.amazonaws.com/groups/global/AuthenticatedUsers<></URI></Grantee></code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>By Email address:</p>
+   *       <p>
+   *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   *          xsi:type="AmazonCustomerByEmail"><EmailAddress><>Grantees@email.com<></EmailAddress>lt;/Grantee></code>
+   *       </p>
+   *       <p>The grantee is resolved to the CanonicalUser and, in a response to a GET Object
+   *       acl request, appears as the CanonicalUser. </p>
+   *       <note>
+   *          <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
    *          <ul>
    *             <li>
-   *                <p>By the person's ID:</p>
-   *                <p>
-   *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   *                   xsi:type="CanonicalUser"><ID><>ID<></ID><DisplayName><>GranteesEmail<></DisplayName>
-   *                   </Grantee></code>
-   *                </p>
-   *                <p>DisplayName is optional and ignored in the request</p>
+   *                <p>US East (N. Virginia)</p>
    *             </li>
    *             <li>
-   *                <p>By URI:</p>
-   *                <p>
-   *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   *                   xsi:type="Group"><URI><>http://acs.amazonaws.com/groups/global/AuthenticatedUsers<></URI></Grantee></code>
-   *                </p>
+   *                <p>US West (N. California)</p>
    *             </li>
    *             <li>
-   *                <p>By Email address:</p>
-   *                <p>
-   *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   *                   xsi:type="AmazonCustomerByEmail"><EmailAddress><>Grantees@email.com<></EmailAddress>lt;/Grantee></code>
-   *                </p>
-   *                <p>The grantee is resolved to the CanonicalUser and, in a response to a GET Object
-   *                acl request, appears as the CanonicalUser. </p>
-   *                <note>
-   *                   <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
-   *                   <ul>
-   *                      <li>
-   *                         <p>US East (N. Virginia)</p>
-   *                      </li>
-   *                      <li>
-   *                         <p>US West (N. California)</p>
-   *                      </li>
-   *                      <li>
-   *                         <p> US West (Oregon)</p>
-   *                      </li>
-   *                      <li>
-   *                         <p> Asia Pacific (Singapore)</p>
-   *                      </li>
-   *                      <li>
-   *                         <p>Asia Pacific (Sydney)</p>
-   *                      </li>
-   *                      <li>
-   *                         <p>Asia Pacific (Tokyo)</p>
-   *                      </li>
-   *                      <li>
-   *                         <p>Europe (Ireland)</p>
-   *                      </li>
-   *                      <li>
-   *                         <p>South America (São Paulo)</p>
-   *                      </li>
-   *                   </ul>
-   *                   <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
-   *                </note>
+   *                <p> US West (Oregon)</p>
+   *             </li>
+   *             <li>
+   *                <p> Asia Pacific (Singapore)</p>
+   *             </li>
+   *             <li>
+   *                <p>Asia Pacific (Sydney)</p>
+   *             </li>
+   *             <li>
+   *                <p>Asia Pacific (Tokyo)</p>
+   *             </li>
+   *             <li>
+   *                <p>Europe (Ireland)</p>
+   *             </li>
+   *             <li>
+   *                <p>South America (São Paulo)</p>
    *             </li>
    *          </ul>
+   *          <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
+   *       </note>
+   *    </li>
+   * </ul>
    *
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html">GetObjectAcl</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html">GetObjectAcl</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketAcl(
     args: PutBucketAclCommandInput,
@@ -5074,121 +5074,121 @@ export class S3 extends S3Client {
 
   /**
    * <p>Sets an analytics configuration for the bucket (specified by the analytics configuration
-   *          ID). You can have up to 1,000 analytics configurations per bucket.</p>
+   * ID). You can have up to 1,000 analytics configurations per bucket.</p>
    *
-   *          <p>You can choose to have storage class analysis export analysis reports sent to a
-   *          comma-separated values (CSV) flat file. See the <code>DataExport</code> request element.
-   *          Reports are updated daily and are based on the object filters that you configure. When
-   *          selecting data export, you specify a destination bucket and an optional destination prefix
-   *          where the file is written. You can export the data to a destination bucket in a different
-   *          account. However, the destination bucket must be in the same Region as the bucket that you
-   *          are making the PUT analytics configuration to. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
-   *             Analysis</a>. </p>
+   * <p>You can choose to have storage class analysis export analysis reports sent to a
+   * comma-separated values (CSV) flat file. See the <code>DataExport</code> request element.
+   * Reports are updated daily and are based on the object filters that you configure. When
+   * selecting data export, you specify a destination bucket and an optional destination prefix
+   * where the file is written. You can export the data to a destination bucket in a different
+   * account. However, the destination bucket must be in the same Region as the bucket that you
+   * are making the PUT analytics configuration to. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
+   *    Analysis</a>. </p>
    *
-   *          <important>
-   *             <p>You must create a bucket policy on the destination bucket where the exported file is
-   *             written to grant permissions to Amazon S3 to write objects to the bucket. For an example
-   *             policy, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html#example-bucket-policies-use-case-9">Granting Permissions for Amazon S3 Inventory and Storage Class Analysis</a>.</p>
-   *          </important>
+   * <important>
+   *    <p>You must create a bucket policy on the destination bucket where the exported file is
+   *    written to grant permissions to Amazon S3 to write objects to the bucket. For an example
+   *    policy, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html#example-bucket-policies-use-case-9">Granting Permissions for Amazon S3 Inventory and Storage Class Analysis</a>.</p>
+   * </important>
    *
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:PutAnalyticsConfiguration</code> action. The bucket owner has this permission
-   *          by default. The bucket owner can grant this permission to others. For more information
-   *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
-   *
-   *
-   *          <p class="title">
-   *             <b>Special Errors</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Error: HTTP 400 Bad Request</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code: InvalidArgument</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause: Invalid argument.</i>
-   *                      </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Error: HTTP 400 Bad Request</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code: TooManyConfigurations</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause: You are attempting to create a new configuration but have
-   *                         already reached the 1,000-configuration limit.</i>
-   *                      </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Error: HTTP 403 Forbidden</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code: AccessDenied</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause: You are not the owner of the specified bucket, or you do
-   *                         not have the s3:PutAnalyticsConfiguration bucket permission to set the
-   *                         configuration on the bucket.</i>
-   *                      </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *          </ul>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:PutAnalyticsConfiguration</code> action. The bucket owner has this permission
+   * by default. The bucket owner can grant this permission to others. For more information
+   * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
    *
    *
+   * <p class="title">
+   *    <b>Special Errors</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Error: HTTP 400 Bad Request</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Code: InvalidArgument</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause: Invalid argument.</i>
+   *             </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Error: HTTP 400 Bad Request</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Code: TooManyConfigurations</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause: You are attempting to create a new configuration but have
+   *                already reached the 1,000-configuration limit.</i>
+   *             </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Error: HTTP 403 Forbidden</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Code: AccessDenied</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause: You are not the owner of the specified bucket, or you do
+   *                not have the s3:PutAnalyticsConfiguration bucket permission to set the
+   *                configuration on the bucket.</i>
+   *             </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   * </ul>
    *
    *
    *
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAnalyticsConfiguration.html">GetBucketAnalyticsConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketAnalyticsConfiguration.html">DeleteBucketAnalyticsConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketAnalyticsConfigurations.html">ListBucketAnalyticsConfigurations</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   *
+   *
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAnalyticsConfiguration.html">GetBucketAnalyticsConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketAnalyticsConfiguration.html">DeleteBucketAnalyticsConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketAnalyticsConfigurations.html">ListBucketAnalyticsConfigurations</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketAnalyticsConfiguration(
     args: PutBucketAnalyticsConfigurationCommandInput,
@@ -5221,62 +5221,62 @@ export class S3 extends S3Client {
 
   /**
    * <p>Sets the <code>cors</code> configuration for your bucket. If the configuration exists,
-   *          Amazon S3 replaces it.</p>
-   *          <p>To use this operation, you must be allowed to perform the <code>s3:PutBucketCORS</code>
-   *          action. By default, the bucket owner has this permission and can grant it to others.</p>
-   *          <p>You set this configuration on a bucket so that the bucket can service cross-origin
-   *          requests. For example, you might want to enable a request whose origin is
-   *             <code>http://www.example.com</code> to access your Amazon S3 bucket at
-   *             <code>my.example.bucket.com</code> by using the browser's <code>XMLHttpRequest</code>
-   *          capability.</p>
-   *          <p>To enable cross-origin resource sharing (CORS) on a bucket, you add the
-   *             <code>cors</code> subresource to the bucket. The <code>cors</code> subresource is an XML
-   *          document in which you configure rules that identify origins and the HTTP methods that can
-   *          be executed on your bucket. The document is limited to 64 KB in size. </p>
-   *          <p>When Amazon S3 receives a cross-origin request (or a pre-flight OPTIONS request) against a
-   *          bucket, it evaluates the <code>cors</code> configuration on the bucket and uses the first
-   *             <code>CORSRule</code> rule that matches the incoming browser request to enable a
-   *          cross-origin request. For a rule to match, the following conditions must be met:</p>
-   *          <ul>
-   *             <li>
-   *                <p>The request's <code>Origin</code> header must match <code>AllowedOrigin</code>
-   *                elements.</p>
-   *             </li>
-   *             <li>
-   *                <p>The request method (for example, GET, PUT, HEAD, and so on) or the
-   *                   <code>Access-Control-Request-Method</code> header in case of a pre-flight
-   *                   <code>OPTIONS</code> request must be one of the <code>AllowedMethod</code>
-   *                elements. </p>
-   *             </li>
-   *             <li>
-   *                <p>Every header specified in the <code>Access-Control-Request-Headers</code> request
-   *                header of a pre-flight request must match an <code>AllowedHeader</code> element.
-   *             </p>
-   *             </li>
-   *          </ul>
-   *          <p> For more information about CORS, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html">Enabling
-   *             Cross-Origin Resource Sharing</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * Amazon S3 replaces it.</p>
+   * <p>To use this operation, you must be allowed to perform the <code>s3:PutBucketCORS</code>
+   * action. By default, the bucket owner has this permission and can grant it to others.</p>
+   * <p>You set this configuration on a bucket so that the bucket can service cross-origin
+   * requests. For example, you might want to enable a request whose origin is
+   *    <code>http://www.example.com</code> to access your Amazon S3 bucket at
+   *    <code>my.example.bucket.com</code> by using the browser's <code>XMLHttpRequest</code>
+   * capability.</p>
+   * <p>To enable cross-origin resource sharing (CORS) on a bucket, you add the
+   *    <code>cors</code> subresource to the bucket. The <code>cors</code> subresource is an XML
+   * document in which you configure rules that identify origins and the HTTP methods that can
+   * be executed on your bucket. The document is limited to 64 KB in size. </p>
+   * <p>When Amazon S3 receives a cross-origin request (or a pre-flight OPTIONS request) against a
+   * bucket, it evaluates the <code>cors</code> configuration on the bucket and uses the first
+   *    <code>CORSRule</code> rule that matches the incoming browser request to enable a
+   * cross-origin request. For a rule to match, the following conditions must be met:</p>
+   * <ul>
+   *    <li>
+   *       <p>The request's <code>Origin</code> header must match <code>AllowedOrigin</code>
+   *       elements.</p>
+   *    </li>
+   *    <li>
+   *       <p>The request method (for example, GET, PUT, HEAD, and so on) or the
+   *          <code>Access-Control-Request-Method</code> header in case of a pre-flight
+   *          <code>OPTIONS</code> request must be one of the <code>AllowedMethod</code>
+   *       elements. </p>
+   *    </li>
+   *    <li>
+   *       <p>Every header specified in the <code>Access-Control-Request-Headers</code> request
+   *       header of a pre-flight request must match an <code>AllowedHeader</code> element.
+   *    </p>
+   *    </li>
+   * </ul>
+   * <p> For more information about CORS, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html">Enabling
+   *    Cross-Origin Resource Sharing</a> in the <i>Amazon S3 User Guide</i>.</p>
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketCors.html">GetBucketCors</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketCors.html">DeleteBucketCors</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTOPTIONSobject.html">RESTOPTIONSobject</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketCors.html">GetBucketCors</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketCors.html">DeleteBucketCors</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTOPTIONSobject.html">RESTOPTIONSobject</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketCors(
     args: PutBucketCorsCommandInput,
@@ -5309,38 +5309,38 @@ export class S3 extends S3Client {
 
   /**
    * <p>This action uses the <code>encryption</code> subresource to configure default
-   *          encryption and Amazon S3 Bucket Key for an existing bucket.</p>
-   *          <p>Default encryption for a bucket can use server-side encryption with Amazon S3-managed keys
-   *          (SSE-S3) or Amazon Web Services KMS customer master keys (SSE-KMS). If you specify default encryption
-   *          using SSE-KMS, you can also configure Amazon S3 Bucket Key. For information about default
-   *          encryption, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html">Amazon S3 default bucket encryption</a>
-   *          in the <i>Amazon S3 User Guide</i>. For more information about S3 Bucket Keys,
-   *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <important>
-   *             <p>This action requires Amazon Web Services Signature Version 4. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html"> Authenticating Requests (Amazon Web Services Signature
-   *                Version 4)</a>. </p>
-   *          </important>
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:PutEncryptionConfiguration</code> action. The bucket owner has this permission
-   *          by default. The bucket owner can grant this permission to others. For more information
-   *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a> in the Amazon S3 User Guide. </p>
+   * encryption and Amazon S3 Bucket Key for an existing bucket.</p>
+   * <p>Default encryption for a bucket can use server-side encryption with Amazon S3-managed keys
+   * (SSE-S3) or Amazon Web Services KMS customer master keys (SSE-KMS). If you specify default encryption
+   * using SSE-KMS, you can also configure Amazon S3 Bucket Key. For information about default
+   * encryption, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html">Amazon S3 default bucket encryption</a>
+   * in the <i>Amazon S3 User Guide</i>. For more information about S3 Bucket Keys,
+   * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <important>
+   *    <p>This action requires Amazon Web Services Signature Version 4. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html"> Authenticating Requests (Amazon Web Services Signature
+   *       Version 4)</a>. </p>
+   * </important>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:PutEncryptionConfiguration</code> action. The bucket owner has this permission
+   * by default. The bucket owner can grant this permission to others. For more information
+   * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a> in the Amazon S3 User Guide. </p>
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html">GetBucketEncryption</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketEncryption.html">DeleteBucketEncryption</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html">GetBucketEncryption</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketEncryption.html">DeleteBucketEncryption</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketEncryption(
     args: PutBucketEncryptionCommandInput,
@@ -5374,87 +5374,87 @@ export class S3 extends S3Client {
   /**
    * <p>Puts a S3 Intelligent-Tiering configuration to the specified bucket.
    *       You can have up to 1,000 S3 Intelligent-Tiering configurations per bucket.</p>
-   *          <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
-   *          <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
-   *          <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
-   *          <p>Operations related to
-   *             <code>PutBucketIntelligentTieringConfiguration</code> include: </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketIntelligentTieringConfiguration.html">DeleteBucketIntelligentTieringConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html">GetBucketIntelligentTieringConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html">ListBucketIntelligentTieringConfigurations</a>
-   *                </p>
-   *             </li>
-   *          </ul>
-   *          <note>
-   *             <p>You only need S3 Intelligent-Tiering enabled on a bucket if you want to automatically
-   *             move objects stored in the S3 Intelligent-Tiering storage class to the
-   *             Archive Access or Deep Archive Access tier.</p>
-   *          </note>
+   * <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
+   * <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
+   * <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
+   * <p>Operations related to
+   *    <code>PutBucketIntelligentTieringConfiguration</code> include: </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketIntelligentTieringConfiguration.html">DeleteBucketIntelligentTieringConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html">GetBucketIntelligentTieringConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html">ListBucketIntelligentTieringConfigurations</a>
+   *       </p>
+   *    </li>
+   * </ul>
+   * <note>
+   *    <p>You only need S3 Intelligent-Tiering enabled on a bucket if you want to automatically
+   *    move objects stored in the S3 Intelligent-Tiering storage class to the
+   *    Archive Access or Deep Archive Access tier.</p>
+   * </note>
    *
-   *          <p class="title">
-   *             <b>Special Errors</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p class="title">
-   *                   <b>HTTP 400 Bad Request Error</b>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidArgument</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause:</i> Invalid Argument</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <p class="title">
-   *                   <b>HTTP 400 Bad Request Error</b>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> TooManyConfigurations</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause:</i> You are attempting to create a new configuration
-   *                      but have already reached the 1,000-configuration limit. </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <p class="title">
-   *                   <b>HTTP 403 Forbidden Error</b>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> AccessDenied</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause:</i> You are not the owner of the specified bucket,
-   *                      or you do not have the <code>s3:PutIntelligentTieringConfiguration</code> bucket
-   *                      permission to set the configuration on the bucket. </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *          </ul>
+   * <p class="title">
+   *    <b>Special Errors</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p class="title">
+   *          <b>HTTP 400 Bad Request Error</b>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidArgument</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause:</i> Invalid Argument</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <p class="title">
+   *          <b>HTTP 400 Bad Request Error</b>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> TooManyConfigurations</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause:</i> You are attempting to create a new configuration
+   *             but have already reached the 1,000-configuration limit. </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <p class="title">
+   *          <b>HTTP 403 Forbidden Error</b>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> AccessDenied</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause:</i> You are not the owner of the specified bucket,
+   *             or you do not have the <code>s3:PutIntelligentTieringConfiguration</code> bucket
+   *             permission to set the configuration on the bucket. </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   * </ul>
    */
   public putBucketIntelligentTieringConfiguration(
     args: PutBucketIntelligentTieringConfigurationCommandInput,
@@ -5489,106 +5489,106 @@ export class S3 extends S3Client {
 
   /**
    * <p>This implementation of the <code>PUT</code> action adds an inventory configuration
-   *          (identified by the inventory ID) to the bucket. You can have up to 1,000 inventory
-   *          configurations per bucket. </p>
-   *          <p>Amazon S3 inventory generates inventories of the objects in the bucket on a daily or weekly
-   *          basis, and the results are published to a flat file. The bucket that is inventoried is
-   *          called the <i>source</i> bucket, and the bucket where the inventory flat file
-   *          is stored is called the <i>destination</i> bucket. The
-   *             <i>destination</i> bucket must be in the same Amazon Web Services Region as the
-   *             <i>source</i> bucket. </p>
-   *          <p>When you configure an inventory for a <i>source</i> bucket, you specify
-   *          the <i>destination</i> bucket where you want the inventory to be stored, and
-   *          whether to generate the inventory daily or weekly. You can also configure what object
-   *          metadata to include and whether to inventory all object versions or only current versions.
-   *          For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3
-   *             Inventory</a> in the Amazon S3 User Guide.</p>
-   *          <important>
-   *             <p>You must create a bucket policy on the <i>destination</i> bucket to
-   *             grant permissions to Amazon S3 to write objects to the bucket in the defined location. For an
-   *             example policy, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html#example-bucket-policies-use-case-9">
-   *                Granting Permissions for Amazon S3 Inventory and Storage Class Analysis</a>.</p>
-   *          </important>
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:PutInventoryConfiguration</code> action. The bucket owner has this permission
-   *          by default and can grant this permission to others. For more information about permissions,
-   *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a> in the Amazon S3 User Guide.</p>
+   * (identified by the inventory ID) to the bucket. You can have up to 1,000 inventory
+   * configurations per bucket. </p>
+   * <p>Amazon S3 inventory generates inventories of the objects in the bucket on a daily or weekly
+   * basis, and the results are published to a flat file. The bucket that is inventoried is
+   * called the <i>source</i> bucket, and the bucket where the inventory flat file
+   * is stored is called the <i>destination</i> bucket. The
+   *    <i>destination</i> bucket must be in the same Amazon Web Services Region as the
+   *    <i>source</i> bucket. </p>
+   * <p>When you configure an inventory for a <i>source</i> bucket, you specify
+   * the <i>destination</i> bucket where you want the inventory to be stored, and
+   * whether to generate the inventory daily or weekly. You can also configure what object
+   * metadata to include and whether to inventory all object versions or only current versions.
+   * For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3
+   *    Inventory</a> in the Amazon S3 User Guide.</p>
+   * <important>
+   *    <p>You must create a bucket policy on the <i>destination</i> bucket to
+   *    grant permissions to Amazon S3 to write objects to the bucket in the defined location. For an
+   *    example policy, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html#example-bucket-policies-use-case-9">
+   *       Granting Permissions for Amazon S3 Inventory and Storage Class Analysis</a>.</p>
+   * </important>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:PutInventoryConfiguration</code> action. The bucket owner has this permission
+   * by default and can grant this permission to others. For more information about permissions,
+   * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a> in the Amazon S3 User Guide.</p>
    *
-   *          <p class="title">
-   *             <b>Special Errors</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p class="title">
-   *                   <b>HTTP 400 Bad Request Error</b>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidArgument</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause:</i> Invalid Argument</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <p class="title">
-   *                   <b>HTTP 400 Bad Request Error</b>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> TooManyConfigurations</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause:</i> You are attempting to create a new configuration
-   *                      but have already reached the 1,000-configuration limit. </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <p class="title">
-   *                   <b>HTTP 403 Forbidden Error</b>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> AccessDenied</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause:</i> You are not the owner of the specified bucket,
-   *                      or you do not have the <code>s3:PutInventoryConfiguration</code> bucket
-   *                      permission to set the configuration on the bucket. </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *          </ul>
+   * <p class="title">
+   *    <b>Special Errors</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p class="title">
+   *          <b>HTTP 400 Bad Request Error</b>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidArgument</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause:</i> Invalid Argument</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <p class="title">
+   *          <b>HTTP 400 Bad Request Error</b>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> TooManyConfigurations</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause:</i> You are attempting to create a new configuration
+   *             but have already reached the 1,000-configuration limit. </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <p class="title">
+   *          <b>HTTP 403 Forbidden Error</b>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> AccessDenied</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause:</i> You are not the owner of the specified bucket,
+   *             or you do not have the <code>s3:PutInventoryConfiguration</code> bucket
+   *             permission to set the configuration on the bucket. </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   * </ul>
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketInventoryConfiguration.html">GetBucketInventoryConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketInventoryConfiguration.html">DeleteBucketInventoryConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketInventoryConfigurations.html">ListBucketInventoryConfigurations</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketInventoryConfiguration.html">GetBucketInventoryConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketInventoryConfiguration.html">DeleteBucketInventoryConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketInventoryConfigurations.html">ListBucketInventoryConfigurations</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketInventoryConfiguration(
     args: PutBucketInventoryConfigurationCommandInput,
@@ -5621,99 +5621,99 @@ export class S3 extends S3Client {
 
   /**
    * <p>Creates a new lifecycle configuration for the bucket or replaces an existing lifecycle
-   *          configuration. For information about lifecycle configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html">Managing your storage
-   *             lifecycle</a>.</p>
+   * configuration. For information about lifecycle configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html">Managing your storage
+   *    lifecycle</a>.</p>
    *
-   *          <note>
-   *             <p>Bucket lifecycle configuration now supports specifying a lifecycle rule using an
-   *             object key name prefix, one or more object tags, or a combination of both. Accordingly,
-   *             this section describes the latest API. The previous version of the API supported
-   *             filtering based only on an object key name prefix, which is supported for backward
-   *             compatibility. For the related API description, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html">PutBucketLifecycle</a>.</p>
-   *          </note>
-   *
-   *
-   *
-   *          <p>
-   *             <b>Rules</b>
-   *          </p>
-   *          <p>You specify the lifecycle configuration in your request body. The lifecycle
-   *          configuration is specified as XML consisting of one or more rules. Each rule consists of
-   *          the following:</p>
-   *
-   *          <ul>
-   *             <li>
-   *                <p>Filter identifying a subset of objects to which the rule applies. The filter can
-   *                be based on a key name prefix, object tags, or a combination of both.</p>
-   *             </li>
-   *             <li>
-   *                <p>Status whether the rule is in effect.</p>
-   *             </li>
-   *             <li>
-   *                <p>One or more lifecycle transition and expiration actions that you want Amazon S3 to
-   *                perform on the objects identified by the filter. If the state of your bucket is
-   *                versioning-enabled or versioning-suspended, you can have many versions of the same
-   *                object (one current version and zero or more noncurrent versions). Amazon S3 provides
-   *                predefined actions that you can specify for current and noncurrent object
-   *                versions.</p>
-   *             </li>
-   *          </ul>
-   *
-   *          <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Object
-   *             Lifecycle Management</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html">Lifecycle Configuration Elements</a>.</p>
+   * <note>
+   *    <p>Bucket lifecycle configuration now supports specifying a lifecycle rule using an
+   *    object key name prefix, one or more object tags, or a combination of both. Accordingly,
+   *    this section describes the latest API. The previous version of the API supported
+   *    filtering based only on an object key name prefix, which is supported for backward
+   *    compatibility. For the related API description, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html">PutBucketLifecycle</a>.</p>
+   * </note>
    *
    *
-   *          <p>
-   *             <b>Permissions</b>
-   *          </p>
+   *
+   * <p>
+   *    <b>Rules</b>
+   * </p>
+   * <p>You specify the lifecycle configuration in your request body. The lifecycle
+   * configuration is specified as XML consisting of one or more rules. Each rule consists of
+   * the following:</p>
+   *
+   * <ul>
+   *    <li>
+   *       <p>Filter identifying a subset of objects to which the rule applies. The filter can
+   *       be based on a key name prefix, object tags, or a combination of both.</p>
+   *    </li>
+   *    <li>
+   *       <p>Status whether the rule is in effect.</p>
+   *    </li>
+   *    <li>
+   *       <p>One or more lifecycle transition and expiration actions that you want Amazon S3 to
+   *       perform on the objects identified by the filter. If the state of your bucket is
+   *       versioning-enabled or versioning-suspended, you can have many versions of the same
+   *       object (one current version and zero or more noncurrent versions). Amazon S3 provides
+   *       predefined actions that you can specify for current and noncurrent object
+   *       versions.</p>
+   *    </li>
+   * </ul>
+   *
+   * <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Object
+   *    Lifecycle Management</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html">Lifecycle Configuration Elements</a>.</p>
    *
    *
-   *          <p>By default, all Amazon S3 resources are private, including buckets, objects, and related
-   *          subresources (for example, lifecycle configuration and website configuration). Only the
-   *          resource owner (that is, the Amazon Web Services account that created it) can access the resource. The
-   *          resource owner can optionally grant access permissions to others by writing an access
-   *          policy. For this operation, a user must get the s3:PutLifecycleConfiguration
-   *          permission.</p>
-   *
-   *          <p>You can also explicitly deny permissions. Explicit deny also supersedes any other
-   *          permissions. If you want to block users or accounts from removing or deleting objects from
-   *          your bucket, you must deny them permissions for the following actions:</p>
-   *
-   *          <ul>
-   *             <li>
-   *                <p>s3:DeleteObject</p>
-   *             </li>
-   *             <li>
-   *                <p>s3:DeleteObjectVersion</p>
-   *             </li>
-   *             <li>
-   *                <p>s3:PutLifecycleConfiguration</p>
-   *             </li>
-   *          </ul>
+   * <p>
+   *    <b>Permissions</b>
+   * </p>
    *
    *
-   *          <p>For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
+   * <p>By default, all Amazon S3 resources are private, including buckets, objects, and related
+   * subresources (for example, lifecycle configuration and website configuration). Only the
+   * resource owner (that is, the Amazon Web Services account that created it) can access the resource. The
+   * resource owner can optionally grant access permissions to others by writing an access
+   * policy. For this operation, a user must get the s3:PutLifecycleConfiguration
+   * permission.</p>
    *
-   *          <p>The following are related to <code>PutBucketLifecycleConfiguration</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/lifecycle-configuration-examples.html">Examples of
-   *                   Lifecycle Configuration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html">GetBucketLifecycleConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketLifecycle.html">DeleteBucketLifecycle</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>You can also explicitly deny permissions. Explicit deny also supersedes any other
+   * permissions. If you want to block users or accounts from removing or deleting objects from
+   * your bucket, you must deny them permissions for the following actions:</p>
+   *
+   * <ul>
+   *    <li>
+   *       <p>s3:DeleteObject</p>
+   *    </li>
+   *    <li>
+   *       <p>s3:DeleteObjectVersion</p>
+   *    </li>
+   *    <li>
+   *       <p>s3:PutLifecycleConfiguration</p>
+   *    </li>
+   * </ul>
+   *
+   *
+   * <p>For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
+   *
+   * <p>The following are related to <code>PutBucketLifecycleConfiguration</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/lifecycle-configuration-examples.html">Examples of
+   *          Lifecycle Configuration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html">GetBucketLifecycleConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketLifecycle.html">DeleteBucketLifecycle</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketLifecycleConfiguration(
     args: PutBucketLifecycleConfigurationCommandInput,
@@ -5746,85 +5746,85 @@ export class S3 extends S3Client {
 
   /**
    * <p>Set the logging parameters for a bucket and to specify permissions for who can view and
-   *          modify the logging parameters. All logs are saved to buckets in the same Amazon Web Services Region as the
-   *          source bucket. To set the logging status of a bucket, you must be the bucket owner.</p>
+   * modify the logging parameters. All logs are saved to buckets in the same Amazon Web Services Region as the
+   * source bucket. To set the logging status of a bucket, you must be the bucket owner.</p>
    *
-   *          <p>The bucket owner is automatically granted FULL_CONTROL to all logs. You use the
-   *             <code>Grantee</code> request element to grant access to other people. The
-   *             <code>Permissions</code> request element specifies the kind of access the grantee has to
-   *          the logs.</p>
+   * <p>The bucket owner is automatically granted FULL_CONTROL to all logs. You use the
+   *    <code>Grantee</code> request element to grant access to other people. The
+   *    <code>Permissions</code> request element specifies the kind of access the grantee has to
+   * the logs.</p>
    *
-   *          <p>
-   *             <b>Grantee Values</b>
-   *          </p>
-   *          <p>You can specify the person (grantee) to whom you're assigning access rights (using
-   *          request elements) in the following ways:</p>
+   * <p>
+   *    <b>Grantee Values</b>
+   * </p>
+   * <p>You can specify the person (grantee) to whom you're assigning access rights (using
+   * request elements) in the following ways:</p>
    *
-   *          <ul>
-   *             <li>
-   *                <p>By the person's ID:</p>
-   *                <p>
-   *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   *                   xsi:type="CanonicalUser"><ID><>ID<></ID><DisplayName><>GranteesEmail<></DisplayName>
-   *                   </Grantee></code>
-   *                </p>
-   *                <p>DisplayName is optional and ignored in the request.</p>
-   *             </li>
-   *             <li>
-   *                <p>By Email address:</p>
-   *                <p>
-   *                   <code> <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   *                   xsi:type="AmazonCustomerByEmail"><EmailAddress><>Grantees@email.com<></EmailAddress></Grantee></code>
-   *                </p>
-   *                <p>The grantee is resolved to the CanonicalUser and, in a response to a GET Object
-   *                acl request, appears as the CanonicalUser.</p>
-   *             </li>
-   *             <li>
-   *                <p>By URI:</p>
-   *                <p>
-   *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   *                   xsi:type="Group"><URI><>http://acs.amazonaws.com/groups/global/AuthenticatedUsers<></URI></Grantee></code>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <ul>
+   *    <li>
+   *       <p>By the person's ID:</p>
+   *       <p>
+   *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   *          xsi:type="CanonicalUser"><ID><>ID<></ID><DisplayName><>GranteesEmail<></DisplayName>
+   *          </Grantee></code>
+   *       </p>
+   *       <p>DisplayName is optional and ignored in the request.</p>
+   *    </li>
+   *    <li>
+   *       <p>By Email address:</p>
+   *       <p>
+   *          <code> <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   *          xsi:type="AmazonCustomerByEmail"><EmailAddress><>Grantees@email.com<></EmailAddress></Grantee></code>
+   *       </p>
+   *       <p>The grantee is resolved to the CanonicalUser and, in a response to a GET Object
+   *       acl request, appears as the CanonicalUser.</p>
+   *    </li>
+   *    <li>
+   *       <p>By URI:</p>
+   *       <p>
+   *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   *          xsi:type="Group"><URI><>http://acs.amazonaws.com/groups/global/AuthenticatedUsers<></URI></Grantee></code>
+   *       </p>
+   *    </li>
+   * </ul>
    *
    *
-   *          <p>To enable logging, you use LoggingEnabled and its children request elements. To disable
-   *          logging, you use an empty BucketLoggingStatus request element:</p>
+   * <p>To enable logging, you use LoggingEnabled and its children request elements. To disable
+   * logging, you use an empty BucketLoggingStatus request element:</p>
    *
-   *          <p>
-   *             <code><BucketLoggingStatus xmlns="http://doc.s3.amazonaws.com/2006-03-01"
-   *             /></code>
-   *          </p>
+   * <p>
+   *    <code><BucketLoggingStatus xmlns="http://doc.s3.amazonaws.com/2006-03-01"
+   *    /></code>
+   * </p>
    *
-   *          <p>For more information about server access logging, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerLogs.html">Server Access Logging</a>. </p>
+   * <p>For more information about server access logging, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerLogs.html">Server Access Logging</a>. </p>
    *
-   *          <p>For more information about creating a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>. For more
-   *          information about returning the logging status of a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLogging.html">GetBucketLogging</a>.</p>
+   * <p>For more information about creating a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>. For more
+   * information about returning the logging status of a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLogging.html">GetBucketLogging</a>.</p>
    *
-   *          <p>The following operations are related to <code>PutBucketLogging</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLogging.html">GetBucketLogging</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>PutBucketLogging</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLogging.html">GetBucketLogging</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketLogging(
     args: PutBucketLoggingCommandInput,
@@ -5857,56 +5857,56 @@ export class S3 extends S3Client {
 
   /**
    * <p>Sets a metrics configuration (specified by the metrics configuration ID) for the bucket.
-   *          You can have up to 1,000 metrics configurations per bucket. If you're updating an existing
-   *          metrics configuration, note that this is a full replacement of the existing metrics
-   *          configuration. If you don't include the elements you want to keep, they are erased.</p>
+   * You can have up to 1,000 metrics configurations per bucket. If you're updating an existing
+   * metrics configuration, note that this is a full replacement of the existing metrics
+   * configuration. If you don't include the elements you want to keep, they are erased.</p>
    *
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:PutMetricsConfiguration</code> action. The bucket owner has this permission by
-   *          default. The bucket owner can grant this permission to others. For more information about
-   *          permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:PutMetricsConfiguration</code> action. The bucket owner has this permission by
+   * default. The bucket owner can grant this permission to others. For more information about
+   * permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
    *
-   *          <p>For information about CloudWatch request metrics for Amazon S3, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
-   *             CloudWatch</a>.</p>
+   * <p>For information about CloudWatch request metrics for Amazon S3, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
+   *    CloudWatch</a>.</p>
    *
-   *          <p>The following operations are related to
-   *          <code>PutBucketMetricsConfiguration</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html">DeleteBucketMetricsConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketMetricsConfigurations.html">ListBucketMetricsConfigurations</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to
+   * <code>PutBucketMetricsConfiguration</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html">DeleteBucketMetricsConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketMetricsConfigurations.html">ListBucketMetricsConfigurations</a>
+   *       </p>
+   *    </li>
+   * </ul>
    *
-   *          <p>
-   *             <code>GetBucketLifecycle</code> has the following special error:</p>
-   *          <ul>
-   *             <li>
-   *                <p>Error code: <code>TooManyConfigurations</code>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>Description: You are attempting to create a new configuration but have
-   *                      already reached the 1,000-configuration limit.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>HTTP Status Code: HTTP 400 Bad Request</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *          </ul>
+   * <p>
+   *    <code>GetBucketLifecycle</code> has the following special error:</p>
+   * <ul>
+   *    <li>
+   *       <p>Error code: <code>TooManyConfigurations</code>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>Description: You are attempting to create a new configuration but have
+   *             already reached the 1,000-configuration limit.</p>
+   *          </li>
+   *          <li>
+   *             <p>HTTP Status Code: HTTP 400 Bad Request</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   * </ul>
    */
   public putBucketMetricsConfiguration(
     args: PutBucketMetricsConfigurationCommandInput,
@@ -5939,67 +5939,67 @@ export class S3 extends S3Client {
 
   /**
    * <p>Enables notifications of specified events for a bucket. For more information about event
-   *          notifications, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Event
-   *             Notifications</a>.</p>
+   * notifications, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Event
+   *    Notifications</a>.</p>
    *
-   *          <p>Using this API, you can replace an existing notification configuration. The
-   *          configuration is an XML file that defines the event types that you want Amazon S3 to publish and
-   *          the destination where you want Amazon S3 to publish an event notification when it detects an
-   *          event of the specified type.</p>
+   * <p>Using this API, you can replace an existing notification configuration. The
+   * configuration is an XML file that defines the event types that you want Amazon S3 to publish and
+   * the destination where you want Amazon S3 to publish an event notification when it detects an
+   * event of the specified type.</p>
    *
-   *          <p>By default, your bucket has no event notifications configured. That is, the notification
-   *          configuration will be an empty <code>NotificationConfiguration</code>.</p>
+   * <p>By default, your bucket has no event notifications configured. That is, the notification
+   * configuration will be an empty <code>NotificationConfiguration</code>.</p>
    *
-   *          <p>
-   *             <code><NotificationConfiguration></code>
-   *          </p>
-   *          <p>
-   *             <code></NotificationConfiguration></code>
-   *          </p>
-   *          <p>This action replaces the existing notification configuration with the configuration
-   *          you include in the request body.</p>
+   * <p>
+   *    <code><NotificationConfiguration></code>
+   * </p>
+   * <p>
+   *    <code></NotificationConfiguration></code>
+   * </p>
+   * <p>This action replaces the existing notification configuration with the configuration
+   * you include in the request body.</p>
    *
-   *          <p>After Amazon S3 receives this request, it first verifies that any Amazon Simple Notification
-   *          Service (Amazon SNS) or Amazon Simple Queue Service (Amazon SQS) destination exists, and
-   *          that the bucket owner has permission to publish to it by sending a test notification. In
-   *          the case of Lambda destinations, Amazon S3 verifies that the Lambda function permissions
-   *          grant Amazon S3 permission to invoke the function from the Amazon S3 bucket. For more information,
-   *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Notifications for Amazon S3
-   *             Events</a>.</p>
+   * <p>After Amazon S3 receives this request, it first verifies that any Amazon Simple Notification
+   * Service (Amazon SNS) or Amazon Simple Queue Service (Amazon SQS) destination exists, and
+   * that the bucket owner has permission to publish to it by sending a test notification. In
+   * the case of Lambda destinations, Amazon S3 verifies that the Lambda function permissions
+   * grant Amazon S3 permission to invoke the function from the Amazon S3 bucket. For more information,
+   * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Notifications for Amazon S3
+   *    Events</a>.</p>
    *
-   *          <p>You can disable notifications by adding the empty NotificationConfiguration
-   *          element.</p>
+   * <p>You can disable notifications by adding the empty NotificationConfiguration
+   * element.</p>
    *
-   *          <p>By default, only the bucket owner can configure notifications on a bucket. However,
-   *          bucket owners can use a bucket policy to grant permission to other users to set this
-   *          configuration with <code>s3:PutBucketNotification</code> permission.</p>
+   * <p>By default, only the bucket owner can configure notifications on a bucket. However,
+   * bucket owners can use a bucket policy to grant permission to other users to set this
+   * configuration with <code>s3:PutBucketNotification</code> permission.</p>
    *
-   *          <note>
-   *             <p>The PUT notification is an atomic operation. For example, suppose your notification
-   *             configuration includes SNS topic, SQS queue, and Lambda function configurations. When
-   *             you send a PUT request with this configuration, Amazon S3 sends test messages to your SNS
-   *             topic. If the message fails, the entire PUT action will fail, and Amazon S3 will not add
-   *             the configuration to your bucket.</p>
-   *          </note>
+   * <note>
+   *    <p>The PUT notification is an atomic operation. For example, suppose your notification
+   *    configuration includes SNS topic, SQS queue, and Lambda function configurations. When
+   *    you send a PUT request with this configuration, Amazon S3 sends test messages to your SNS
+   *    topic. If the message fails, the entire PUT action will fail, and Amazon S3 will not add
+   *    the configuration to your bucket.</p>
+   * </note>
    *
-   *          <p>
-   *             <b>Responses</b>
-   *          </p>
-   *          <p>If the configuration in the request body includes only one
-   *             <code>TopicConfiguration</code> specifying only the
-   *             <code>s3:ReducedRedundancyLostObject</code> event type, the response will also include
-   *          the <code>x-amz-sns-test-message-id</code> header containing the message ID of the test
-   *          notification sent to the topic.</p>
+   * <p>
+   *    <b>Responses</b>
+   * </p>
+   * <p>If the configuration in the request body includes only one
+   *    <code>TopicConfiguration</code> specifying only the
+   *    <code>s3:ReducedRedundancyLostObject</code> event type, the response will also include
+   * the <code>x-amz-sns-test-message-id</code> header containing the message ID of the test
+   * notification sent to the topic.</p>
    *
-   *          <p>The following action is related to
-   *          <code>PutBucketNotificationConfiguration</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketNotificationConfiguration.html">GetBucketNotificationConfiguration</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following action is related to
+   * <code>PutBucketNotificationConfiguration</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketNotificationConfiguration.html">GetBucketNotificationConfiguration</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketNotificationConfiguration(
     args: PutBucketNotificationConfigurationCommandInput,
@@ -6032,22 +6032,22 @@ export class S3 extends S3Client {
 
   /**
    * <p>Creates or modifies <code>OwnershipControls</code> for an Amazon S3 bucket. To use this
-   *          operation, you must have the <code>s3:PutBucketOwnershipControls</code> permission. For
-   *          more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a Policy</a>. </p>
-   *          <p>For information about Amazon S3 Object Ownership, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html">Using Object Ownership</a>. </p>
-   *          <p>The following operations are related to <code>PutBucketOwnershipControls</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a>GetBucketOwnershipControls</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a>DeleteBucketOwnershipControls</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * operation, you must have the <code>s3:PutBucketOwnershipControls</code> permission. For
+   * more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a Policy</a>. </p>
+   * <p>For information about Amazon S3 Object Ownership, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html">Using Object Ownership</a>. </p>
+   * <p>The following operations are related to <code>PutBucketOwnershipControls</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a>GetBucketOwnershipControls</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a>DeleteBucketOwnershipControls</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketOwnershipControls(
     args: PutBucketOwnershipControlsCommandInput,
@@ -6080,35 +6080,35 @@ export class S3 extends S3Client {
 
   /**
    * <p>Applies an Amazon S3 bucket policy to an Amazon S3 bucket. If you are using an identity other than
-   *          the root user of the Amazon Web Services account that owns the bucket, the calling identity must have the
-   *             <code>PutBucketPolicy</code> permissions on the specified bucket and belong to the
-   *          bucket owner's account in order to use this operation.</p>
+   * the root user of the Amazon Web Services account that owns the bucket, the calling identity must have the
+   *    <code>PutBucketPolicy</code> permissions on the specified bucket and belong to the
+   * bucket owner's account in order to use this operation.</p>
    *
-   *          <p>If you don't have <code>PutBucketPolicy</code> permissions, Amazon S3 returns a <code>403
-   *             Access Denied</code> error. If you have the correct permissions, but you're not using an
-   *          identity that belongs to the bucket owner's account, Amazon S3 returns a <code>405 Method Not
-   *             Allowed</code> error.</p>
+   * <p>If you don't have <code>PutBucketPolicy</code> permissions, Amazon S3 returns a <code>403
+   *    Access Denied</code> error. If you have the correct permissions, but you're not using an
+   * identity that belongs to the bucket owner's account, Amazon S3 returns a <code>405 Method Not
+   *    Allowed</code> error.</p>
    *
-   *          <important>
-   *             <p> As a security precaution, the root user of the Amazon Web Services account that owns a bucket can
-   *             always use this operation, even if the policy explicitly denies the root user the
-   *             ability to perform this action. </p>
-   *          </important>
-   *          <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/example-bucket-policies.html">Bucket policy examples</a>.</p>
+   * <important>
+   *    <p> As a security precaution, the root user of the Amazon Web Services account that owns a bucket can
+   *    always use this operation, even if the policy explicitly denies the root user the
+   *    ability to perform this action. </p>
+   * </important>
+   * <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/example-bucket-policies.html">Bucket policy examples</a>.</p>
    *
-   *          <p>The following operations are related to <code>PutBucketPolicy</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>PutBucketPolicy</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketPolicy(
     args: PutBucketPolicyCommandInput,
@@ -6141,75 +6141,75 @@ export class S3 extends S3Client {
 
   /**
    * <p> Creates a replication configuration or replaces an existing one. For more information,
-   *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html">Replication</a> in the <i>Amazon S3 User Guide</i>. </p>
+   * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html">Replication</a> in the <i>Amazon S3 User Guide</i>. </p>
    *
-   *          <p>Specify the replication configuration in the request body. In the replication
-   *          configuration, you provide the name of the destination bucket or buckets where you want
-   *          Amazon S3 to replicate objects, the IAM role that Amazon S3 can assume to replicate objects on your
-   *          behalf, and other relevant information.</p>
+   * <p>Specify the replication configuration in the request body. In the replication
+   * configuration, you provide the name of the destination bucket or buckets where you want
+   * Amazon S3 to replicate objects, the IAM role that Amazon S3 can assume to replicate objects on your
+   * behalf, and other relevant information.</p>
    *
    *
-   *          <p>A replication configuration must include at least one rule, and can contain a maximum of
-   *          1,000. Each rule identifies a subset of objects to replicate by filtering the objects in
-   *          the source bucket. To choose additional subsets of objects to replicate, add a rule for
-   *          each subset.</p>
+   * <p>A replication configuration must include at least one rule, and can contain a maximum of
+   * 1,000. Each rule identifies a subset of objects to replicate by filtering the objects in
+   * the source bucket. To choose additional subsets of objects to replicate, add a rule for
+   * each subset.</p>
    *
-   *          <p>To specify a subset of the objects in the source bucket to apply a replication rule to,
-   *          add the Filter element as a child of the Rule element. You can filter objects based on an
-   *          object key prefix, one or more object tags, or both. When you add the Filter element in the
-   *          configuration, you must also add the following elements:
-   *             <code>DeleteMarkerReplication</code>, <code>Status</code>, and
-   *          <code>Priority</code>.</p>
-   *          <note>
-   *             <p>If you are using an earlier version of the replication configuration, Amazon S3 handles
-   *             replication of delete markers differently. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-backward-compat-considerations">Backward Compatibility</a>.</p>
-   *          </note>
-   *          <p>For information about enabling versioning on a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html">Using Versioning</a>.</p>
+   * <p>To specify a subset of the objects in the source bucket to apply a replication rule to,
+   * add the Filter element as a child of the Rule element. You can filter objects based on an
+   * object key prefix, one or more object tags, or both. When you add the Filter element in the
+   * configuration, you must also add the following elements:
+   *    <code>DeleteMarkerReplication</code>, <code>Status</code>, and
+   * <code>Priority</code>.</p>
+   * <note>
+   *    <p>If you are using an earlier version of the replication configuration, Amazon S3 handles
+   *    replication of delete markers differently. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-backward-compat-considerations">Backward Compatibility</a>.</p>
+   * </note>
+   * <p>For information about enabling versioning on a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html">Using Versioning</a>.</p>
    *
-   *          <p>
-   *             <b>Handling Replication of Encrypted Objects</b>
-   *          </p>
-   *          <p>By default, Amazon S3 doesn't replicate objects that are stored at rest using server-side
-   *          encryption with CMKs stored in Amazon Web Services KMS. To replicate Amazon Web Services KMS-encrypted objects, add the
-   *          following: <code>SourceSelectionCriteria</code>, <code>SseKmsEncryptedObjects</code>,
-   *             <code>Status</code>, <code>EncryptionConfiguration</code>, and
-   *             <code>ReplicaKmsKeyID</code>. For information about replication configuration, see
-   *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-config-for-kms-objects.html">Replicating Objects
-   *             Created with SSE Using CMKs stored in Amazon Web Services KMS</a>.</p>
+   * <p>
+   *    <b>Handling Replication of Encrypted Objects</b>
+   * </p>
+   * <p>By default, Amazon S3 doesn't replicate objects that are stored at rest using server-side
+   * encryption with CMKs stored in Amazon Web Services KMS. To replicate Amazon Web Services KMS-encrypted objects, add the
+   * following: <code>SourceSelectionCriteria</code>, <code>SseKmsEncryptedObjects</code>,
+   *    <code>Status</code>, <code>EncryptionConfiguration</code>, and
+   *    <code>ReplicaKmsKeyID</code>. For information about replication configuration, see
+   *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-config-for-kms-objects.html">Replicating Objects
+   *    Created with SSE Using CMKs stored in Amazon Web Services KMS</a>.</p>
    *
-   *          <p>For information on <code>PutBucketReplication</code> errors, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ReplicationErrorCodeList">List of
-   *             replication-related error codes</a>
-   *          </p>
+   * <p>For information on <code>PutBucketReplication</code> errors, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ReplicationErrorCodeList">List of
+   *    replication-related error codes</a>
+   * </p>
    *
-   *          <p>
-   *             <b>Permissions</b>
-   *          </p>
-   *          <p>To create a <code>PutBucketReplication</code> request, you must have <code>s3:PutReplicationConfiguration</code>
-   *          permissions for the bucket.
-   *          </p>
-   *          <p>By default, a resource owner, in this case the Amazon Web Services account that created the bucket, can
-   *          perform this operation. The resource owner can also grant others permissions to perform the
-   *          operation. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a Policy</a>
-   *          and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your
-   *             Amazon S3 Resources</a>.</p>
-   *          <note>
-   *             <p>To perform this operation, the user or role performing the action must have the
-   *                <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html">iam:PassRole</a> permission.</p>
-   *          </note>
+   * <p>
+   *    <b>Permissions</b>
+   * </p>
+   * <p>To create a <code>PutBucketReplication</code> request, you must have <code>s3:PutReplicationConfiguration</code>
+   * permissions for the bucket.
+   * </p>
+   * <p>By default, a resource owner, in this case the Amazon Web Services account that created the bucket, can
+   * perform this operation. The resource owner can also grant others permissions to perform the
+   * operation. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a Policy</a>
+   * and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your
+   *    Amazon S3 Resources</a>.</p>
+   * <note>
+   *    <p>To perform this operation, the user or role performing the action must have the
+   *       <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html">iam:PassRole</a> permission.</p>
+   * </note>
    *
-   *          <p>The following operations are related to <code>PutBucketReplication</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketReplication.html">GetBucketReplication</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketReplication.html">DeleteBucketReplication</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>PutBucketReplication</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketReplication.html">GetBucketReplication</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketReplication.html">DeleteBucketReplication</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketReplication(
     args: PutBucketReplicationCommandInput,
@@ -6242,24 +6242,24 @@ export class S3 extends S3Client {
 
   /**
    * <p>Sets the request payment configuration for a bucket. By default, the bucket owner pays
-   *          for downloads from the bucket. This configuration parameter enables the bucket owner (only)
-   *          to specify that the person requesting the download will be charged for the download. For
-   *          more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html">Requester Pays
-   *             Buckets</a>.</p>
+   * for downloads from the bucket. This configuration parameter enables the bucket owner (only)
+   * to specify that the person requesting the download will be charged for the download. For
+   * more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html">Requester Pays
+   *    Buckets</a>.</p>
    *
-   *          <p>The following operations are related to <code>PutBucketRequestPayment</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketRequestPayment.html">GetBucketRequestPayment</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>PutBucketRequestPayment</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketRequestPayment.html">GetBucketRequestPayment</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketRequestPayment(
     args: PutBucketRequestPaymentCommandInput,
@@ -6292,84 +6292,84 @@ export class S3 extends S3Client {
 
   /**
    * <p>Sets the tags for a bucket.</p>
-   *          <p>Use tags to organize your Amazon Web Services bill to reflect your own cost structure. To do this, sign
-   *          up to get your Amazon Web Services account bill with tag key values included. Then, to see the cost of
-   *          combined resources, organize your billing information according to resources with the same
-   *          tag key values. For example, you can tag several resources with a specific application
-   *          name, and then organize your billing information to see the total cost of that application
-   *          across several services. For more information, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html">Cost Allocation
-   *             and Tagging</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CostAllocTagging.html">Using Cost Allocation in Amazon S3 Bucket
-   *                Tags</a>.</p>
+   * <p>Use tags to organize your Amazon Web Services bill to reflect your own cost structure. To do this, sign
+   * up to get your Amazon Web Services account bill with tag key values included. Then, to see the cost of
+   * combined resources, organize your billing information according to resources with the same
+   * tag key values. For example, you can tag several resources with a specific application
+   * name, and then organize your billing information to see the total cost of that application
+   * across several services. For more information, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html">Cost Allocation
+   *    and Tagging</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CostAllocTagging.html">Using Cost Allocation in Amazon S3 Bucket
+   *       Tags</a>.</p>
    *
-   *          <note>
-   *             <p>
-   *             When this operation sets the tags for a bucket, it will overwrite any current tags the
-   *             bucket already has. You cannot use this operation to add tags to an existing list of tags.</p>
-   *          </note>
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:PutBucketTagging</code> action. The bucket owner has this permission by default
-   *          and can grant this permission to others. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a>.</p>
+   * <note>
+   *    <p>
+   *    When this operation sets the tags for a bucket, it will overwrite any current tags the
+   *    bucket already has. You cannot use this operation to add tags to an existing list of tags.</p>
+   * </note>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:PutBucketTagging</code> action. The bucket owner has this permission by default
+   * and can grant this permission to others. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a>.</p>
    *
-   *          <p>
-   *             <code>PutBucketTagging</code> has the following special errors:</p>
-   *          <ul>
-   *             <li>
-   *                <p>Error code: <code>InvalidTagError</code>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>Description: The tag provided was not a valid tag. This error can occur if
-   *                      the tag did not pass input validation. For information about tag restrictions,
-   *                      see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html">User-Defined Tag Restrictions</a> and <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/aws-tag-restrictions.html">Amazon Web Services-Generated Cost Allocation Tag Restrictions</a>.</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <p>Error code: <code>MalformedXMLError</code>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>Description: The XML provided does not match the schema.</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <p>Error code: <code>OperationAbortedError </code>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>Description: A conflicting conditional action is currently in progress
-   *                      against this resource. Please try again.</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <p>Error code: <code>InternalError</code>
-   *                </p>
-   *                <ul>
-   *                   <li>
-   *                      <p>Description: The service was unable to apply the provided tag to the
-   *                      bucket.</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *          </ul>
+   * <p>
+   *    <code>PutBucketTagging</code> has the following special errors:</p>
+   * <ul>
+   *    <li>
+   *       <p>Error code: <code>InvalidTagError</code>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>Description: The tag provided was not a valid tag. This error can occur if
+   *             the tag did not pass input validation. For information about tag restrictions,
+   *             see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html">User-Defined Tag Restrictions</a> and <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/aws-tag-restrictions.html">Amazon Web Services-Generated Cost Allocation Tag Restrictions</a>.</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <p>Error code: <code>MalformedXMLError</code>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>Description: The XML provided does not match the schema.</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <p>Error code: <code>OperationAbortedError </code>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>Description: A conflicting conditional action is currently in progress
+   *             against this resource. Please try again.</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <p>Error code: <code>InternalError</code>
+   *       </p>
+   *       <ul>
+   *          <li>
+   *             <p>Description: The service was unable to apply the provided tag to the
+   *             bucket.</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   * </ul>
    *
    *
-   *          <p>The following operations are related to <code>PutBucketTagging</code>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html">GetBucketTagging</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketTagging.html">DeleteBucketTagging</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>The following operations are related to <code>PutBucketTagging</code>:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html">GetBucketTagging</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketTagging.html">DeleteBucketTagging</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketTagging(
     args: PutBucketTaggingCommandInput,
@@ -6402,54 +6402,54 @@ export class S3 extends S3Client {
 
   /**
    * <p>Sets the versioning state of an existing bucket. To set the versioning state, you must
-   *          be the bucket owner.</p>
-   *          <p>You can set the versioning state with one of the following values:</p>
+   * be the bucket owner.</p>
+   * <p>You can set the versioning state with one of the following values:</p>
    *
-   *          <p>
-   *             <b>Enabled</b>—Enables versioning for the objects in the
-   *          bucket. All objects added to the bucket receive a unique version ID.</p>
+   * <p>
+   *    <b>Enabled</b>—Enables versioning for the objects in the
+   * bucket. All objects added to the bucket receive a unique version ID.</p>
    *
-   *          <p>
-   *             <b>Suspended</b>—Disables versioning for the objects in the
-   *          bucket. All objects added to the bucket receive the version ID null.</p>
+   * <p>
+   *    <b>Suspended</b>—Disables versioning for the objects in the
+   * bucket. All objects added to the bucket receive the version ID null.</p>
    *
-   *          <p>If the versioning state has never been set on a bucket, it has no versioning state; a
-   *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html">GetBucketVersioning</a> request does not return a versioning state value.</p>
+   * <p>If the versioning state has never been set on a bucket, it has no versioning state; a
+   *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html">GetBucketVersioning</a> request does not return a versioning state value.</p>
    *
-   *          <p>If the bucket owner enables MFA Delete in the bucket versioning configuration, the
-   *          bucket owner must include the <code>x-amz-mfa request</code> header and the
-   *             <code>Status</code> and the <code>MfaDelete</code> request elements in a request to set
-   *          the versioning state of the bucket.</p>
+   * <p>If the bucket owner enables MFA Delete in the bucket versioning configuration, the
+   * bucket owner must include the <code>x-amz-mfa request</code> header and the
+   *    <code>Status</code> and the <code>MfaDelete</code> request elements in a request to set
+   * the versioning state of the bucket.</p>
    *
-   *          <important>
-   *             <p>If you have an object expiration lifecycle policy in your non-versioned bucket and
-   *             you want to maintain the same permanent delete behavior when you enable versioning, you
-   *             must add a noncurrent expiration policy. The noncurrent expiration lifecycle policy will
-   *             manage the deletes of the noncurrent object versions in the version-enabled bucket. (A
-   *             version-enabled bucket maintains one current and zero or more noncurrent object
-   *             versions.) For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html#lifecycle-and-other-bucket-config">Lifecycle and Versioning</a>.</p>
-   *          </important>
+   * <important>
+   *    <p>If you have an object expiration lifecycle policy in your non-versioned bucket and
+   *    you want to maintain the same permanent delete behavior when you enable versioning, you
+   *    must add a noncurrent expiration policy. The noncurrent expiration lifecycle policy will
+   *    manage the deletes of the noncurrent object versions in the version-enabled bucket. (A
+   *    version-enabled bucket maintains one current and zero or more noncurrent object
+   *    versions.) For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html#lifecycle-and-other-bucket-config">Lifecycle and Versioning</a>.</p>
+   * </important>
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html">GetBucketVersioning</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html">GetBucketVersioning</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putBucketVersioning(
     args: PutBucketVersioningCommandInput,
@@ -6482,131 +6482,131 @@ export class S3 extends S3Client {
 
   /**
    * <p>Sets the configuration of the website that is specified in the <code>website</code>
-   *          subresource. To configure a bucket as a website, you can add this subresource on the bucket
-   *          with website configuration information such as the file name of the index document and any
-   *          redirect rules. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html">Hosting Websites on Amazon S3</a>.</p>
+   * subresource. To configure a bucket as a website, you can add this subresource on the bucket
+   * with website configuration information such as the file name of the index document and any
+   * redirect rules. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html">Hosting Websites on Amazon S3</a>.</p>
    *
-   *          <p>This PUT action requires the <code>S3:PutBucketWebsite</code> permission. By default,
-   *          only the bucket owner can configure the website attached to a bucket; however, bucket
-   *          owners can allow other users to set the website configuration by writing a bucket policy
-   *          that grants them the <code>S3:PutBucketWebsite</code> permission.</p>
+   * <p>This PUT action requires the <code>S3:PutBucketWebsite</code> permission. By default,
+   * only the bucket owner can configure the website attached to a bucket; however, bucket
+   * owners can allow other users to set the website configuration by writing a bucket policy
+   * that grants them the <code>S3:PutBucketWebsite</code> permission.</p>
    *
-   *          <p>To redirect all website requests sent to the bucket's website endpoint, you add a
-   *          website configuration with the following elements. Because all requests are sent to another
-   *          website, you don't need to provide index document name for the bucket.</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <code>WebsiteConfiguration</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>RedirectAllRequestsTo</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>HostName</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>Protocol</code>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>To redirect all website requests sent to the bucket's website endpoint, you add a
+   * website configuration with the following elements. Because all requests are sent to another
+   * website, you don't need to provide index document name for the bucket.</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <code>WebsiteConfiguration</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>RedirectAllRequestsTo</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>HostName</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>Protocol</code>
+   *       </p>
+   *    </li>
+   * </ul>
    *
-   *          <p>If you want granular control over redirects, you can use the following elements to add
-   *          routing rules that describe conditions for redirecting requests and information about the
-   *          redirect destination. In this case, the website configuration must provide an index
-   *          document for the bucket, because some requests might not be redirected. </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <code>WebsiteConfiguration</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>IndexDocument</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>Suffix</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>ErrorDocument</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>Key</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>RoutingRules</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>RoutingRule</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>Condition</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>HttpErrorCodeReturnedEquals</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>KeyPrefixEquals</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>Redirect</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>Protocol</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>HostName</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>ReplaceKeyPrefixWith</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>ReplaceKeyWith</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>HttpRedirectCode</code>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>If you want granular control over redirects, you can use the following elements to add
+   * routing rules that describe conditions for redirecting requests and information about the
+   * redirect destination. In this case, the website configuration must provide an index
+   * document for the bucket, because some requests might not be redirected. </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <code>WebsiteConfiguration</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>IndexDocument</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>Suffix</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>ErrorDocument</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>Key</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>RoutingRules</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>RoutingRule</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>Condition</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>HttpErrorCodeReturnedEquals</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>KeyPrefixEquals</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>Redirect</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>Protocol</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>HostName</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>ReplaceKeyPrefixWith</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>ReplaceKeyWith</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>HttpRedirectCode</code>
+   *       </p>
+   *    </li>
+   * </ul>
    *
-   *          <p>Amazon S3 has a limitation of 50 routing rules per website configuration. If you require more
-   *          than 50 routing rules, you can use object redirect. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html">Configuring an
-   *             Object Redirect</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>Amazon S3 has a limitation of 50 routing rules per website configuration. If you require more
+   * than 50 routing rules, you can use object redirect. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html">Configuring an
+   *    Object Redirect</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   public putBucketWebsite(
     args: PutBucketWebsiteCommandInput,
@@ -6639,100 +6639,100 @@ export class S3 extends S3Client {
 
   /**
    * <p>Adds an object to a bucket. You must have WRITE permissions on a bucket to add an object
-   *          to it.</p>
+   * to it.</p>
    *
    *
-   *          <p>Amazon S3 never adds partial objects; if you receive a success response, Amazon S3 added the
-   *          entire object to the bucket.</p>
+   * <p>Amazon S3 never adds partial objects; if you receive a success response, Amazon S3 added the
+   * entire object to the bucket.</p>
    *
-   *          <p>Amazon S3 is a distributed system. If it receives multiple write requests for the same object
-   *          simultaneously, it overwrites all but the last object written. Amazon S3 does not provide object
-   *          locking; if you need this, make sure to build it into your application layer or use
-   *          versioning instead.</p>
+   * <p>Amazon S3 is a distributed system. If it receives multiple write requests for the same object
+   * simultaneously, it overwrites all but the last object written. Amazon S3 does not provide object
+   * locking; if you need this, make sure to build it into your application layer or use
+   * versioning instead.</p>
    *
-   *          <p>To ensure that data is not corrupted traversing the network, use the
-   *             <code>Content-MD5</code> header. When you use this header, Amazon S3 checks the object
-   *          against the provided MD5 value and, if they do not match, returns an error. Additionally,
-   *          you can calculate the MD5 while putting an object to Amazon S3 and compare the returned ETag to
-   *          the calculated MD5 value.</p>
-   *          <note>
-   *             <ul>
-   *                <li>
-   *                   <p>To successfully complete the <code>PutObject</code> request, you must have the
-   *                <code>s3:PutObject</code> in your IAM permissions.</p>
-   *                </li>
-   *                <li>
-   *                   <p>To successfully change the objects acl of your <code>PutObject</code> request,
-   *                you must have the <code>s3:PutObjectAcl</code> in your IAM permissions.</p>
-   *                </li>
-   *                <li>
-   *                   <p> The <code>Content-MD5</code> header is required for any request to upload an object
-   *                   with a retention period configured using Amazon S3 Object Lock. For more information about
-   *                   Amazon S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html">Amazon S3 Object Lock Overview</a>
-   *                   in the <i>Amazon S3 User Guide</i>. </p>
-   *                </li>
-   *             </ul>
-   *          </note>
+   * <p>To ensure that data is not corrupted traversing the network, use the
+   *    <code>Content-MD5</code> header. When you use this header, Amazon S3 checks the object
+   * against the provided MD5 value and, if they do not match, returns an error. Additionally,
+   * you can calculate the MD5 while putting an object to Amazon S3 and compare the returned ETag to
+   * the calculated MD5 value.</p>
+   * <note>
+   *    <ul>
+   *       <li>
+   *          <p>To successfully complete the <code>PutObject</code> request, you must have the
+   *       <code>s3:PutObject</code> in your IAM permissions.</p>
+   *       </li>
+   *       <li>
+   *          <p>To successfully change the objects acl of your <code>PutObject</code> request,
+   *       you must have the <code>s3:PutObjectAcl</code> in your IAM permissions.</p>
+   *       </li>
+   *       <li>
+   *          <p> The <code>Content-MD5</code> header is required for any request to upload an object
+   *          with a retention period configured using Amazon S3 Object Lock. For more information about
+   *          Amazon S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html">Amazon S3 Object Lock Overview</a>
+   *          in the <i>Amazon S3 User Guide</i>. </p>
+   *       </li>
+   *    </ul>
+   * </note>
    *
-   *          <p>
-   *             <b>Server-side Encryption</b>
-   *          </p>
-   *          <p>You can optionally request server-side encryption. With server-side encryption, Amazon S3 encrypts
-   *          your data as it writes it to disks in its data centers and decrypts the data
-   *          when you access it. You have the option to provide your own encryption key or use Amazon Web Services
-   *          managed encryption keys (SSE-S3 or SSE-KMS). For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html">Using Server-Side
-   *             Encryption</a>.</p>
-   *          <p>If you request server-side encryption using Amazon Web Services Key Management Service (SSE-KMS), you can enable
-   *          an S3 Bucket Key at the object-level. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the
-   *          <i>Amazon S3 User Guide</i>.</p>
-   *          <p>
-   *             <b>Access Control List (ACL)-Specific Request
-   *          Headers</b>
-   *          </p>
-   *          <p>You can use headers to grant ACL- based permissions. By default, all objects are
-   *          private. Only the owner has full access control. When adding a new object, you can grant
-   *          permissions to individual Amazon Web Services accounts or to predefined groups defined by Amazon S3. These
-   *          permissions are then added to the ACL on the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List
-   *             (ACL) Overview</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-using-rest-api.html">Managing ACLs Using the REST
-   *             API</a>. </p>
+   * <p>
+   *    <b>Server-side Encryption</b>
+   * </p>
+   * <p>You can optionally request server-side encryption. With server-side encryption, Amazon S3 encrypts
+   * your data as it writes it to disks in its data centers and decrypts the data
+   * when you access it. You have the option to provide your own encryption key or use Amazon Web Services
+   * managed encryption keys (SSE-S3 or SSE-KMS). For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html">Using Server-Side
+   *    Encryption</a>.</p>
+   * <p>If you request server-side encryption using Amazon Web Services Key Management Service (SSE-KMS), you can enable
+   * an S3 Bucket Key at the object-level. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the
+   * <i>Amazon S3 User Guide</i>.</p>
+   * <p>
+   *    <b>Access Control List (ACL)-Specific Request
+   * Headers</b>
+   * </p>
+   * <p>You can use headers to grant ACL- based permissions. By default, all objects are
+   * private. Only the owner has full access control. When adding a new object, you can grant
+   * permissions to individual Amazon Web Services accounts or to predefined groups defined by Amazon S3. These
+   * permissions are then added to the ACL on the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List
+   *    (ACL) Overview</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-using-rest-api.html">Managing ACLs Using the REST
+   *    API</a>. </p>
    *
-   *          <p>
-   *             <b>Storage Class Options</b>
-   *          </p>
-   *          <p>By default, Amazon S3 uses the STANDARD Storage Class to store newly created objects. The
-   *          STANDARD storage class provides high durability and high availability. Depending on
-   *          performance needs, you can specify a different Storage Class. Amazon S3 on Outposts only uses
-   *          the OUTPOSTS Storage Class. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a> in the
-   *          <i>Amazon S3 User Guide</i>.</p>
-   *
-   *
-   *          <p>
-   *             <b>Versioning</b>
-   *          </p>
-   *          <p>If you enable versioning for a bucket, Amazon S3 automatically generates a unique version ID
-   *          for the object being stored. Amazon S3 returns this ID in the response. When you enable
-   *          versioning for a bucket, if Amazon S3 receives multiple write requests for the same object
-   *          simultaneously, it stores all of the objects.</p>
-   *          <p>For more information about versioning, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/AddingObjectstoVersioningEnabledBuckets.html">Adding Objects to
-   *             Versioning Enabled Buckets</a>. For information about returning the versioning state
-   *          of a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html">GetBucketVersioning</a>. </p>
+   * <p>
+   *    <b>Storage Class Options</b>
+   * </p>
+   * <p>By default, Amazon S3 uses the STANDARD Storage Class to store newly created objects. The
+   * STANDARD storage class provides high durability and high availability. Depending on
+   * performance needs, you can specify a different Storage Class. Amazon S3 on Outposts only uses
+   * the OUTPOSTS Storage Class. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a> in the
+   * <i>Amazon S3 User Guide</i>.</p>
    *
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html">CopyObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>
+   *    <b>Versioning</b>
+   * </p>
+   * <p>If you enable versioning for a bucket, Amazon S3 automatically generates a unique version ID
+   * for the object being stored. Amazon S3 returns this ID in the response. When you enable
+   * versioning for a bucket, if Amazon S3 receives multiple write requests for the same object
+   * simultaneously, it stores all of the objects.</p>
+   * <p>For more information about versioning, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/AddingObjectstoVersioningEnabledBuckets.html">Adding Objects to
+   *    Versioning Enabled Buckets</a>. For information about returning the versioning state
+   * of a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html">GetBucketVersioning</a>. </p>
+   *
+   *
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html">CopyObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putObject(args: PutObjectCommandInput, options?: __HttpHandlerOptions): Promise<PutObjectCommandOutput>;
   public putObject(args: PutObjectCommandInput, cb: (err: any, data?: PutObjectCommandOutput) => void): void;
@@ -6759,182 +6759,182 @@ export class S3 extends S3Client {
 
   /**
    * <p>Uses the <code>acl</code> subresource to set the access control list (ACL) permissions
-   *          for a new or existing object in an S3 bucket. You must have <code>WRITE_ACP</code>
-   *          permission to set the ACL of an object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#permissions">What
-   *             permissions can I grant?</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
-   *          <p>Depending on your application needs, you can choose to set
-   *          the ACL on an object using either the request body or the headers. For example, if you have
-   *          an existing application that updates a bucket ACL using the request body, you can continue
-   *          to use that approach. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL) Overview</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * for a new or existing object in an S3 bucket. You must have <code>WRITE_ACP</code>
+   * permission to set the ACL of an object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#permissions">What
+   *    permissions can I grant?</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>Depending on your application needs, you can choose to set
+   * the ACL on an object using either the request body or the headers. For example, if you have
+   * an existing application that updates a bucket ACL using the request body, you can continue
+   * to use that approach. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL) Overview</a> in the <i>Amazon S3 User Guide</i>.</p>
    *
    *
    *
-   *          <p>
-   *             <b>Access Permissions</b>
-   *          </p>
-   *          <p>You can set access permissions using one of the following methods:</p>
-   *          <ul>
-   *             <li>
-   *                <p>Specify a canned ACL with the <code>x-amz-acl</code> request header. Amazon S3 supports
-   *                a set of predefined ACLs, known as canned ACLs. Each canned ACL has a predefined set
-   *                of grantees and permissions. Specify the canned ACL name as the value of
-   *                   <code>x-amz-ac</code>l. If you use this header, you cannot use other access
-   *                control-specific headers in your request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
-   *             </li>
-   *             <li>
-   *                <p>Specify access permissions explicitly with the <code>x-amz-grant-read</code>,
-   *                   <code>x-amz-grant-read-acp</code>, <code>x-amz-grant-write-acp</code>, and
-   *                   <code>x-amz-grant-full-control</code> headers. When using these headers, you
-   *                specify explicit access permissions and grantees (Amazon Web Services accounts or Amazon S3 groups) who
-   *                will receive the permission. If you use these ACL-specific headers, you cannot use
-   *                   <code>x-amz-acl</code> header to set a canned ACL. These parameters map to the set
-   *                of permissions that Amazon S3 supports in an ACL. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL)
-   *                Overview</a>.</p>
+   * <p>
+   *    <b>Access Permissions</b>
+   * </p>
+   * <p>You can set access permissions using one of the following methods:</p>
+   * <ul>
+   *    <li>
+   *       <p>Specify a canned ACL with the <code>x-amz-acl</code> request header. Amazon S3 supports
+   *       a set of predefined ACLs, known as canned ACLs. Each canned ACL has a predefined set
+   *       of grantees and permissions. Specify the canned ACL name as the value of
+   *          <code>x-amz-ac</code>l. If you use this header, you cannot use other access
+   *       control-specific headers in your request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
+   *    </li>
+   *    <li>
+   *       <p>Specify access permissions explicitly with the <code>x-amz-grant-read</code>,
+   *          <code>x-amz-grant-read-acp</code>, <code>x-amz-grant-write-acp</code>, and
+   *          <code>x-amz-grant-full-control</code> headers. When using these headers, you
+   *       specify explicit access permissions and grantees (Amazon Web Services accounts or Amazon S3 groups) who
+   *       will receive the permission. If you use these ACL-specific headers, you cannot use
+   *          <code>x-amz-acl</code> header to set a canned ACL. These parameters map to the set
+   *       of permissions that Amazon S3 supports in an ACL. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL)
+   *       Overview</a>.</p>
    *
-   *                <p>You specify each grantee as a type=value pair, where the type is one of the
-   *                following:</p>
+   *       <p>You specify each grantee as a type=value pair, where the type is one of the
+   *       following:</p>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <code>id</code> – if the value specified is the canonical user ID of an Amazon Web Services account</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <code>uri</code> – if you are granting permissions to a predefined
+   *             group</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <code>emailAddress</code> – if the value specified is the email address of
+   *             an Amazon Web Services account</p>
+   *             <note>
+   *                <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
    *                <ul>
    *                   <li>
-   *                      <p>
-   *                         <code>id</code> – if the value specified is the canonical user ID of an Amazon Web Services account</p>
+   *                      <p>US East (N. Virginia)</p>
    *                   </li>
    *                   <li>
-   *                      <p>
-   *                         <code>uri</code> – if you are granting permissions to a predefined
-   *                      group</p>
+   *                      <p>US West (N. California)</p>
    *                   </li>
    *                   <li>
-   *                      <p>
-   *                         <code>emailAddress</code> – if the value specified is the email address of
-   *                      an Amazon Web Services account</p>
-   *                      <note>
-   *                         <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
-   *                         <ul>
-   *                            <li>
-   *                               <p>US East (N. Virginia)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>US West (N. California)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p> US West (Oregon)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p> Asia Pacific (Singapore)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>Asia Pacific (Sydney)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>Asia Pacific (Tokyo)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>Europe (Ireland)</p>
-   *                            </li>
-   *                            <li>
-   *                               <p>South America (São Paulo)</p>
-   *                            </li>
-   *                         </ul>
-   *                         <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
-   *                      </note>
+   *                      <p> US West (Oregon)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p> Asia Pacific (Singapore)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p>Asia Pacific (Sydney)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p>Asia Pacific (Tokyo)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p>Europe (Ireland)</p>
+   *                   </li>
+   *                   <li>
+   *                      <p>South America (São Paulo)</p>
    *                   </li>
    *                </ul>
-   *                <p>For example, the following <code>x-amz-grant-read</code> header grants list
-   *                objects permission to the two Amazon Web Services accounts identified by their email
-   *                addresses.</p>
-   *                <p>
-   *                   <code>x-amz-grant-read: emailAddress="xyz@amazon.com",
-   *                   emailAddress="abc@amazon.com" </code>
-   *                </p>
+   *                <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
+   *             </note>
+   *          </li>
+   *       </ul>
+   *       <p>For example, the following <code>x-amz-grant-read</code> header grants list
+   *       objects permission to the two Amazon Web Services accounts identified by their email
+   *       addresses.</p>
+   *       <p>
+   *          <code>x-amz-grant-read: emailAddress="xyz@amazon.com",
+   *          emailAddress="abc@amazon.com" </code>
+   *       </p>
    *
-   *             </li>
-   *          </ul>
-   *          <p>You can use either a canned ACL or specify access permissions explicitly. You cannot do
-   *          both.</p>
-   *          <p>
-   *             <b>Grantee Values</b>
-   *          </p>
-   *          <p>You can specify the person (grantee) to whom you're assigning access rights (using
-   *          request elements) in the following ways:</p>
+   *    </li>
+   * </ul>
+   * <p>You can use either a canned ACL or specify access permissions explicitly. You cannot do
+   * both.</p>
+   * <p>
+   *    <b>Grantee Values</b>
+   * </p>
+   * <p>You can specify the person (grantee) to whom you're assigning access rights (using
+   * request elements) in the following ways:</p>
+   * <ul>
+   *    <li>
+   *       <p>By the person's ID:</p>
+   *       <p>
+   *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   *          xsi:type="CanonicalUser"><ID><>ID<></ID><DisplayName><>GranteesEmail<></DisplayName>
+   *          </Grantee></code>
+   *       </p>
+   *       <p>DisplayName is optional and ignored in the request.</p>
+   *    </li>
+   *    <li>
+   *       <p>By URI:</p>
+   *       <p>
+   *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   *          xsi:type="Group"><URI><>http://acs.amazonaws.com/groups/global/AuthenticatedUsers<></URI></Grantee></code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>By Email address:</p>
+   *       <p>
+   *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   *          xsi:type="AmazonCustomerByEmail"><EmailAddress><>Grantees@email.com<></EmailAddress>lt;/Grantee></code>
+   *       </p>
+   *       <p>The grantee is resolved to the CanonicalUser and, in a response to a GET Object
+   *       acl request, appears as the CanonicalUser.</p>
+   *       <note>
+   *          <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
    *          <ul>
    *             <li>
-   *                <p>By the person's ID:</p>
-   *                <p>
-   *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   *                   xsi:type="CanonicalUser"><ID><>ID<></ID><DisplayName><>GranteesEmail<></DisplayName>
-   *                   </Grantee></code>
-   *                </p>
-   *                <p>DisplayName is optional and ignored in the request.</p>
+   *                <p>US East (N. Virginia)</p>
    *             </li>
    *             <li>
-   *                <p>By URI:</p>
-   *                <p>
-   *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   *                   xsi:type="Group"><URI><>http://acs.amazonaws.com/groups/global/AuthenticatedUsers<></URI></Grantee></code>
-   *                </p>
+   *                <p>US West (N. California)</p>
    *             </li>
    *             <li>
-   *                <p>By Email address:</p>
-   *                <p>
-   *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   *                   xsi:type="AmazonCustomerByEmail"><EmailAddress><>Grantees@email.com<></EmailAddress>lt;/Grantee></code>
-   *                </p>
-   *                <p>The grantee is resolved to the CanonicalUser and, in a response to a GET Object
-   *                acl request, appears as the CanonicalUser.</p>
-   *                <note>
-   *                   <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
-   *                   <ul>
-   *                      <li>
-   *                         <p>US East (N. Virginia)</p>
-   *                      </li>
-   *                      <li>
-   *                         <p>US West (N. California)</p>
-   *                      </li>
-   *                      <li>
-   *                         <p> US West (Oregon)</p>
-   *                      </li>
-   *                      <li>
-   *                         <p> Asia Pacific (Singapore)</p>
-   *                      </li>
-   *                      <li>
-   *                         <p>Asia Pacific (Sydney)</p>
-   *                      </li>
-   *                      <li>
-   *                         <p>Asia Pacific (Tokyo)</p>
-   *                      </li>
-   *                      <li>
-   *                         <p>Europe (Ireland)</p>
-   *                      </li>
-   *                      <li>
-   *                         <p>South America (São Paulo)</p>
-   *                      </li>
-   *                   </ul>
-   *                   <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
-   *                </note>
+   *                <p> US West (Oregon)</p>
+   *             </li>
+   *             <li>
+   *                <p> Asia Pacific (Singapore)</p>
+   *             </li>
+   *             <li>
+   *                <p>Asia Pacific (Sydney)</p>
+   *             </li>
+   *             <li>
+   *                <p>Asia Pacific (Tokyo)</p>
+   *             </li>
+   *             <li>
+   *                <p>Europe (Ireland)</p>
+   *             </li>
+   *             <li>
+   *                <p>South America (São Paulo)</p>
    *             </li>
    *          </ul>
-   *          <p>
-   *             <b>Versioning</b>
-   *          </p>
-   *          <p>The ACL of an object is set at the object version level. By default, PUT sets the ACL of
-   *          the current version of an object. To set the ACL of a different version, use the
-   *             <code>versionId</code> subresource.</p>
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html">CopyObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   *          <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
+   *       </note>
+   *    </li>
+   * </ul>
+   * <p>
+   *    <b>Versioning</b>
+   * </p>
+   * <p>The ACL of an object is set at the object version level. By default, PUT sets the ACL of
+   * the current version of an object. To set the ACL of a different version, use the
+   *    <code>versionId</code> subresource.</p>
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html">CopyObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putObjectAcl(
     args: PutObjectAclCommandInput,
@@ -6964,9 +6964,9 @@ export class S3 extends S3Client {
 
   /**
    * <p>Applies a Legal Hold configuration to the specified object. For more information, see
-   *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking
-   *             Objects</a>.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking
+   *    Objects</a>.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   public putObjectLegalHold(
     args: PutObjectLegalHoldCommandInput,
@@ -6999,26 +6999,26 @@ export class S3 extends S3Client {
 
   /**
    * <p>Places an Object Lock configuration on the specified bucket. The rule specified in the
-   *          Object Lock configuration will be applied by default to every new object placed in the
-   *          specified bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking Objects</a>.
+   * Object Lock configuration will be applied by default to every new object placed in the
+   * specified bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking Objects</a>.
    *       </p>
-   *          <note>
-   *             <ul>
-   *                <li>
-   *                   <p>The <code>DefaultRetention</code> settings require both a mode and a
-   *                period.</p>
-   *                </li>
-   *                <li>
-   *                   <p>The <code>DefaultRetention</code> period can be either <code>Days</code>
-   *                or <code>Years</code> but you must select one. You cannot specify <code>Days</code>
-   *                and <code>Years</code> at the same time.</p>
-   *                </li>
-   *                <li>
-   *                   <p>You can only enable Object Lock for new buckets. If you want to turn on
-   *                Object Lock for an existing bucket, contact Amazon Web Services Support.</p>
-   *                </li>
-   *             </ul>
-   *          </note>
+   * <note>
+   *    <ul>
+   *       <li>
+   *          <p>The <code>DefaultRetention</code> settings require both a mode and a
+   *       period.</p>
+   *       </li>
+   *       <li>
+   *          <p>The <code>DefaultRetention</code> period can be either <code>Days</code>
+   *       or <code>Years</code> but you must select one. You cannot specify <code>Days</code>
+   *       and <code>Years</code> at the same time.</p>
+   *       </li>
+   *       <li>
+   *          <p>You can only enable Object Lock for new buckets. If you want to turn on
+   *       Object Lock for an existing bucket, contact Amazon Web Services Support.</p>
+   *       </li>
+   *    </ul>
+   * </note>
    */
   public putObjectLockConfiguration(
     args: PutObjectLockConfigurationCommandInput,
@@ -7051,18 +7051,18 @@ export class S3 extends S3Client {
 
   /**
    * <p>Places an Object Retention configuration on an object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking Objects</a>.
-   *           Users or accounts require the <code>s3:PutObjectRetention</code> permission in order to place
-   *           an Object Retention configuration on objects. Bypassing a Governance Retention configuration
-   *           requires the <code>s3:BypassGovernanceRetention</code> permission.
-   *          </p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   *  Users or accounts require the <code>s3:PutObjectRetention</code> permission in order to place
+   *  an Object Retention configuration on objects. Bypassing a Governance Retention configuration
+   *  requires the <code>s3:BypassGovernanceRetention</code> permission.
+   * </p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    *
-   *          <p>
-   *             <b>Permissions</b>
-   *          </p>
-   *          <p>When the Object Lock retention mode is set to compliance, you need <code>s3:PutObjectRetention</code> and
-   *          <code>s3:BypassGovernanceRetention</code> permissions. For other requests to <code>PutObjectRetention</code>,
-   *          only <code>s3:PutObjectRetention</code> permissions are required.</p>
+   * <p>
+   *    <b>Permissions</b>
+   * </p>
+   * <p>When the Object Lock retention mode is set to compliance, you need <code>s3:PutObjectRetention</code> and
+   * <code>s3:BypassGovernanceRetention</code> permissions. For other requests to <code>PutObjectRetention</code>,
+   * only <code>s3:PutObjectRetention</code> permissions are required.</p>
    */
   public putObjectRetention(
     args: PutObjectRetentionCommandInput,
@@ -7095,109 +7095,109 @@ export class S3 extends S3Client {
 
   /**
    * <p>Sets the supplied tag-set to an object that already exists in a bucket.</p>
-   *          <p>A tag is a key-value pair. You can associate tags with an object by sending a PUT
-   *          request against the tagging subresource that is associated with the object. You can
-   *          retrieve tags by sending a GET request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a>.</p>
+   * <p>A tag is a key-value pair. You can associate tags with an object by sending a PUT
+   * request against the tagging subresource that is associated with the object. You can
+   * retrieve tags by sending a GET request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a>.</p>
    *
-   *          <p>For tagging-related restrictions related to characters and encodings, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html">Tag
-   *             Restrictions</a>. Note that Amazon S3 limits the maximum number of tags to 10 tags per
-   *          object.</p>
+   * <p>For tagging-related restrictions related to characters and encodings, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html">Tag
+   *    Restrictions</a>. Note that Amazon S3 limits the maximum number of tags to 10 tags per
+   * object.</p>
    *
-   *          <p>To use this operation, you must have permission to perform the
-   *             <code>s3:PutObjectTagging</code> action. By default, the bucket owner has this
-   *          permission and can grant this permission to others.</p>
+   * <p>To use this operation, you must have permission to perform the
+   *    <code>s3:PutObjectTagging</code> action. By default, the bucket owner has this
+   * permission and can grant this permission to others.</p>
    *
-   *          <p>To put tags of any other version, use the <code>versionId</code> query parameter. You
-   *          also need permission for the <code>s3:PutObjectVersionTagging</code> action.</p>
+   * <p>To put tags of any other version, use the <code>versionId</code> query parameter. You
+   * also need permission for the <code>s3:PutObjectVersionTagging</code> action.</p>
    *
-   *          <p>For information about the Amazon S3 object tagging feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html">Object Tagging</a>.</p>
-   *
-   *
-   *          <p class="title">
-   *             <b>Special Errors</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code: InvalidTagError </i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause: The tag provided was not a valid tag. This error can occur
-   *                         if the tag did not pass input validation. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html">Object Tagging</a>.</i>
-   *                      </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code: MalformedXMLError </i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause: The XML provided does not match the schema.</i>
-   *                      </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code: OperationAbortedError </i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause: A conflicting conditional action is currently in
-   *                         progress against this resource. Please try again.</i>
-   *                      </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code: InternalError</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause: The service was unable to apply the provided tag to the
-   *                         object.</i>
-   *                      </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *          </ul>
+   * <p>For information about the Amazon S3 object tagging feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html">Object Tagging</a>.</p>
    *
    *
+   * <p class="title">
+   *    <b>Special Errors</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code: InvalidTagError </i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause: The tag provided was not a valid tag. This error can occur
+   *                if the tag did not pass input validation. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html">Object Tagging</a>.</i>
+   *             </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code: MalformedXMLError </i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause: The XML provided does not match the schema.</i>
+   *             </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code: OperationAbortedError </i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause: A conflicting conditional action is currently in
+   *                progress against this resource. Please try again.</i>
+   *             </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code: InternalError</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause: The service was unable to apply the provided tag to the
+   *                object.</i>
+   *             </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   * </ul>
    *
    *
    *
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectTagging.html">DeleteObjectTagging</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   *
+   *
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectTagging.html">DeleteObjectTagging</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putObjectTagging(
     args: PutObjectTaggingCommandInput,
@@ -7230,50 +7230,50 @@ export class S3 extends S3Client {
 
   /**
    * <p>Creates or modifies the <code>PublicAccessBlock</code> configuration for an Amazon S3 bucket.
-   *          To use this operation, you must have the <code>s3:PutBucketPublicAccessBlock</code>
-   *          permission. For more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a
-   *          Policy</a>.</p>
+   * To use this operation, you must have the <code>s3:PutBucketPublicAccessBlock</code>
+   * permission. For more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a
+   * Policy</a>.</p>
    *
-   *          <important>
-   *             <p>When Amazon S3 evaluates the <code>PublicAccessBlock</code> configuration for a bucket or
-   *             an object, it checks the <code>PublicAccessBlock</code> configuration for both the
-   *             bucket (or the bucket that contains the object) and the bucket owner's account. If the
-   *                <code>PublicAccessBlock</code> configurations are different between the bucket and
-   *             the account, Amazon S3 uses the most restrictive combination of the bucket-level and
-   *             account-level settings.</p>
-   *          </important>
-   *
-   *
-   *          <p>For more information about when Amazon S3 considers a bucket or an object public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a>.</p>
+   * <important>
+   *    <p>When Amazon S3 evaluates the <code>PublicAccessBlock</code> configuration for a bucket or
+   *    an object, it checks the <code>PublicAccessBlock</code> configuration for both the
+   *    bucket (or the bucket that contains the object) and the bucket owner's account. If the
+   *       <code>PublicAccessBlock</code> configurations are different between the bucket and
+   *    the account, Amazon S3 uses the most restrictive combination of the bucket-level and
+   *    account-level settings.</p>
+   * </important>
    *
    *
+   * <p>For more information about when Amazon S3 considers a bucket or an object public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a>.</p>
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletePublicAccessBlock.html">DeletePublicAccessBlock</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicyStatus.html">GetBucketPolicyStatus</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
-   *                   Public Access</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   *
+   *
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletePublicAccessBlock.html">DeletePublicAccessBlock</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicyStatus.html">GetBucketPolicyStatus</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
+   *          Public Access</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public putPublicAccessBlock(
     args: PutPublicAccessBlockCommandInput,
@@ -7306,297 +7306,297 @@ export class S3 extends S3Client {
 
   /**
    * <p>Restores an archived copy of an object back into Amazon S3</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
-   *          <p>This action performs the following types of requests: </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <code>select</code> - Perform a select query on an archived object</p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>restore an archive</code> - Restore an archived object</p>
-   *             </li>
-   *          </ul>
-   *          <p>To use this operation, you must have permissions to perform the
-   *             <code>s3:RestoreObject</code> action. The bucket owner has this permission by default
-   *          and can grant this permission to others. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
-   *             Resources</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>
-   *             <b>Querying Archives with Select Requests</b>
-   *          </p>
-   *          <p>You use a select type of request to perform SQL queries on archived objects. The
-   *          archived objects that are being queried by the select request must be formatted as
-   *          uncompressed comma-separated values (CSV) files. You can run queries and custom analytics
-   *          on your archived data without having to restore your data to a hotter Amazon S3 tier. For an
-   *          overview about select requests, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/querying-glacier-archives.html">Querying Archived Objects</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When making a select request, do the following:</p>
-   *          <ul>
-   *             <li>
-   *                <p>Define an output location for the select query's output. This must be an Amazon S3
-   *                bucket in the same Amazon Web Services Region as the bucket that contains the archive object that is
-   *                being queried. The Amazon Web Services account that initiates the job must have permissions to write
-   *                to the S3 bucket. You can specify the storage class and encryption for the output
-   *                objects stored in the bucket. For more information about output, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/querying-glacier-archives.html">Querying Archived Objects</a>
-   *                in the <i>Amazon S3 User Guide</i>.</p>
-   *                <p>For more information about the <code>S3</code> structure in the request body, see
-   *                the following:</p>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Managing Access with
-   *                         ACLs</a> in the <i>Amazon S3 User Guide</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Protecting Data Using
-   *                         Server-Side Encryption</a> in the
-   *                      <i>Amazon S3 User Guide</i>
-   *                      </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <p>Define the SQL expression for the <code>SELECT</code> type of restoration for your
-   *                query in the request body's <code>SelectParameters</code> structure. You can use
-   *                expressions like the following examples.</p>
-   *                <ul>
-   *                   <li>
-   *                      <p>The following expression returns all records from the specified
-   *                      object.</p>
-   *                      <p>
-   *                         <code>SELECT * FROM Object</code>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>Assuming that you are not using any headers for data stored in the object,
-   *                      you can specify columns with positional headers.</p>
-   *                      <p>
-   *                         <code>SELECT s._1, s._2 FROM Object s WHERE s._3 > 100</code>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>If you have headers and you set the <code>fileHeaderInfo</code> in the
-   *                         <code>CSV</code> structure in the request body to <code>USE</code>, you can
-   *                      specify headers in the query. (If you set the <code>fileHeaderInfo</code> field
-   *                      to <code>IGNORE</code>, the first row is skipped for the query.) You cannot mix
-   *                      ordinal positions with header column names. </p>
-   *                      <p>
-   *                         <code>SELECT s.Id, s.FirstName, s.SSN FROM S3Object s</code>
-   *                      </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *          </ul>
-   *          <p>For more information about using SQL with S3 Glacier Select restore, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference.html">SQL Reference for Amazon S3 Select and
-   *             S3 Glacier Select</a> in the <i>Amazon S3 User Guide</i>. </p>
-   *          <p>When making a select request, you can also do the following:</p>
-   *          <ul>
-   *             <li>
-   *                <p>To expedite your queries, specify the <code>Expedited</code> tier. For more
-   *                information about tiers, see "Restoring Archives," later in this topic.</p>
-   *             </li>
-   *             <li>
-   *                <p>Specify details about the data serialization format of both the input object that
-   *                is being queried and the serialization of the CSV-encoded query results.</p>
-   *             </li>
-   *          </ul>
-   *          <p>The following are additional important facts about the select feature:</p>
-   *          <ul>
-   *             <li>
-   *                <p>The output results are new Amazon S3 objects. Unlike archive retrievals, they are
-   *                stored until explicitly deleted-manually or through a lifecycle policy.</p>
-   *             </li>
-   *             <li>
-   *                <p>You can issue more than one select request on the same Amazon S3 object. Amazon S3 doesn't
-   *                deduplicate requests, so avoid issuing duplicate requests.</p>
-   *             </li>
-   *             <li>
-   *                <p> Amazon S3 accepts a select request even if the object has already been restored. A
-   *                select request doesn’t return error response <code>409</code>.</p>
-   *             </li>
-   *          </ul>
-   *          <p>
-   *             <b>Restoring objects</b>
-   *          </p>
-   *          <p>Objects that you archive to the S3 Glacier or
-   *          S3 Glacier Deep Archive storage class, and S3 Intelligent-Tiering Archive or
-   *          S3 Intelligent-Tiering Deep Archive tiers are not accessible in real time. For objects in
-   *          Archive Access or Deep Archive Access tiers you must first initiate a restore request, and
-   *          then wait until the object is moved into the Frequent Access tier. For objects in
-   *          S3 Glacier or S3 Glacier Deep Archive storage classes you must
-   *          first initiate a restore request, and then wait until a temporary copy of the object is
-   *          available. To access an archived object, you must restore the object for the duration
-   *          (number of days) that you specify.</p>
-   *          <p>To restore a specific object version, you can provide a version ID. If you don't provide
-   *          a version ID, Amazon S3 restores the current version.</p>
-   *          <p>When restoring an archived object (or using a select request), you can specify one of
-   *          the following data access tier options in the <code>Tier</code> element of the request
-   *          body: </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <b>
-   *                      <code>Expedited</code>
-   *                   </b> - Expedited retrievals
-   *                allow you to quickly access your data stored in the S3 Glacier
-   *                storage class or S3 Intelligent-Tiering Archive tier when occasional urgent requests for a
-   *                subset of archives are required. For all but the largest archived objects (250 MB+),
-   *                data accessed using Expedited retrievals is typically made available within 1–5
-   *                minutes. Provisioned capacity ensures that retrieval capacity for Expedited
-   *                retrievals is available when you need it. Expedited retrievals and provisioned
-   *                capacity are not available for objects stored in the S3 Glacier Deep Archive
-   *                storage class or S3 Intelligent-Tiering Deep Archive tier.</p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <b>
-   *                      <code>Standard</code>
-   *                   </b> - Standard retrievals allow
-   *                you to access any of your archived objects within several hours. This is the default
-   *                option for retrieval requests that do not specify the retrieval option. Standard
-   *                retrievals typically finish within 3–5 hours for objects stored in the
-   *                S3 Glacier storage class or S3 Intelligent-Tiering Archive tier. They
-   *                typically finish within 12 hours for objects stored in the
-   *                S3 Glacier Deep Archive storage class or S3 Intelligent-Tiering Deep Archive tier.
-   *                Standard retrievals are free for objects stored in S3 Intelligent-Tiering.</p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <b>
-   *                      <code>Bulk</code>
-   *                   </b> - Bulk retrievals are the
-   *                lowest-cost retrieval option in S3 Glacier, enabling you to retrieve large amounts,
-   *                even petabytes, of data inexpensively. Bulk retrievals typically finish within 5–12
-   *                hours for objects stored in the S3 Glacier storage class or
-   *                S3 Intelligent-Tiering Archive tier. They typically finish within 48 hours for objects stored
-   *                in the S3 Glacier Deep Archive storage class or S3 Intelligent-Tiering Deep Archive tier.
-   *                Bulk retrievals are free for objects stored in S3 Intelligent-Tiering.</p>
-   *             </li>
-   *          </ul>
-   *          <p>For more information about archive retrieval options and provisioned capacity for
-   *             <code>Expedited</code> data access, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html">Restoring Archived Objects</a> in the <i>Amazon S3 User Guide</i>. </p>
-   *          <p>You can use Amazon S3 restore speed upgrade to change the restore speed to a faster speed
-   *          while it is in progress. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html#restoring-objects-upgrade-tier.title.html">
-   *             Upgrading the speed of an in-progress restore</a> in the
-   *             <i>Amazon S3 User Guide</i>. </p>
-   *          <p>To get the status of object restoration, you can send a <code>HEAD</code> request.
-   *          Operations return the <code>x-amz-restore</code> header, which provides information about
-   *          the restoration status, in the response. You can use Amazon S3 event notifications to notify you
-   *          when a restore is initiated or completed. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Amazon S3 Event Notifications</a> in
-   *          the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>After restoring an archived object, you can update the restoration period by reissuing
-   *          the request with a new period. Amazon S3 updates the restoration period relative to the current
-   *          time and charges only for the request-there are no data transfer charges. You cannot
-   *          update the restoration period when Amazon S3 is actively processing your current restore request
-   *          for the object.</p>
-   *          <p>If your bucket has a lifecycle configuration with a rule that includes an expiration
-   *          action, the object expiration overrides the life span that you specify in a restore
-   *          request. For example, if you restore an object copy for 10 days, but the object is
-   *          scheduled to expire in 3 days, Amazon S3 deletes the object in 3 days. For more information
-   *          about lifecycle configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Object Lifecycle Management</a> in
-   *             <i>Amazon S3 User Guide</i>.</p>
-   *          <p>
-   *             <b>Responses</b>
-   *          </p>
-   *          <p>A successful action returns either the <code>200 OK</code> or <code>202
-   *             Accepted</code> status code. </p>
-   *          <ul>
-   *             <li>
-   *                <p>If the object is not previously restored, then Amazon S3 returns <code>202
-   *                   Accepted</code> in the response. </p>
-   *             </li>
-   *             <li>
-   *                <p>If the object is previously restored, Amazon S3 returns <code>200 OK</code> in the
-   *                response. </p>
-   *             </li>
-   *          </ul>
-   *          <p class="title">
-   *             <b>Special Errors</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code: RestoreAlreadyInProgress</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause: Object restore is already in progress. (This error does not
-   *                         apply to SELECT type requests.)</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code: 409 Conflict</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix: Client</i>
-   *                      </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code: GlacierExpeditedRetrievalNotAvailable</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause: expedited retrievals are currently not available. Try again
-   *                         later. (Returned if there is insufficient capacity to process the Expedited
-   *                         request. This error applies only to Expedited retrievals and not to
-   *                         S3 Standard or Bulk retrievals.)</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code: 503</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix: N/A</i>
-   *                      </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *          </ul>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action performs the following types of requests: </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <code>select</code> - Perform a select query on an archived object</p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>restore an archive</code> - Restore an archived object</p>
+   *    </li>
+   * </ul>
+   * <p>To use this operation, you must have permissions to perform the
+   *    <code>s3:RestoreObject</code> action. The bucket owner has this permission by default
+   * and can grant this permission to others. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+   *    Resources</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>
+   *    <b>Querying Archives with Select Requests</b>
+   * </p>
+   * <p>You use a select type of request to perform SQL queries on archived objects. The
+   * archived objects that are being queried by the select request must be formatted as
+   * uncompressed comma-separated values (CSV) files. You can run queries and custom analytics
+   * on your archived data without having to restore your data to a hotter Amazon S3 tier. For an
+   * overview about select requests, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/querying-glacier-archives.html">Querying Archived Objects</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When making a select request, do the following:</p>
+   * <ul>
+   *    <li>
+   *       <p>Define an output location for the select query's output. This must be an Amazon S3
+   *       bucket in the same Amazon Web Services Region as the bucket that contains the archive object that is
+   *       being queried. The Amazon Web Services account that initiates the job must have permissions to write
+   *       to the S3 bucket. You can specify the storage class and encryption for the output
+   *       objects stored in the bucket. For more information about output, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/querying-glacier-archives.html">Querying Archived Objects</a>
+   *       in the <i>Amazon S3 User Guide</i>.</p>
+   *       <p>For more information about the <code>S3</code> structure in the request body, see
+   *       the following:</p>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Managing Access with
+   *                ACLs</a> in the <i>Amazon S3 User Guide</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Protecting Data Using
+   *                Server-Side Encryption</a> in the
+   *             <i>Amazon S3 User Guide</i>
+   *             </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <p>Define the SQL expression for the <code>SELECT</code> type of restoration for your
+   *       query in the request body's <code>SelectParameters</code> structure. You can use
+   *       expressions like the following examples.</p>
+   *       <ul>
+   *          <li>
+   *             <p>The following expression returns all records from the specified
+   *             object.</p>
+   *             <p>
+   *                <code>SELECT * FROM Object</code>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>Assuming that you are not using any headers for data stored in the object,
+   *             you can specify columns with positional headers.</p>
+   *             <p>
+   *                <code>SELECT s._1, s._2 FROM Object s WHERE s._3 > 100</code>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>If you have headers and you set the <code>fileHeaderInfo</code> in the
+   *                <code>CSV</code> structure in the request body to <code>USE</code>, you can
+   *             specify headers in the query. (If you set the <code>fileHeaderInfo</code> field
+   *             to <code>IGNORE</code>, the first row is skipped for the query.) You cannot mix
+   *             ordinal positions with header column names. </p>
+   *             <p>
+   *                <code>SELECT s.Id, s.FirstName, s.SSN FROM S3Object s</code>
+   *             </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   * </ul>
+   * <p>For more information about using SQL with S3 Glacier Select restore, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference.html">SQL Reference for Amazon S3 Select and
+   *    S3 Glacier Select</a> in the <i>Amazon S3 User Guide</i>. </p>
+   * <p>When making a select request, you can also do the following:</p>
+   * <ul>
+   *    <li>
+   *       <p>To expedite your queries, specify the <code>Expedited</code> tier. For more
+   *       information about tiers, see "Restoring Archives," later in this topic.</p>
+   *    </li>
+   *    <li>
+   *       <p>Specify details about the data serialization format of both the input object that
+   *       is being queried and the serialization of the CSV-encoded query results.</p>
+   *    </li>
+   * </ul>
+   * <p>The following are additional important facts about the select feature:</p>
+   * <ul>
+   *    <li>
+   *       <p>The output results are new Amazon S3 objects. Unlike archive retrievals, they are
+   *       stored until explicitly deleted-manually or through a lifecycle policy.</p>
+   *    </li>
+   *    <li>
+   *       <p>You can issue more than one select request on the same Amazon S3 object. Amazon S3 doesn't
+   *       deduplicate requests, so avoid issuing duplicate requests.</p>
+   *    </li>
+   *    <li>
+   *       <p> Amazon S3 accepts a select request even if the object has already been restored. A
+   *       select request doesn’t return error response <code>409</code>.</p>
+   *    </li>
+   * </ul>
+   * <p>
+   *    <b>Restoring objects</b>
+   * </p>
+   * <p>Objects that you archive to the S3 Glacier or
+   * S3 Glacier Deep Archive storage class, and S3 Intelligent-Tiering Archive or
+   * S3 Intelligent-Tiering Deep Archive tiers are not accessible in real time. For objects in
+   * Archive Access or Deep Archive Access tiers you must first initiate a restore request, and
+   * then wait until the object is moved into the Frequent Access tier. For objects in
+   * S3 Glacier or S3 Glacier Deep Archive storage classes you must
+   * first initiate a restore request, and then wait until a temporary copy of the object is
+   * available. To access an archived object, you must restore the object for the duration
+   * (number of days) that you specify.</p>
+   * <p>To restore a specific object version, you can provide a version ID. If you don't provide
+   * a version ID, Amazon S3 restores the current version.</p>
+   * <p>When restoring an archived object (or using a select request), you can specify one of
+   * the following data access tier options in the <code>Tier</code> element of the request
+   * body: </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <b>
+   *             <code>Expedited</code>
+   *          </b> - Expedited retrievals
+   *       allow you to quickly access your data stored in the S3 Glacier
+   *       storage class or S3 Intelligent-Tiering Archive tier when occasional urgent requests for a
+   *       subset of archives are required. For all but the largest archived objects (250 MB+),
+   *       data accessed using Expedited retrievals is typically made available within 1–5
+   *       minutes. Provisioned capacity ensures that retrieval capacity for Expedited
+   *       retrievals is available when you need it. Expedited retrievals and provisioned
+   *       capacity are not available for objects stored in the S3 Glacier Deep Archive
+   *       storage class or S3 Intelligent-Tiering Deep Archive tier.</p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <b>
+   *             <code>Standard</code>
+   *          </b> - Standard retrievals allow
+   *       you to access any of your archived objects within several hours. This is the default
+   *       option for retrieval requests that do not specify the retrieval option. Standard
+   *       retrievals typically finish within 3–5 hours for objects stored in the
+   *       S3 Glacier storage class or S3 Intelligent-Tiering Archive tier. They
+   *       typically finish within 12 hours for objects stored in the
+   *       S3 Glacier Deep Archive storage class or S3 Intelligent-Tiering Deep Archive tier.
+   *       Standard retrievals are free for objects stored in S3 Intelligent-Tiering.</p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <b>
+   *             <code>Bulk</code>
+   *          </b> - Bulk retrievals are the
+   *       lowest-cost retrieval option in S3 Glacier, enabling you to retrieve large amounts,
+   *       even petabytes, of data inexpensively. Bulk retrievals typically finish within 5–12
+   *       hours for objects stored in the S3 Glacier storage class or
+   *       S3 Intelligent-Tiering Archive tier. They typically finish within 48 hours for objects stored
+   *       in the S3 Glacier Deep Archive storage class or S3 Intelligent-Tiering Deep Archive tier.
+   *       Bulk retrievals are free for objects stored in S3 Intelligent-Tiering.</p>
+   *    </li>
+   * </ul>
+   * <p>For more information about archive retrieval options and provisioned capacity for
+   *    <code>Expedited</code> data access, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html">Restoring Archived Objects</a> in the <i>Amazon S3 User Guide</i>. </p>
+   * <p>You can use Amazon S3 restore speed upgrade to change the restore speed to a faster speed
+   * while it is in progress. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html#restoring-objects-upgrade-tier.title.html">
+   *    Upgrading the speed of an in-progress restore</a> in the
+   *    <i>Amazon S3 User Guide</i>. </p>
+   * <p>To get the status of object restoration, you can send a <code>HEAD</code> request.
+   * Operations return the <code>x-amz-restore</code> header, which provides information about
+   * the restoration status, in the response. You can use Amazon S3 event notifications to notify you
+   * when a restore is initiated or completed. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Amazon S3 Event Notifications</a> in
+   * the <i>Amazon S3 User Guide</i>.</p>
+   * <p>After restoring an archived object, you can update the restoration period by reissuing
+   * the request with a new period. Amazon S3 updates the restoration period relative to the current
+   * time and charges only for the request-there are no data transfer charges. You cannot
+   * update the restoration period when Amazon S3 is actively processing your current restore request
+   * for the object.</p>
+   * <p>If your bucket has a lifecycle configuration with a rule that includes an expiration
+   * action, the object expiration overrides the life span that you specify in a restore
+   * request. For example, if you restore an object copy for 10 days, but the object is
+   * scheduled to expire in 3 days, Amazon S3 deletes the object in 3 days. For more information
+   * about lifecycle configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Object Lifecycle Management</a> in
+   *    <i>Amazon S3 User Guide</i>.</p>
+   * <p>
+   *    <b>Responses</b>
+   * </p>
+   * <p>A successful action returns either the <code>200 OK</code> or <code>202
+   *    Accepted</code> status code. </p>
+   * <ul>
+   *    <li>
+   *       <p>If the object is not previously restored, then Amazon S3 returns <code>202
+   *          Accepted</code> in the response. </p>
+   *    </li>
+   *    <li>
+   *       <p>If the object is previously restored, Amazon S3 returns <code>200 OK</code> in the
+   *       response. </p>
+   *    </li>
+   * </ul>
+   * <p class="title">
+   *    <b>Special Errors</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code: RestoreAlreadyInProgress</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause: Object restore is already in progress. (This error does not
+   *                apply to SELECT type requests.)</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code: 409 Conflict</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix: Client</i>
+   *             </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code: GlacierExpeditedRetrievalNotAvailable</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause: expedited retrievals are currently not available. Try again
+   *                later. (Returned if there is insufficient capacity to process the Expedited
+   *                request. This error applies only to Expedited retrievals and not to
+   *                S3 Standard or Bulk retrievals.)</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code: 503</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix: N/A</i>
+   *             </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   * </ul>
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketNotificationConfiguration.html">GetBucketNotificationConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference.html">SQL Reference for
-   *                   Amazon S3 Select and S3 Glacier Select </a> in the
-   *                   <i>Amazon S3 User Guide</i>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketNotificationConfiguration.html">GetBucketNotificationConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference.html">SQL Reference for
+   *          Amazon S3 Select and S3 Glacier Select </a> in the
+   *          <i>Amazon S3 User Guide</i>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public restoreObject(
     args: RestoreObjectCommandInput,
@@ -7629,122 +7629,122 @@ export class S3 extends S3Client {
 
   /**
    * <p>This action filters the contents of an Amazon S3 object based on a simple structured query
-   *          language (SQL) statement. In the request, along with the SQL expression, you must also
-   *          specify a data serialization format (JSON, CSV, or Apache Parquet) of the object. Amazon S3 uses
-   *          this format to parse object data into records, and returns only records that match the
-   *          specified SQL expression. You must also specify the data serialization format for the
-   *          response.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
-   *          <p>For more information about Amazon S3 Select,
-   *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/selecting-content-from-objects.html">Selecting Content from
-   *             Objects</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>For more information about using SQL with Amazon S3 Select, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference.html"> SQL Reference for Amazon S3 Select
-   *             and S3 Glacier Select</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p></p>
-   *          <p>
-   *             <b>Permissions</b>
-   *          </p>
-   *          <p>You must have <code>s3:GetObject</code> permission for this operation. Amazon S3 Select does
-   *          not support anonymous access. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a Policy</a>
-   *          in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p></p>
-   *          <p>
-   *             <i>Object Data Formats</i>
-   *          </p>
-   *          <p>You can use Amazon S3 Select to query objects that have the following format
-   *          properties:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <i>CSV, JSON, and Parquet</i> - Objects must be in CSV, JSON, or
-   *                Parquet format.</p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <i>UTF-8</i> - UTF-8 is the only encoding type Amazon S3 Select
-   *                supports.</p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <i>GZIP or BZIP2</i> - CSV and JSON files can be compressed using
-   *                GZIP or BZIP2. GZIP and BZIP2 are the only compression formats that Amazon S3 Select
-   *                supports for CSV and JSON files. Amazon S3 Select supports columnar compression for
-   *                Parquet using GZIP or Snappy. Amazon S3 Select does not support whole-object compression
-   *                for Parquet objects.</p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <i>Server-side encryption</i> - Amazon S3 Select supports querying
-   *                objects that are protected with server-side encryption.</p>
-   *                <p>For objects that are encrypted with customer-provided encryption keys (SSE-C), you
-   *                must use HTTPS, and you must use the headers that are documented in the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>. For more information about SSE-C, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html">Server-Side Encryption
-   *                   (Using Customer-Provided Encryption Keys)</a> in the
-   *                   <i>Amazon S3 User Guide</i>.</p>
-   *                <p>For objects that are encrypted with Amazon S3 managed encryption keys (SSE-S3) and
-   *                customer master keys (CMKs) stored in Amazon Web Services Key Management Service (SSE-KMS),
-   *                server-side encryption is handled transparently, so you don't need to specify
-   *                anything. For more information about server-side encryption, including SSE-S3 and
-   *                SSE-KMS, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Protecting Data Using
-   *                   Server-Side Encryption</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *             </li>
-   *          </ul>
+   * language (SQL) statement. In the request, along with the SQL expression, you must also
+   * specify a data serialization format (JSON, CSV, or Apache Parquet) of the object. Amazon S3 uses
+   * this format to parse object data into records, and returns only records that match the
+   * specified SQL expression. You must also specify the data serialization format for the
+   * response.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>For more information about Amazon S3 Select,
+   * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/selecting-content-from-objects.html">Selecting Content from
+   *    Objects</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>For more information about using SQL with Amazon S3 Select, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference.html"> SQL Reference for Amazon S3 Select
+   *    and S3 Glacier Select</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p></p>
+   * <p>
+   *    <b>Permissions</b>
+   * </p>
+   * <p>You must have <code>s3:GetObject</code> permission for this operation. Amazon S3 Select does
+   * not support anonymous access. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a Policy</a>
+   * in the <i>Amazon S3 User Guide</i>.</p>
+   * <p></p>
+   * <p>
+   *    <i>Object Data Formats</i>
+   * </p>
+   * <p>You can use Amazon S3 Select to query objects that have the following format
+   * properties:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <i>CSV, JSON, and Parquet</i> - Objects must be in CSV, JSON, or
+   *       Parquet format.</p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <i>UTF-8</i> - UTF-8 is the only encoding type Amazon S3 Select
+   *       supports.</p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <i>GZIP or BZIP2</i> - CSV and JSON files can be compressed using
+   *       GZIP or BZIP2. GZIP and BZIP2 are the only compression formats that Amazon S3 Select
+   *       supports for CSV and JSON files. Amazon S3 Select supports columnar compression for
+   *       Parquet using GZIP or Snappy. Amazon S3 Select does not support whole-object compression
+   *       for Parquet objects.</p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <i>Server-side encryption</i> - Amazon S3 Select supports querying
+   *       objects that are protected with server-side encryption.</p>
+   *       <p>For objects that are encrypted with customer-provided encryption keys (SSE-C), you
+   *       must use HTTPS, and you must use the headers that are documented in the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>. For more information about SSE-C, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html">Server-Side Encryption
+   *          (Using Customer-Provided Encryption Keys)</a> in the
+   *          <i>Amazon S3 User Guide</i>.</p>
+   *       <p>For objects that are encrypted with Amazon S3 managed encryption keys (SSE-S3) and
+   *       customer master keys (CMKs) stored in Amazon Web Services Key Management Service (SSE-KMS),
+   *       server-side encryption is handled transparently, so you don't need to specify
+   *       anything. For more information about server-side encryption, including SSE-S3 and
+   *       SSE-KMS, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Protecting Data Using
+   *          Server-Side Encryption</a> in the <i>Amazon S3 User Guide</i>.</p>
+   *    </li>
+   * </ul>
    *
-   *          <p>
-   *             <b>Working with the Response Body</b>
-   *          </p>
-   *          <p>Given the response size is unknown, Amazon S3 Select streams the response as a series of
-   *          messages and includes a <code>Transfer-Encoding</code> header with <code>chunked</code> as
-   *          its value in the response. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html">Appendix: SelectObjectContent
-   *             Response</a>.</p>
+   * <p>
+   *    <b>Working with the Response Body</b>
+   * </p>
+   * <p>Given the response size is unknown, Amazon S3 Select streams the response as a series of
+   * messages and includes a <code>Transfer-Encoding</code> header with <code>chunked</code> as
+   * its value in the response. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html">Appendix: SelectObjectContent
+   *    Response</a>.</p>
    *
-   *          <p></p>
-   *          <p>
-   *             <b>GetObject Support</b>
-   *          </p>
-   *          <p>The <code>SelectObjectContent</code> action does not support the following
-   *             <code>GetObject</code> functionality. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>.</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <code>Range</code>: Although you can specify a scan range for an Amazon S3 Select request
-   *                (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_SelectObjectContent.html#AmazonS3-SelectObjectContent-request-ScanRange">SelectObjectContentRequest - ScanRange</a> in the request parameters),
-   *                you cannot specify the range of bytes of an object to return. </p>
-   *             </li>
-   *             <li>
-   *                <p>GLACIER, DEEP_ARCHIVE and REDUCED_REDUNDANCY storage classes: You cannot specify
-   *                the GLACIER, DEEP_ARCHIVE, or <code>REDUCED_REDUNDANCY</code> storage classes. For
-   *                more information, about storage classes see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#storage-class-intro">Storage Classes</a>
-   *                in the <i>Amazon S3 User Guide</i>.</p>
-   *             </li>
-   *          </ul>
-   *          <p></p>
-   *          <p>
-   *             <b>Special Errors</b>
-   *          </p>
+   * <p></p>
+   * <p>
+   *    <b>GetObject Support</b>
+   * </p>
+   * <p>The <code>SelectObjectContent</code> action does not support the following
+   *    <code>GetObject</code> functionality. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>.</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <code>Range</code>: Although you can specify a scan range for an Amazon S3 Select request
+   *       (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_SelectObjectContent.html#AmazonS3-SelectObjectContent-request-ScanRange">SelectObjectContentRequest - ScanRange</a> in the request parameters),
+   *       you cannot specify the range of bytes of an object to return. </p>
+   *    </li>
+   *    <li>
+   *       <p>GLACIER, DEEP_ARCHIVE and REDUCED_REDUNDANCY storage classes: You cannot specify
+   *       the GLACIER, DEEP_ARCHIVE, or <code>REDUCED_REDUNDANCY</code> storage classes. For
+   *       more information, about storage classes see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#storage-class-intro">Storage Classes</a>
+   *       in the <i>Amazon S3 User Guide</i>.</p>
+   *    </li>
+   * </ul>
+   * <p></p>
+   * <p>
+   *    <b>Special Errors</b>
+   * </p>
    *
-   *          <p>For a list of special errors for this operation, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#SelectObjectContentErrorCodeList">List of
-   *             SELECT Object Content Error Codes</a>
-   *          </p>
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html">GetBucketLifecycleConfiguration</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   * <p>For a list of special errors for this operation, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#SelectObjectContentErrorCodeList">List of
+   *    SELECT Object Content Error Codes</a>
+   * </p>
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html">GetBucketLifecycleConfiguration</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public selectObjectContent(
     args: SelectObjectContentCommandInput,
@@ -7777,143 +7777,143 @@ export class S3 extends S3Client {
 
   /**
    * <p>Uploads a part in a multipart upload.</p>
-   *          <note>
-   *             <p>In this operation, you provide part data in your request. However, you have an option
-   *             to specify your existing Amazon S3 object as a data source for the part you are uploading. To
-   *             upload a part from an existing object, you use the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html">UploadPartCopy</a> operation.
-   *          </p>
-   *          </note>
+   * <note>
+   *    <p>In this operation, you provide part data in your request. However, you have an option
+   *    to specify your existing Amazon S3 object as a data source for the part you are uploading. To
+   *    upload a part from an existing object, you use the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html">UploadPartCopy</a> operation.
+   * </p>
+   * </note>
    *
-   *          <p>You must initiate a multipart upload (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>)
-   *          before you can upload any part. In response to your initiate request, Amazon S3 returns an
-   *          upload ID, a unique identifier, that you must include in your upload part request.</p>
-   *          <p>Part numbers can be any number from 1 to 10,000, inclusive. A part number uniquely
-   *          identifies a part and also defines its position within the object being created. If you
-   *          upload a new part using the same part number that was used with a previous part, the
-   *          previously uploaded part is overwritten. Each part must be at least 5 MB in size, except
-   *          the last part. There is no size limit on the last part of your multipart upload.</p>
-   *          <p>To ensure that data is not corrupted when traversing the network, specify the
-   *             <code>Content-MD5</code> header in the upload part request. Amazon S3 checks the part data
-   *          against the provided MD5 value. If they do not match, Amazon S3 returns an error. </p>
+   * <p>You must initiate a multipart upload (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>)
+   * before you can upload any part. In response to your initiate request, Amazon S3 returns an
+   * upload ID, a unique identifier, that you must include in your upload part request.</p>
+   * <p>Part numbers can be any number from 1 to 10,000, inclusive. A part number uniquely
+   * identifies a part and also defines its position within the object being created. If you
+   * upload a new part using the same part number that was used with a previous part, the
+   * previously uploaded part is overwritten. Each part must be at least 5 MB in size, except
+   * the last part. There is no size limit on the last part of your multipart upload.</p>
+   * <p>To ensure that data is not corrupted when traversing the network, specify the
+   *    <code>Content-MD5</code> header in the upload part request. Amazon S3 checks the part data
+   * against the provided MD5 value. If they do not match, Amazon S3 returns an error. </p>
    *
-   *          <p>If the upload request is signed with Signature Version 4, then Amazon Web Services S3 uses the
-   *             <code>x-amz-content-sha256</code> header as a checksum instead of
-   *             <code>Content-MD5</code>. For more information see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html">Authenticating Requests: Using the Authorization Header (Amazon Web Services Signature Version
-   *             4)</a>. </p>
-   *
-   *
-   *
-   *          <p>
-   *             <b>Note:</b> After you initiate multipart upload and upload
-   *          one or more parts, you must either complete or abort multipart upload in order to stop
-   *          getting charged for storage of the uploaded parts. Only after you either complete or abort
-   *          multipart upload, Amazon S3 frees up the parts storage and stops charging you for the parts
-   *          storage.</p>
-   *
-   *          <p>For more information on multipart uploads, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html">Multipart Upload Overview</a> in the
-   *             <i>Amazon S3 User Guide </i>.</p>
-   *          <p>For information on the permissions required to use the multipart upload API, go to
-   *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
-   *             Permissions</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *
-   *          <p>You can optionally request server-side encryption where Amazon S3 encrypts your data as it
-   *          writes it to disks in its data centers and decrypts it for you when you access it. You have
-   *          the option of providing your own encryption key, or you can use the Amazon Web Services managed encryption
-   *          keys. If you choose to provide your own encryption key, the request headers you provide in
-   *          the request must match the headers you used in the request to initiate the upload by using
-   *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>. For more information, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html">Using Server-Side Encryption</a> in
-   *          the <i>Amazon S3 User Guide</i>.</p>
-   *
-   *          <p>Server-side encryption is supported by the S3 Multipart Upload actions. Unless you are
-   *          using a customer-provided encryption key, you don't need to specify the encryption
-   *          parameters in each UploadPart request. Instead, you only need to specify the server-side
-   *          encryption parameters in the initial Initiate Multipart request. For more information, see
-   *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>.</p>
-   *
-   *          <p>If you requested server-side encryption using a customer-provided encryption key in your
-   *          initiate multipart upload request, you must provide identical encryption information in
-   *          each part upload using the following headers.</p>
+   * <p>If the upload request is signed with Signature Version 4, then Amazon Web Services S3 uses the
+   *    <code>x-amz-content-sha256</code> header as a checksum instead of
+   *    <code>Content-MD5</code>. For more information see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html">Authenticating Requests: Using the Authorization Header (Amazon Web Services Signature Version
+   *    4)</a>. </p>
    *
    *
-   *          <ul>
-   *             <li>
-   *                <p>x-amz-server-side-encryption-customer-algorithm</p>
-   *             </li>
-   *             <li>
-   *                <p>x-amz-server-side-encryption-customer-key</p>
-   *             </li>
-   *             <li>
-   *                <p>x-amz-server-side-encryption-customer-key-MD5</p>
-   *             </li>
-   *          </ul>
    *
-   *          <p class="title">
-   *             <b>Special Errors</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code: NoSuchUpload</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause: The specified multipart upload does not exist. The upload
-   *                         ID might be invalid, or the multipart upload might have been aborted or
-   *                         completed.</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i> HTTP Status Code: 404 Not Found </i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix: Client</i>
-   *                      </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *          </ul>
+   * <p>
+   *    <b>Note:</b> After you initiate multipart upload and upload
+   * one or more parts, you must either complete or abort multipart upload in order to stop
+   * getting charged for storage of the uploaded parts. Only after you either complete or abort
+   * multipart upload, Amazon S3 frees up the parts storage and stops charging you for the parts
+   * storage.</p>
+   *
+   * <p>For more information on multipart uploads, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html">Multipart Upload Overview</a> in the
+   *    <i>Amazon S3 User Guide </i>.</p>
+   * <p>For information on the permissions required to use the multipart upload API, go to
+   *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
+   *    Permissions</a> in the <i>Amazon S3 User Guide</i>.</p>
+   *
+   * <p>You can optionally request server-side encryption where Amazon S3 encrypts your data as it
+   * writes it to disks in its data centers and decrypts it for you when you access it. You have
+   * the option of providing your own encryption key, or you can use the Amazon Web Services managed encryption
+   * keys. If you choose to provide your own encryption key, the request headers you provide in
+   * the request must match the headers you used in the request to initiate the upload by using
+   *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>. For more information, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html">Using Server-Side Encryption</a> in
+   * the <i>Amazon S3 User Guide</i>.</p>
+   *
+   * <p>Server-side encryption is supported by the S3 Multipart Upload actions. Unless you are
+   * using a customer-provided encryption key, you don't need to specify the encryption
+   * parameters in each UploadPart request. Instead, you only need to specify the server-side
+   * encryption parameters in the initial Initiate Multipart request. For more information, see
+   *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>.</p>
+   *
+   * <p>If you requested server-side encryption using a customer-provided encryption key in your
+   * initiate multipart upload request, you must provide identical encryption information in
+   * each part upload using the following headers.</p>
    *
    *
+   * <ul>
+   *    <li>
+   *       <p>x-amz-server-side-encryption-customer-algorithm</p>
+   *    </li>
+   *    <li>
+   *       <p>x-amz-server-side-encryption-customer-key</p>
+   *    </li>
+   *    <li>
+   *       <p>x-amz-server-side-encryption-customer-key-MD5</p>
+   *    </li>
+   * </ul>
+   *
+   * <p class="title">
+   *    <b>Special Errors</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code: NoSuchUpload</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause: The specified multipart upload does not exist. The upload
+   *                ID might be invalid, or the multipart upload might have been aborted or
+   *                completed.</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i> HTTP Status Code: 404 Not Found </i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix: Client</i>
+   *             </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   * </ul>
    *
    *
    *
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   *
+   *
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public uploadPart(args: UploadPartCommandInput, options?: __HttpHandlerOptions): Promise<UploadPartCommandOutput>;
   public uploadPart(args: UploadPartCommandInput, cb: (err: any, data?: UploadPartCommandOutput) => void): void;
@@ -7940,184 +7940,184 @@ export class S3 extends S3Client {
 
   /**
    * <p>Uploads a part by copying data from an existing object as data source. You specify the
-   *          data source by adding the request header <code>x-amz-copy-source</code> in your request and
-   *          a byte range by adding the request header <code>x-amz-copy-source-range</code> in your
-   *          request. </p>
-   *          <p>The minimum allowable part size for a multipart upload is 5 MB. For more information
-   *          about multipart upload limits, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html">Quick
-   *             Facts</a> in the <i>Amazon S3 User Guide</i>. </p>
-   *          <note>
-   *             <p>Instead of using an existing object as part data, you might use the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
-   *             action and provide data in your request.</p>
-   *          </note>
+   * data source by adding the request header <code>x-amz-copy-source</code> in your request and
+   * a byte range by adding the request header <code>x-amz-copy-source-range</code> in your
+   * request. </p>
+   * <p>The minimum allowable part size for a multipart upload is 5 MB. For more information
+   * about multipart upload limits, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html">Quick
+   *    Facts</a> in the <i>Amazon S3 User Guide</i>. </p>
+   * <note>
+   *    <p>Instead of using an existing object as part data, you might use the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+   *    action and provide data in your request.</p>
+   * </note>
    *
-   *          <p>You must initiate a multipart upload before you can upload any part. In response to your
-   *          initiate request. Amazon S3 returns a unique identifier, the upload ID, that you must include in
-   *          your upload part request.</p>
-   *          <p>For more information about using the <code>UploadPartCopy</code> operation, see the
-   *          following:</p>
+   * <p>You must initiate a multipart upload before you can upload any part. In response to your
+   * initiate request. Amazon S3 returns a unique identifier, the upload ID, that you must include in
+   * your upload part request.</p>
+   * <p>For more information about using the <code>UploadPartCopy</code> operation, see the
+   * following:</p>
    *
-   *          <ul>
-   *             <li>
-   *                <p>For conceptual information about multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
-   *                   Upload</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *             </li>
-   *             <li>
-   *                <p>For information about permissions required to use the multipart upload API, see
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload  and
-   *                   Permissions</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *             </li>
-   *             <li>
-   *                <p>For information about copying objects using a single atomic action vs. the
-   *                multipart upload, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectOperations.html">Operations on
-   *                   Objects</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *             </li>
-   *             <li>
-   *                <p>For information about using server-side encryption with customer-provided
-   *                encryption keys with the UploadPartCopy operation, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html">CopyObject</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>.</p>
-   *             </li>
-   *          </ul>
-   *          <p>Note the following additional considerations about the request headers
-   *             <code>x-amz-copy-source-if-match</code>, <code>x-amz-copy-source-if-none-match</code>,
-   *             <code>x-amz-copy-source-if-unmodified-since</code>, and
-   *             <code>x-amz-copy-source-if-modified-since</code>:</p>
-   *          <p> </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <b>Consideration 1</b> - If both of the
-   *                   <code>x-amz-copy-source-if-match</code> and
-   *                   <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the
-   *                request as follows:</p>
-   *                <p>
-   *                   <code>x-amz-copy-source-if-match</code> condition evaluates to <code>true</code>,
-   *                and;</p>
-   *                <p>
-   *                   <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to
-   *                   <code>false</code>;</p>
-   *                <p>Amazon S3 returns <code>200 OK</code> and copies the data.
-   *                </p>
+   * <ul>
+   *    <li>
+   *       <p>For conceptual information about multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
+   *          Upload</a> in the <i>Amazon S3 User Guide</i>.</p>
+   *    </li>
+   *    <li>
+   *       <p>For information about permissions required to use the multipart upload API, see
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload  and
+   *          Permissions</a> in the <i>Amazon S3 User Guide</i>.</p>
+   *    </li>
+   *    <li>
+   *       <p>For information about copying objects using a single atomic action vs. the
+   *       multipart upload, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectOperations.html">Operations on
+   *          Objects</a> in the <i>Amazon S3 User Guide</i>.</p>
+   *    </li>
+   *    <li>
+   *       <p>For information about using server-side encryption with customer-provided
+   *       encryption keys with the UploadPartCopy operation, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html">CopyObject</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>.</p>
+   *    </li>
+   * </ul>
+   * <p>Note the following additional considerations about the request headers
+   *    <code>x-amz-copy-source-if-match</code>, <code>x-amz-copy-source-if-none-match</code>,
+   *    <code>x-amz-copy-source-if-unmodified-since</code>, and
+   *    <code>x-amz-copy-source-if-modified-since</code>:</p>
+   * <p> </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <b>Consideration 1</b> - If both of the
+   *          <code>x-amz-copy-source-if-match</code> and
+   *          <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the
+   *       request as follows:</p>
+   *       <p>
+   *          <code>x-amz-copy-source-if-match</code> condition evaluates to <code>true</code>,
+   *       and;</p>
+   *       <p>
+   *          <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to
+   *          <code>false</code>;</p>
+   *       <p>Amazon S3 returns <code>200 OK</code> and copies the data.
+   *       </p>
    *
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <b>Consideration 2</b> - If both of the
-   *                   <code>x-amz-copy-source-if-none-match</code> and
-   *                   <code>x-amz-copy-source-if-modified-since</code> headers are present in the
-   *                request as follows:</p>
-   *                <p>
-   *                   <code>x-amz-copy-source-if-none-match</code> condition evaluates to
-   *                   <code>false</code>, and;</p>
-   *                <p>
-   *                   <code>x-amz-copy-source-if-modified-since</code> condition evaluates to
-   *                   <code>true</code>;</p>
-   *                <p>Amazon S3 returns <code>412 Precondition Failed</code> response code.
-   *                </p>
-   *             </li>
-   *          </ul>
-   *          <p>
-   *             <b>Versioning</b>
-   *          </p>
-   *          <p>If your bucket has versioning enabled, you could have multiple versions of the same
-   *          object. By default, <code>x-amz-copy-source</code> identifies the current version of the
-   *          object to copy. If the current version is a delete marker and you don't specify a versionId
-   *          in the <code>x-amz-copy-source</code>, Amazon S3 returns a 404 error, because the object does
-   *          not exist. If you specify versionId in the <code>x-amz-copy-source</code> and the versionId
-   *          is a delete marker, Amazon S3 returns an HTTP 400 error, because you are not allowed to specify
-   *          a delete marker as a version for the <code>x-amz-copy-source</code>. </p>
-   *          <p>You can optionally specify a specific version of the source object to copy by adding the
-   *             <code>versionId</code> subresource as shown in the following example:</p>
-   *          <p>
-   *             <code>x-amz-copy-source: /bucket/object?versionId=version id</code>
-   *          </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <b>Consideration 2</b> - If both of the
+   *          <code>x-amz-copy-source-if-none-match</code> and
+   *          <code>x-amz-copy-source-if-modified-since</code> headers are present in the
+   *       request as follows:</p>
+   *       <p>
+   *          <code>x-amz-copy-source-if-none-match</code> condition evaluates to
+   *          <code>false</code>, and;</p>
+   *       <p>
+   *          <code>x-amz-copy-source-if-modified-since</code> condition evaluates to
+   *          <code>true</code>;</p>
+   *       <p>Amazon S3 returns <code>412 Precondition Failed</code> response code.
+   *       </p>
+   *    </li>
+   * </ul>
+   * <p>
+   *    <b>Versioning</b>
+   * </p>
+   * <p>If your bucket has versioning enabled, you could have multiple versions of the same
+   * object. By default, <code>x-amz-copy-source</code> identifies the current version of the
+   * object to copy. If the current version is a delete marker and you don't specify a versionId
+   * in the <code>x-amz-copy-source</code>, Amazon S3 returns a 404 error, because the object does
+   * not exist. If you specify versionId in the <code>x-amz-copy-source</code> and the versionId
+   * is a delete marker, Amazon S3 returns an HTTP 400 error, because you are not allowed to specify
+   * a delete marker as a version for the <code>x-amz-copy-source</code>. </p>
+   * <p>You can optionally specify a specific version of the source object to copy by adding the
+   *    <code>versionId</code> subresource as shown in the following example:</p>
+   * <p>
+   *    <code>x-amz-copy-source: /bucket/object?versionId=version id</code>
+   * </p>
    *
-   *          <p class="title">
-   *             <b>Special Errors</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code: NoSuchUpload</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause: The specified multipart upload does not exist. The upload
-   *                         ID might be invalid, or the multipart upload might have been aborted or
-   *                         completed.</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code: 404 Not Found</i>
-   *                      </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code: InvalidRequest</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Cause: The specified copy source is not supported as a byte-range
-   *                         copy source.</i>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code: 400 Bad Request</i>
-   *                      </p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *          </ul>
-   *
-   *
+   * <p class="title">
+   *    <b>Special Errors</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code: NoSuchUpload</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause: The specified multipart upload does not exist. The upload
+   *                ID might be invalid, or the multipart upload might have been aborted or
+   *                completed.</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code: 404 Not Found</i>
+   *             </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code: InvalidRequest</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Cause: The specified copy source is not supported as a byte-range
+   *                copy source.</i>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code: 400 Bad Request</i>
+   *             </p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   * </ul>
    *
    *
    *
    *
-   *          <p class="title">
-   *             <b>Related Resources</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
-   *                </p>
-   *             </li>
-   *          </ul>
+   *
+   *
+   * <p class="title">
+   *    <b>Related Resources</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
+   *       </p>
+   *    </li>
+   * </ul>
    */
   public uploadPartCopy(
     args: UploadPartCopyCommandInput,
@@ -8150,28 +8150,28 @@ export class S3 extends S3Client {
 
   /**
    * <p>Passes transformed
-   *          objects to a <code>GetObject</code> operation when using Object Lambda Access Points. For information about
-   *          Object Lambda Access Points, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/transforming-objects.html">Transforming objects with
-   *             Object Lambda Access Points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>This operation supports metadata that can be returned by <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>, in addition to
-   *            <code>RequestRoute</code>, <code>RequestToken</code>, <code>StatusCode</code>,
-   *            <code>ErrorCode</code>, and <code>ErrorMessage</code>. The <code>GetObject</code>
+   * objects to a <code>GetObject</code> operation when using Object Lambda Access Points. For information about
+   * Object Lambda Access Points, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/transforming-objects.html">Transforming objects with
+   *    Object Lambda Access Points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>This operation supports metadata that can be returned by <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>, in addition to
+   *   <code>RequestRoute</code>, <code>RequestToken</code>, <code>StatusCode</code>,
+   *   <code>ErrorCode</code>, and <code>ErrorMessage</code>. The <code>GetObject</code>
    *         response metadata is supported so that the <code>WriteGetObjectResponse</code> caller,
    *         typically an Lambda function, can provide the same metadata when it internally invokes
-   *            <code>GetObject</code>. When <code>WriteGetObjectResponse</code> is called by a
+   *   <code>GetObject</code>. When <code>WriteGetObjectResponse</code> is called by a
    *         customer-owned Lambda function, the metadata returned to the end user
-   *            <code>GetObject</code> call might differ from what Amazon S3 would normally return.</p>
-   *          <p>You can include any number of metadata headers. When including a metadata header, it should be
-   *          prefaced with <code>x-amz-meta</code>. For example, <code>x-amz-meta-my-custom-header: MyCustomValue</code>.
-   *          The primary use case for this is to forward <code>GetObject</code> metadata.</p>
-   *          <p>Amazon Web Services provides some prebuilt Lambda functions that you can use with S3 Object Lambda to detect and redact
-   *          personally identifiable information (PII) and decompress S3 objects. These Lambda functions
-   *          are available in the Amazon Web Services Serverless Application Repository, and can be selected through the Amazon Web Services Management Console when you create your
-   *          Object Lambda Access Point.</p>
-   *          <p>Example 1: PII Access Control - This Lambda function uses Amazon Comprehend, a natural language processing (NLP) service using machine learning to find insights and relationships in text. It automatically detects personally identifiable information (PII) such as names, addresses, dates, credit card numbers, and social security numbers from documents in your Amazon S3 bucket. </p>
-   *          <p>Example 2: PII Redaction - This Lambda function uses Amazon Comprehend, a natural language processing (NLP) service using machine learning to find insights and relationships in text. It automatically redacts personally identifiable information (PII) such as names, addresses, dates, credit card numbers, and social security numbers from documents in your Amazon S3 bucket. </p>
-   *          <p>Example 3: Decompression - The Lambda function S3ObjectLambdaDecompression, is equipped to decompress objects stored in S3 in one of six compressed file formats including bzip2, gzip, snappy, zlib, zstandard and ZIP. </p>
-   *          <p>For information on how to view and use these functions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/olap-examples.html">Using Amazon Web Services built Lambda functions</a> in the <i>Amazon S3 User Guide</i>.</p>
+   *   <code>GetObject</code> call might differ from what Amazon S3 would normally return.</p>
+   * <p>You can include any number of metadata headers. When including a metadata header, it should be
+   * prefaced with <code>x-amz-meta</code>. For example, <code>x-amz-meta-my-custom-header: MyCustomValue</code>.
+   * The primary use case for this is to forward <code>GetObject</code> metadata.</p>
+   * <p>Amazon Web Services provides some prebuilt Lambda functions that you can use with S3 Object Lambda to detect and redact
+   * personally identifiable information (PII) and decompress S3 objects. These Lambda functions
+   * are available in the Amazon Web Services Serverless Application Repository, and can be selected through the Amazon Web Services Management Console when you create your
+   * Object Lambda Access Point.</p>
+   * <p>Example 1: PII Access Control - This Lambda function uses Amazon Comprehend, a natural language processing (NLP) service using machine learning to find insights and relationships in text. It automatically detects personally identifiable information (PII) such as names, addresses, dates, credit card numbers, and social security numbers from documents in your Amazon S3 bucket. </p>
+   * <p>Example 2: PII Redaction - This Lambda function uses Amazon Comprehend, a natural language processing (NLP) service using machine learning to find insights and relationships in text. It automatically redacts personally identifiable information (PII) such as names, addresses, dates, credit card numbers, and social security numbers from documents in your Amazon S3 bucket. </p>
+   * <p>Example 3: Decompression - The Lambda function S3ObjectLambdaDecompression, is equipped to decompress objects stored in S3 in one of six compressed file formats including bzip2, gzip, snappy, zlib, zstandard and ZIP. </p>
+   * <p>For information on how to view and use these functions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/olap-examples.html">Using Amazon Web Services built Lambda functions</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   public writeGetObjectResponse(
     args: WriteGetObjectResponseCommandInput,

--- a/clients/client-s3/src/commands/AbortMultipartUploadCommand.ts
+++ b/clients/client-s3/src/commands/AbortMultipartUploadCommand.ts
@@ -23,44 +23,44 @@ export interface AbortMultipartUploadCommandOutput extends AbortMultipartUploadO
 
 /**
  * <p>This action aborts a multipart upload. After a multipart upload is aborted, no
- *          additional parts can be uploaded using that upload ID. The storage consumed by any
- *          previously uploaded parts will be freed. However, if any part uploads are currently in
- *          progress, those part uploads might or might not succeed. As a result, it might be necessary
- *          to abort a given multipart upload multiple times in order to completely free all storage
- *          consumed by all parts. </p>
- *          <p>To verify that all parts have been removed, so you don't get charged for the part
- *          storage, you should call the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a> action and ensure that
- *          the parts list is empty.</p>
- *          <p>For information about permissions required to use the multipart upload, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
- *          Permissions</a>.</p>
- *          <p>The following operations are related to <code>AbortMultipartUpload</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
- *                </p>
- *             </li>
- *          </ul>
+ * additional parts can be uploaded using that upload ID. The storage consumed by any
+ * previously uploaded parts will be freed. However, if any part uploads are currently in
+ * progress, those part uploads might or might not succeed. As a result, it might be necessary
+ * to abort a given multipart upload multiple times in order to completely free all storage
+ * consumed by all parts. </p>
+ * <p>To verify that all parts have been removed, so you don't get charged for the part
+ * storage, you should call the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a> action and ensure that
+ * the parts list is empty.</p>
+ * <p>For information about permissions required to use the multipart upload, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
+ * Permissions</a>.</p>
+ * <p>The following operations are related to <code>AbortMultipartUpload</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/CompleteMultipartUploadCommand.ts
+++ b/clients/client-s3/src/commands/CompleteMultipartUploadCommand.ts
@@ -24,115 +24,115 @@ export interface CompleteMultipartUploadCommandOutput extends CompleteMultipartU
 
 /**
  * <p>Completes a multipart upload by assembling previously uploaded parts.</p>
- *          <p>You first initiate the multipart upload and then upload all parts using the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
- *          operation. After successfully uploading all relevant parts of an upload, you call this
- *          action to complete the upload. Upon receiving this request, Amazon S3 concatenates all
- *          the parts in ascending order by part number to create a new object. In the Complete
- *          Multipart Upload request, you must provide the parts list. You must ensure that the parts
- *          list is complete. This action concatenates the parts that you provide in the list. For
- *          each part in the list, you must provide the part number and the <code>ETag</code> value,
- *          returned after that part was uploaded.</p>
- *          <p>Processing of a Complete Multipart Upload request could take several minutes to
- *          complete. After Amazon S3 begins processing the request, it sends an HTTP response header that
- *          specifies a 200 OK response. While processing is in progress, Amazon S3 periodically sends white
- *          space characters to keep the connection from timing out. Because a request could fail after
- *          the initial 200 OK response has been sent, it is important that you check the response body
- *          to determine whether the request succeeded.</p>
- *          <p>Note that if <code>CompleteMultipartUpload</code> fails, applications should be prepared
- *          to retry the failed requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ErrorBestPractices.html">Amazon S3 Error Best Practices</a>.</p>
- *          <p>For more information about multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
- *             Upload</a>.</p>
- *          <p>For information about permissions required to use the multipart upload API, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
- *          Permissions</a>.</p>
+ * <p>You first initiate the multipart upload and then upload all parts using the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+ * operation. After successfully uploading all relevant parts of an upload, you call this
+ * action to complete the upload. Upon receiving this request, Amazon S3 concatenates all
+ * the parts in ascending order by part number to create a new object. In the Complete
+ * Multipart Upload request, you must provide the parts list. You must ensure that the parts
+ * list is complete. This action concatenates the parts that you provide in the list. For
+ * each part in the list, you must provide the part number and the <code>ETag</code> value,
+ * returned after that part was uploaded.</p>
+ * <p>Processing of a Complete Multipart Upload request could take several minutes to
+ * complete. After Amazon S3 begins processing the request, it sends an HTTP response header that
+ * specifies a 200 OK response. While processing is in progress, Amazon S3 periodically sends white
+ * space characters to keep the connection from timing out. Because a request could fail after
+ * the initial 200 OK response has been sent, it is important that you check the response body
+ * to determine whether the request succeeded.</p>
+ * <p>Note that if <code>CompleteMultipartUpload</code> fails, applications should be prepared
+ * to retry the failed requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ErrorBestPractices.html">Amazon S3 Error Best Practices</a>.</p>
+ * <p>For more information about multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
+ *    Upload</a>.</p>
+ * <p>For information about permissions required to use the multipart upload API, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
+ * Permissions</a>.</p>
  *
  *
- *          <p>
- *             <code>CompleteMultipartUpload</code> has the following special errors:</p>
- *          <ul>
- *             <li>
- *                <p>Error code: <code>EntityTooSmall</code>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>Description: Your proposed upload is smaller than the minimum allowed object
- *                      size. Each part must be at least 5 MB in size, except the last part.</p>
- *                   </li>
- *                   <li>
- *                      <p>400 Bad Request</p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <p>Error code: <code>InvalidPart</code>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>Description: One or more of the specified parts could not be found. The part
- *                      might not have been uploaded, or the specified entity tag might not have
- *                      matched the part's entity tag.</p>
- *                   </li>
- *                   <li>
- *                      <p>400 Bad Request</p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <p>Error code: <code>InvalidPartOrder</code>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>Description: The list of parts was not in ascending order. The parts list
- *                      must be specified in order by part number.</p>
- *                   </li>
- *                   <li>
- *                      <p>400 Bad Request</p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <p>Error code: <code>NoSuchUpload</code>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>Description: The specified multipart upload does not exist. The upload ID
- *                      might be invalid, or the multipart upload might have been aborted or
- *                      completed.</p>
- *                   </li>
- *                   <li>
- *                      <p>404 Not Found</p>
- *                   </li>
- *                </ul>
- *             </li>
- *          </ul>
+ * <p>
+ *    <code>CompleteMultipartUpload</code> has the following special errors:</p>
+ * <ul>
+ *    <li>
+ *       <p>Error code: <code>EntityTooSmall</code>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>Description: Your proposed upload is smaller than the minimum allowed object
+ *             size. Each part must be at least 5 MB in size, except the last part.</p>
+ *          </li>
+ *          <li>
+ *             <p>400 Bad Request</p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <p>Error code: <code>InvalidPart</code>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>Description: One or more of the specified parts could not be found. The part
+ *             might not have been uploaded, or the specified entity tag might not have
+ *             matched the part's entity tag.</p>
+ *          </li>
+ *          <li>
+ *             <p>400 Bad Request</p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <p>Error code: <code>InvalidPartOrder</code>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>Description: The list of parts was not in ascending order. The parts list
+ *             must be specified in order by part number.</p>
+ *          </li>
+ *          <li>
+ *             <p>400 Bad Request</p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <p>Error code: <code>NoSuchUpload</code>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>Description: The specified multipart upload does not exist. The upload ID
+ *             might be invalid, or the multipart upload might have been aborted or
+ *             completed.</p>
+ *          </li>
+ *          <li>
+ *             <p>404 Not Found</p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ * </ul>
  *
- *          <p>The following operations are related to <code>CompleteMultipartUpload</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>CompleteMultipartUpload</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/CopyObjectCommand.ts
+++ b/clients/client-s3/src/commands/CopyObjectCommand.ts
@@ -25,175 +25,175 @@ export interface CopyObjectCommandOutput extends CopyObjectOutput, __MetadataBea
 
 /**
  * <p>Creates a copy of an object that is already stored in Amazon S3.</p>
- *          <note>
- *             <p>You can store individual objects of up to 5 TB in Amazon S3. You create a copy of your
- *             object up to 5 GB in size in a single atomic action using this API. However, to copy
- *             an object greater than 5 GB, you must use the multipart upload Upload Part - Copy API.
- *             For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjctsUsingRESTMPUapi.html">Copy Object Using the REST Multipart Upload API</a>.</p>
- *          </note>
- *          <p>All copy requests must be authenticated. Additionally, you must have
- *             <i>read</i> access to the source object and <i>write</i>
- *          access to the destination bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html">REST Authentication</a>. Both the Region
- *          that you want to copy the object from and the Region that you want to copy the object to
- *          must be enabled for your account.</p>
- *          <p>A copy request might return an error when Amazon S3 receives the copy request or while Amazon S3
- *          is copying the files. If the error occurs before the copy action starts, you receive a
- *          standard Amazon S3 error. If the error occurs during the copy operation, the error response is
- *          embedded in the <code>200 OK</code> response. This means that a <code>200 OK</code>
- *          response can contain either a success or an error. Design your application to parse the
- *          contents of the response and handle it appropriately.</p>
- *          <p>If the copy is successful, you receive a response with information about the copied
- *          object.</p>
- *          <note>
- *             <p>If the request is an HTTP 1.1 request, the response is chunk encoded. If it were not,
- *             it would not contain the content-length, and you would need to read the entire
- *             body.</p>
- *          </note>
- *          <p>The copy request charge is based on the storage class and Region that you specify for
- *          the destination object. For pricing information, see <a href="http://aws.amazon.com/s3/pricing/">Amazon S3 pricing</a>.</p>
- *          <important>
- *             <p>Amazon S3 transfer acceleration does not support cross-Region copies. If you request a
- *             cross-Region copy using a transfer acceleration endpoint, you get a 400 <code>Bad
- *                Request</code> error. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html">Transfer Acceleration</a>.</p>
- *          </important>
- *          <p>
- *             <b>Metadata</b>
- *          </p>
- *          <p>When copying an object, you can preserve all metadata (default) or specify new metadata.
- *          However, the ACL is not preserved and is set to private for the user making the request. To
- *          override the default ACL setting, specify a new ACL when generating a copy request. For
- *          more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. </p>
- *          <p>To specify whether you want the object metadata copied from the source object or
- *          replaced with metadata provided in the request, you can optionally add the
- *             <code>x-amz-metadata-directive</code> header. When you grant permissions, you can use
- *          the <code>s3:x-amz-metadata-directive</code> condition key to enforce certain metadata
- *          behavior when objects are uploaded. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html">Specifying Conditions in a
- *             Policy</a> in the <i>Amazon S3 User Guide</i>. For a complete list of
- *          Amazon S3-specific condition keys, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/list_amazons3.html">Actions, Resources, and Condition Keys for
- *             Amazon S3</a>.</p>
- *          <p>
- *             <b>
- *                <code>x-amz-copy-source-if</code> Headers</b>
- *          </p>
- *          <p>To only copy an object under certain conditions, such as whether the <code>Etag</code>
- *          matches or whether the object was modified before or after a specified date, use the
- *          following request parameters:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <code>x-amz-copy-source-if-match</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>x-amz-copy-source-if-none-match</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>x-amz-copy-source-if-unmodified-since</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>x-amz-copy-source-if-modified-since</code>
- *                </p>
- *             </li>
- *          </ul>
- *          <p> If both the <code>x-amz-copy-source-if-match</code> and
- *             <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request
- *          and evaluate as follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <code>x-amz-copy-source-if-match</code> condition evaluates to true</p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to
- *                false</p>
- *             </li>
- *          </ul>
+ * <note>
+ *    <p>You can store individual objects of up to 5 TB in Amazon S3. You create a copy of your
+ *    object up to 5 GB in size in a single atomic action using this API. However, to copy
+ *    an object greater than 5 GB, you must use the multipart upload Upload Part - Copy API.
+ *    For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjctsUsingRESTMPUapi.html">Copy Object Using the REST Multipart Upload API</a>.</p>
+ * </note>
+ * <p>All copy requests must be authenticated. Additionally, you must have
+ *    <i>read</i> access to the source object and <i>write</i>
+ * access to the destination bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html">REST Authentication</a>. Both the Region
+ * that you want to copy the object from and the Region that you want to copy the object to
+ * must be enabled for your account.</p>
+ * <p>A copy request might return an error when Amazon S3 receives the copy request or while Amazon S3
+ * is copying the files. If the error occurs before the copy action starts, you receive a
+ * standard Amazon S3 error. If the error occurs during the copy operation, the error response is
+ * embedded in the <code>200 OK</code> response. This means that a <code>200 OK</code>
+ * response can contain either a success or an error. Design your application to parse the
+ * contents of the response and handle it appropriately.</p>
+ * <p>If the copy is successful, you receive a response with information about the copied
+ * object.</p>
+ * <note>
+ *    <p>If the request is an HTTP 1.1 request, the response is chunk encoded. If it were not,
+ *    it would not contain the content-length, and you would need to read the entire
+ *    body.</p>
+ * </note>
+ * <p>The copy request charge is based on the storage class and Region that you specify for
+ * the destination object. For pricing information, see <a href="http://aws.amazon.com/s3/pricing/">Amazon S3 pricing</a>.</p>
+ * <important>
+ *    <p>Amazon S3 transfer acceleration does not support cross-Region copies. If you request a
+ *    cross-Region copy using a transfer acceleration endpoint, you get a 400 <code>Bad
+ *       Request</code> error. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html">Transfer Acceleration</a>.</p>
+ * </important>
+ * <p>
+ *    <b>Metadata</b>
+ * </p>
+ * <p>When copying an object, you can preserve all metadata (default) or specify new metadata.
+ * However, the ACL is not preserved and is set to private for the user making the request. To
+ * override the default ACL setting, specify a new ACL when generating a copy request. For
+ * more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. </p>
+ * <p>To specify whether you want the object metadata copied from the source object or
+ * replaced with metadata provided in the request, you can optionally add the
+ *    <code>x-amz-metadata-directive</code> header. When you grant permissions, you can use
+ * the <code>s3:x-amz-metadata-directive</code> condition key to enforce certain metadata
+ * behavior when objects are uploaded. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html">Specifying Conditions in a
+ *    Policy</a> in the <i>Amazon S3 User Guide</i>. For a complete list of
+ * Amazon S3-specific condition keys, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/list_amazons3.html">Actions, Resources, and Condition Keys for
+ *    Amazon S3</a>.</p>
+ * <p>
+ *    <b>
+ *       <code>x-amz-copy-source-if</code> Headers</b>
+ * </p>
+ * <p>To only copy an object under certain conditions, such as whether the <code>Etag</code>
+ * matches or whether the object was modified before or after a specified date, use the
+ * following request parameters:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <code>x-amz-copy-source-if-match</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>x-amz-copy-source-if-none-match</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>x-amz-copy-source-if-unmodified-since</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>x-amz-copy-source-if-modified-since</code>
+ *       </p>
+ *    </li>
+ * </ul>
+ * <p> If both the <code>x-amz-copy-source-if-match</code> and
+ *    <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the request
+ * and evaluate as follows, Amazon S3 returns <code>200 OK</code> and copies the data:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <code>x-amz-copy-source-if-match</code> condition evaluates to true</p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to
+ *       false</p>
+ *    </li>
+ * </ul>
  *
- *          <p>If both the <code>x-amz-copy-source-if-none-match</code> and
- *             <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and
- *          evaluate as follows, Amazon S3 returns the <code>412 Precondition Failed</code> response
- *          code:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <code>x-amz-copy-source-if-none-match</code> condition evaluates to false</p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>x-amz-copy-source-if-modified-since</code> condition evaluates to
- *                true</p>
- *             </li>
- *          </ul>
+ * <p>If both the <code>x-amz-copy-source-if-none-match</code> and
+ *    <code>x-amz-copy-source-if-modified-since</code> headers are present in the request and
+ * evaluate as follows, Amazon S3 returns the <code>412 Precondition Failed</code> response
+ * code:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <code>x-amz-copy-source-if-none-match</code> condition evaluates to false</p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>x-amz-copy-source-if-modified-since</code> condition evaluates to
+ *       true</p>
+ *    </li>
+ * </ul>
  *
- *          <note>
- *             <p>All headers with the <code>x-amz-</code> prefix, including
- *                <code>x-amz-copy-source</code>, must be signed.</p>
- *          </note>
- *          <p>
- *             <b>Server-side encryption</b>
- *          </p>
- *          <p>When you perform a CopyObject operation, you can optionally use the appropriate encryption-related
- *          headers to encrypt the object using server-side encryption with Amazon Web Services managed encryption keys
- *          (SSE-S3 or SSE-KMS) or a customer-provided encryption key. With server-side encryption, Amazon S3
- *          encrypts your data as it writes it to disks in its data centers and decrypts the data when
- *          you access it. For more information about server-side encryption, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Using
- *          Server-Side Encryption</a>.</p>
- *          <p>If a target object uses SSE-KMS, you can enable an S3 Bucket Key for the object. For more
- *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.</p>
- *          <p>
- *             <b>Access Control List (ACL)-Specific Request
- *          Headers</b>
- *          </p>
- *          <p>When copying an object, you can optionally use headers to grant ACL-based permissions.
- *          By default, all objects are private. Only the owner has full access control. When adding a
- *          new object, you can grant permissions to individual Amazon Web Services accounts or to predefined groups
- *          defined by Amazon S3. These permissions are then added to the ACL on the object. For more
- *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL) Overview</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-using-rest-api.html">Managing ACLs Using the REST
- *             API</a>. </p>
+ * <note>
+ *    <p>All headers with the <code>x-amz-</code> prefix, including
+ *       <code>x-amz-copy-source</code>, must be signed.</p>
+ * </note>
+ * <p>
+ *    <b>Server-side encryption</b>
+ * </p>
+ * <p>When you perform a CopyObject operation, you can optionally use the appropriate encryption-related
+ * headers to encrypt the object using server-side encryption with Amazon Web Services managed encryption keys
+ * (SSE-S3 or SSE-KMS) or a customer-provided encryption key. With server-side encryption, Amazon S3
+ * encrypts your data as it writes it to disks in its data centers and decrypts the data when
+ * you access it. For more information about server-side encryption, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Using
+ * Server-Side Encryption</a>.</p>
+ * <p>If a target object uses SSE-KMS, you can enable an S3 Bucket Key for the object. For more
+ * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * <p>
+ *    <b>Access Control List (ACL)-Specific Request
+ * Headers</b>
+ * </p>
+ * <p>When copying an object, you can optionally use headers to grant ACL-based permissions.
+ * By default, all objects are private. Only the owner has full access control. When adding a
+ * new object, you can grant permissions to individual Amazon Web Services accounts or to predefined groups
+ * defined by Amazon S3. These permissions are then added to the ACL on the object. For more
+ * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL) Overview</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-using-rest-api.html">Managing ACLs Using the REST
+ *    API</a>. </p>
  *
- *          <p>
- *             <b>Storage Class Options</b>
- *          </p>
- *          <p>You can use the <code>CopyObject</code> action to change the storage class of an
- *          object that is already stored in Amazon S3 using the <code>StorageClass</code> parameter. For
- *          more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage
- *             Classes</a> in the <i>Amazon S3 User Guide</i>.</p>
- *          <p>
- *             <b>Versioning</b>
- *          </p>
- *          <p>By default, <code>x-amz-copy-source</code> identifies the current version of an object
- *          to copy. If the current version is a delete marker, Amazon S3 behaves as if the object was
- *          deleted. To copy a different version, use the <code>versionId</code> subresource.</p>
- *          <p>If you enable versioning on the target bucket, Amazon S3 generates a unique version ID for
- *          the object being copied. This version ID is different from the version ID of the source
- *          object. Amazon S3 returns the version ID of the copied object in the
- *             <code>x-amz-version-id</code> response header in the response.</p>
- *          <p>If you do not enable versioning or suspend it on the target bucket, the version ID that
- *          Amazon S3 generates is always null.</p>
- *          <p>If the source object's storage class is GLACIER, you must restore a copy of this object
- *          before you can use it as a source object for the copy operation. For more information, see
- *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a>.</p>
- *          <p>The following operations are related to <code>CopyObject</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
- *                </p>
- *             </li>
- *          </ul>
- *          <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html">Copying
- *             Objects</a>.</p>
+ * <p>
+ *    <b>Storage Class Options</b>
+ * </p>
+ * <p>You can use the <code>CopyObject</code> action to change the storage class of an
+ * object that is already stored in Amazon S3 using the <code>StorageClass</code> parameter. For
+ * more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage
+ *    Classes</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * <p>
+ *    <b>Versioning</b>
+ * </p>
+ * <p>By default, <code>x-amz-copy-source</code> identifies the current version of an object
+ * to copy. If the current version is a delete marker, Amazon S3 behaves as if the object was
+ * deleted. To copy a different version, use the <code>versionId</code> subresource.</p>
+ * <p>If you enable versioning on the target bucket, Amazon S3 generates a unique version ID for
+ * the object being copied. This version ID is different from the version ID of the source
+ * object. Amazon S3 returns the version ID of the copied object in the
+ *    <code>x-amz-version-id</code> response header in the response.</p>
+ * <p>If you do not enable versioning or suspend it on the target bucket, the version ID that
+ * Amazon S3 generates is always null.</p>
+ * <p>If the source object's storage class is GLACIER, you must restore a copy of this object
+ * before you can use it as a source object for the copy operation. For more information, see
+ *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a>.</p>
+ * <p>The following operations are related to <code>CopyObject</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+ *       </p>
+ *    </li>
+ * </ul>
+ * <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html">Copying
+ *    Objects</a>.</p>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/CreateBucketCommand.ts
+++ b/clients/client-s3/src/commands/CreateBucketCommand.ts
@@ -23,124 +23,124 @@ export interface CreateBucketCommandOutput extends CreateBucketOutput, __Metadat
 
 /**
  * <p>Creates a new S3 bucket. To create a bucket, you must register with Amazon S3 and have a
- *          valid Amazon Web Services Access Key ID to authenticate requests. Anonymous requests are never allowed to
- *          create buckets. By creating the bucket, you become the bucket owner.</p>
- *          <p>Not every string is an acceptable bucket name. For information about bucket naming
- *          restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html">Bucket naming rules</a>.</p>
- *          <p>If you want to create an Amazon S3 on Outposts bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_CreateBucket.html">Create Bucket</a>. </p>
- *          <p>By default, the bucket is created in the US East (N. Virginia) Region. You can
- *          optionally specify a Region in the request body. You might choose a Region to optimize
- *          latency, minimize costs, or address regulatory requirements. For example, if you reside in
- *          Europe, you will probably find it advantageous to create buckets in the Europe (Ireland)
- *          Region. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro">Accessing a
- *          bucket</a>.</p>
- *          <note>
- *             <p>If you send your create bucket request to the <code>s3.amazonaws.com</code> endpoint,
- *             the request goes to the us-east-1 Region. Accordingly, the signature calculations in
- *             Signature Version 4 must use us-east-1 as the Region, even if the location constraint in
- *             the request specifies another Region where the bucket is to be created. If you create a
- *             bucket in a Region other than US East (N. Virginia), your application must be able to
- *             handle 307 redirect. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html">Virtual hosting of buckets</a>.</p>
- *          </note>
- *          <p>When creating a bucket using this operation, you can optionally specify the accounts or
- *          groups that should be granted specific permissions on the bucket. There are two ways to
- *          grant the appropriate permissions using the request headers.</p>
- *          <ul>
- *             <li>
- *                <p>Specify a canned ACL using the <code>x-amz-acl</code> request header. Amazon S3
- *                supports a set of predefined ACLs, known as <i>canned ACLs</i>. Each
- *                canned ACL has a predefined set of grantees and permissions. For more information,
- *                see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
- *             </li>
- *             <li>
- *                <p>Specify access permissions explicitly using the <code>x-amz-grant-read</code>,
- *                   <code>x-amz-grant-write</code>, <code>x-amz-grant-read-acp</code>,
- *                   <code>x-amz-grant-write-acp</code>, and <code>x-amz-grant-full-control</code>
- *                headers. These headers map to the set of permissions Amazon S3 supports in an ACL. For
- *                more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access control list
- *                   (ACL) overview</a>.</p>
- *                <p>You specify each grantee as a type=value pair, where the type is one of the
- *                following:</p>
+ * valid Amazon Web Services Access Key ID to authenticate requests. Anonymous requests are never allowed to
+ * create buckets. By creating the bucket, you become the bucket owner.</p>
+ * <p>Not every string is an acceptable bucket name. For information about bucket naming
+ * restrictions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html">Bucket naming rules</a>.</p>
+ * <p>If you want to create an Amazon S3 on Outposts bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_CreateBucket.html">Create Bucket</a>. </p>
+ * <p>By default, the bucket is created in the US East (N. Virginia) Region. You can
+ * optionally specify a Region in the request body. You might choose a Region to optimize
+ * latency, minimize costs, or address regulatory requirements. For example, if you reside in
+ * Europe, you will probably find it advantageous to create buckets in the Europe (Ireland)
+ * Region. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro">Accessing a
+ * bucket</a>.</p>
+ * <note>
+ *    <p>If you send your create bucket request to the <code>s3.amazonaws.com</code> endpoint,
+ *    the request goes to the us-east-1 Region. Accordingly, the signature calculations in
+ *    Signature Version 4 must use us-east-1 as the Region, even if the location constraint in
+ *    the request specifies another Region where the bucket is to be created. If you create a
+ *    bucket in a Region other than US East (N. Virginia), your application must be able to
+ *    handle 307 redirect. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html">Virtual hosting of buckets</a>.</p>
+ * </note>
+ * <p>When creating a bucket using this operation, you can optionally specify the accounts or
+ * groups that should be granted specific permissions on the bucket. There are two ways to
+ * grant the appropriate permissions using the request headers.</p>
+ * <ul>
+ *    <li>
+ *       <p>Specify a canned ACL using the <code>x-amz-acl</code> request header. Amazon S3
+ *       supports a set of predefined ACLs, known as <i>canned ACLs</i>. Each
+ *       canned ACL has a predefined set of grantees and permissions. For more information,
+ *       see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
+ *    </li>
+ *    <li>
+ *       <p>Specify access permissions explicitly using the <code>x-amz-grant-read</code>,
+ *          <code>x-amz-grant-write</code>, <code>x-amz-grant-read-acp</code>,
+ *          <code>x-amz-grant-write-acp</code>, and <code>x-amz-grant-full-control</code>
+ *       headers. These headers map to the set of permissions Amazon S3 supports in an ACL. For
+ *       more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access control list
+ *          (ACL) overview</a>.</p>
+ *       <p>You specify each grantee as a type=value pair, where the type is one of the
+ *       following:</p>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <code>id</code> – if the value specified is the canonical user ID of an Amazon Web Services account</p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <code>uri</code> – if you are granting permissions to a predefined
+ *             group</p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <code>emailAddress</code> – if the value specified is the email address of
+ *             an Amazon Web Services account</p>
+ *             <note>
+ *                <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
  *                <ul>
  *                   <li>
- *                      <p>
- *                         <code>id</code> – if the value specified is the canonical user ID of an Amazon Web Services account</p>
+ *                      <p>US East (N. Virginia)</p>
  *                   </li>
  *                   <li>
- *                      <p>
- *                         <code>uri</code> – if you are granting permissions to a predefined
- *                      group</p>
+ *                      <p>US West (N. California)</p>
  *                   </li>
  *                   <li>
- *                      <p>
- *                         <code>emailAddress</code> – if the value specified is the email address of
- *                      an Amazon Web Services account</p>
- *                      <note>
- *                         <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
- *                         <ul>
- *                            <li>
- *                               <p>US East (N. Virginia)</p>
- *                            </li>
- *                            <li>
- *                               <p>US West (N. California)</p>
- *                            </li>
- *                            <li>
- *                               <p> US West (Oregon)</p>
- *                            </li>
- *                            <li>
- *                               <p> Asia Pacific (Singapore)</p>
- *                            </li>
- *                            <li>
- *                               <p>Asia Pacific (Sydney)</p>
- *                            </li>
- *                            <li>
- *                               <p>Asia Pacific (Tokyo)</p>
- *                            </li>
- *                            <li>
- *                               <p>Europe (Ireland)</p>
- *                            </li>
- *                            <li>
- *                               <p>South America (São Paulo)</p>
- *                            </li>
- *                         </ul>
- *                         <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
- *                      </note>
+ *                      <p> US West (Oregon)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p> Asia Pacific (Singapore)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p>Asia Pacific (Sydney)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p>Asia Pacific (Tokyo)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p>Europe (Ireland)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p>South America (São Paulo)</p>
  *                   </li>
  *                </ul>
- *                <p>For example, the following <code>x-amz-grant-read</code> header grants the Amazon Web Services accounts identified by account IDs permissions to read object data and its metadata:</p>
- *                <p>
- *                   <code>x-amz-grant-read: id="11112222333", id="444455556666" </code>
- *                </p>
- *             </li>
- *          </ul>
- *          <note>
- *             <p>You can use either a canned ACL or specify access permissions explicitly. You cannot
- *             do both.</p>
- *          </note>
+ *                <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
+ *             </note>
+ *          </li>
+ *       </ul>
+ *       <p>For example, the following <code>x-amz-grant-read</code> header grants the Amazon Web Services accounts identified by account IDs permissions to read object data and its metadata:</p>
+ *       <p>
+ *          <code>x-amz-grant-read: id="11112222333", id="444455556666" </code>
+ *       </p>
+ *    </li>
+ * </ul>
+ * <note>
+ *    <p>You can use either a canned ACL or specify access permissions explicitly. You cannot
+ *    do both.</p>
+ * </note>
  *
- *          <p>
- *             <b>Permissions</b>
- *          </p>
- *          <p>If your <code>CreateBucket</code> request specifies ACL permissions and the ACL is public-read, public-read-write,
- *          authenticated-read, or if you specify access permissions explicitly through any other ACL, both
- *          <code>s3:CreateBucket</code> and <code>s3:PutBucketAcl</code> permissions are needed. If the ACL the
- *          <code>CreateBucket</code> request is private, only <code>s3:CreateBucket</code> permission is needed. </p>
- *          <p>If <code>ObjectLockEnabledForBucket</code> is set to true in your <code>CreateBucket</code> request,
- *          <code>s3:PutBucketObjectLockConfiguration</code> and <code>s3:PutBucketVersioning</code> permissions are required.</p>
+ * <p>
+ *    <b>Permissions</b>
+ * </p>
+ * <p>If your <code>CreateBucket</code> request specifies ACL permissions and the ACL is public-read, public-read-write,
+ * authenticated-read, or if you specify access permissions explicitly through any other ACL, both
+ * <code>s3:CreateBucket</code> and <code>s3:PutBucketAcl</code> permissions are needed. If the ACL the
+ * <code>CreateBucket</code> request is private, only <code>s3:CreateBucket</code> permission is needed. </p>
+ * <p>If <code>ObjectLockEnabledForBucket</code> is set to true in your <code>CreateBucket</code> request,
+ * <code>s3:PutBucketObjectLockConfiguration</code> and <code>s3:PutBucketVersioning</code> permissions are required.</p>
  *
- *          <p>The following operations are related to <code>CreateBucket</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>CreateBucket</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/CreateMultipartUploadCommand.ts
+++ b/clients/client-s3/src/commands/CreateMultipartUploadCommand.ts
@@ -24,266 +24,266 @@ export interface CreateMultipartUploadCommandOutput extends CreateMultipartUploa
 
 /**
  * <p>This action initiates a multipart upload and returns an upload ID. This upload ID is
- *          used to associate all of the parts in the specific multipart upload. You specify this
- *          upload ID in each of your subsequent upload part requests (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>). You also include this
- *          upload ID in the final request to either complete or abort the multipart upload
- *          request.</p>
+ * used to associate all of the parts in the specific multipart upload. You specify this
+ * upload ID in each of your subsequent upload part requests (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>). You also include this
+ * upload ID in the final request to either complete or abort the multipart upload
+ * request.</p>
  *
- *          <p>For more information about multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html">Multipart Upload Overview</a>.</p>
+ * <p>For more information about multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html">Multipart Upload Overview</a>.</p>
  *
- *          <p>If you have configured a lifecycle rule to abort incomplete multipart uploads, the
- *          upload must complete within the number of days specified in the bucket lifecycle
- *          configuration. Otherwise, the incomplete multipart upload becomes eligible for an abort
- *          action and Amazon S3 aborts the multipart upload. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config">Aborting
- *             Incomplete Multipart Uploads Using a Bucket Lifecycle Policy</a>.</p>
+ * <p>If you have configured a lifecycle rule to abort incomplete multipart uploads, the
+ * upload must complete within the number of days specified in the bucket lifecycle
+ * configuration. Otherwise, the incomplete multipart upload becomes eligible for an abort
+ * action and Amazon S3 aborts the multipart upload. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config">Aborting
+ *    Incomplete Multipart Uploads Using a Bucket Lifecycle Policy</a>.</p>
  *
- *          <p>For information about the permissions required to use the multipart upload API, see
- *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
- *             Permissions</a>.</p>
+ * <p>For information about the permissions required to use the multipart upload API, see
+ *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
+ *    Permissions</a>.</p>
  *
- *          <p>For request signing, multipart upload is just a series of regular requests. You initiate
- *          a multipart upload, send one or more requests to upload parts, and then complete the
- *          multipart upload process. You sign each request individually. There is nothing special
- *          about signing multipart upload requests. For more information about signing, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html">Authenticating
- *             Requests (Amazon Web Services Signature Version 4)</a>.</p>
+ * <p>For request signing, multipart upload is just a series of regular requests. You initiate
+ * a multipart upload, send one or more requests to upload parts, and then complete the
+ * multipart upload process. You sign each request individually. There is nothing special
+ * about signing multipart upload requests. For more information about signing, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html">Authenticating
+ *    Requests (Amazon Web Services Signature Version 4)</a>.</p>
  *
- *          <note>
- *             <p> After you initiate a multipart upload and upload one or more parts, to stop being
- *             charged for storing the uploaded parts, you must either complete or abort the multipart
- *             upload. Amazon S3 frees up the space used to store the parts and stop charging you for
- *             storing them only after you either complete or abort a multipart upload. </p>
- *          </note>
+ * <note>
+ *    <p> After you initiate a multipart upload and upload one or more parts, to stop being
+ *    charged for storing the uploaded parts, you must either complete or abort the multipart
+ *    upload. Amazon S3 frees up the space used to store the parts and stop charging you for
+ *    storing them only after you either complete or abort a multipart upload. </p>
+ * </note>
  *
- *          <p>You can optionally request server-side encryption. For server-side encryption, Amazon S3
- *          encrypts your data as it writes it to disks in its data centers and decrypts it when you
- *          access it. You can provide your own encryption key, or use Amazon Web Services Key Management Service (Amazon Web Services
- *          KMS) customer master keys (CMKs) or Amazon S3-managed encryption keys. If you choose to provide
- *          your own encryption key, the request headers you provide in <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html">UploadPartCopy</a> requests must match the headers you used in the request to
- *          initiate the upload by using <code>CreateMultipartUpload</code>. </p>
- *          <p>To perform a multipart upload with encryption using an Amazon Web Services KMS CMK, the requester must
- *          have permission to the <code>kms:Decrypt</code> and <code>kms:GenerateDataKey*</code>
- *          actions on the key. These permissions are required because Amazon S3 must decrypt and read data
- *          from the encrypted file parts before it completes the multipart upload. For more
- *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html#mpuAndPermissions">Multipart upload API
- *             and permissions</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * <p>You can optionally request server-side encryption. For server-side encryption, Amazon S3
+ * encrypts your data as it writes it to disks in its data centers and decrypts it when you
+ * access it. You can provide your own encryption key, or use Amazon Web Services Key Management Service (Amazon Web Services
+ * KMS) customer master keys (CMKs) or Amazon S3-managed encryption keys. If you choose to provide
+ * your own encryption key, the request headers you provide in <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html">UploadPartCopy</a> requests must match the headers you used in the request to
+ * initiate the upload by using <code>CreateMultipartUpload</code>. </p>
+ * <p>To perform a multipart upload with encryption using an Amazon Web Services KMS CMK, the requester must
+ * have permission to the <code>kms:Decrypt</code> and <code>kms:GenerateDataKey*</code>
+ * actions on the key. These permissions are required because Amazon S3 must decrypt and read data
+ * from the encrypted file parts before it completes the multipart upload. For more
+ * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html#mpuAndPermissions">Multipart upload API
+ *    and permissions</a> in the <i>Amazon S3 User Guide</i>.</p>
  *
- *          <p>If your Identity and Access Management (IAM) user or role is in the same Amazon Web Services account
- *          as the Amazon Web Services KMS CMK, then you must have these permissions on the key policy. If your IAM
- *          user or role belongs to a different account than the key, then you must have the
- *          permissions on both the key policy and your IAM user or role.</p>
+ * <p>If your Identity and Access Management (IAM) user or role is in the same Amazon Web Services account
+ * as the Amazon Web Services KMS CMK, then you must have these permissions on the key policy. If your IAM
+ * user or role belongs to a different account than the key, then you must have the
+ * permissions on both the key policy and your IAM user or role.</p>
  *
  *
- *          <p> For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Protecting
- *             Data Using Server-Side Encryption</a>.</p>
+ * <p> For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Protecting
+ *    Data Using Server-Side Encryption</a>.</p>
  *
- *          <dl>
- *             <dt>Access Permissions</dt>
- *             <dd>
- *                <p>When copying an object, you can optionally specify the accounts or groups that
- *                   should be granted specific permissions on the new object. There are two ways to
- *                   grant the permissions using the request headers:</p>
- *                <ul>
- *                   <li>
- *                      <p>Specify a canned ACL with the <code>x-amz-acl</code> request header. For
- *                         more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
- *                   </li>
- *                   <li>
- *                      <p>Specify access permissions explicitly with the
- *                            <code>x-amz-grant-read</code>, <code>x-amz-grant-read-acp</code>,
- *                            <code>x-amz-grant-write-acp</code>, and
- *                            <code>x-amz-grant-full-control</code> headers. These parameters map to
- *                         the set of permissions that Amazon S3 supports in an ACL. For more information,
- *                         see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL)
- *                            Overview</a>.</p>
- *                   </li>
- *                </ul>
- *                <p>You can use either a canned ACL or specify access permissions explicitly. You
- *                   cannot do both.</p>
- *             </dd>
- *             <dt>Server-Side- Encryption-Specific Request Headers</dt>
- *             <dd>
- *                <p>You can optionally tell Amazon S3 to encrypt data at rest using server-side
- *                   encryption. Server-side encryption is for data encryption at rest. Amazon S3 encrypts
- *                   your data as it writes it to disks in its data centers and decrypts it when you
- *                   access it. The option you use depends on whether you want to use Amazon Web Services managed
- *                   encryption keys or provide your own encryption key. </p>
- *                <ul>
- *                   <li>
- *                      <p>Use encryption keys managed by Amazon S3 or customer master keys (CMKs) stored
- *                         in Amazon Web Services Key Management Service (Amazon Web Services KMS) – If you want Amazon Web Services to manage the keys
- *                         used to encrypt data, specify the following headers in the request.</p>
+ * <dl>
+ *    <dt>Access Permissions</dt>
+ *    <dd>
+ *       <p>When copying an object, you can optionally specify the accounts or groups that
+ *          should be granted specific permissions on the new object. There are two ways to
+ *          grant the permissions using the request headers:</p>
+ *       <ul>
+ *          <li>
+ *             <p>Specify a canned ACL with the <code>x-amz-acl</code> request header. For
+ *                more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
+ *          </li>
+ *          <li>
+ *             <p>Specify access permissions explicitly with the
+ *                   <code>x-amz-grant-read</code>, <code>x-amz-grant-read-acp</code>,
+ *                   <code>x-amz-grant-write-acp</code>, and
+ *                   <code>x-amz-grant-full-control</code> headers. These parameters map to
+ *                the set of permissions that Amazon S3 supports in an ACL. For more information,
+ *                see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL)
+ *                   Overview</a>.</p>
+ *          </li>
+ *       </ul>
+ *       <p>You can use either a canned ACL or specify access permissions explicitly. You
+ *          cannot do both.</p>
+ *    </dd>
+ *    <dt>Server-Side- Encryption-Specific Request Headers</dt>
+ *    <dd>
+ *       <p>You can optionally tell Amazon S3 to encrypt data at rest using server-side
+ *          encryption. Server-side encryption is for data encryption at rest. Amazon S3 encrypts
+ *          your data as it writes it to disks in its data centers and decrypts it when you
+ *          access it. The option you use depends on whether you want to use Amazon Web Services managed
+ *          encryption keys or provide your own encryption key. </p>
+ *       <ul>
+ *          <li>
+ *             <p>Use encryption keys managed by Amazon S3 or customer master keys (CMKs) stored
+ *                in Amazon Web Services Key Management Service (Amazon Web Services KMS) – If you want Amazon Web Services to manage the keys
+ *                used to encrypt data, specify the following headers in the request.</p>
+ *             <ul>
+ *                <li>
+ *                   <p>x-amz-server-side-encryption</p>
+ *                </li>
+ *                <li>
+ *                   <p>x-amz-server-side-encryption-aws-kms-key-id</p>
+ *                </li>
+ *                <li>
+ *                   <p>x-amz-server-side-encryption-context</p>
+ *                </li>
+ *             </ul>
+ *             <note>
+ *                <p>If you specify <code>x-amz-server-side-encryption:aws:kms</code>, but
+ *                   don't provide <code>x-amz-server-side-encryption-aws-kms-key-id</code>,
+ *                   Amazon S3 uses the Amazon Web Services managed CMK in Amazon Web Services KMS to protect the data.</p>
+ *             </note>
+ *             <important>
+ *                <p>All GET and PUT requests for an object protected by Amazon Web Services KMS fail if
+ *                   you don't make them with SSL or by using SigV4.</p>
+ *             </important>
+ *             <p>For more information about server-side encryption with CMKs stored in Amazon Web Services
+ *                KMS (SSE-KMS), see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html">Protecting Data Using Server-Side Encryption with CMKs stored in Amazon Web Services
+ *                   KMS</a>.</p>
+ *          </li>
+ *          <li>
+ *             <p>Use customer-provided encryption keys – If you want to manage your own
+ *                encryption keys, provide all the following headers in the request.</p>
+ *             <ul>
+ *                <li>
+ *                   <p>x-amz-server-side-encryption-customer-algorithm</p>
+ *                </li>
+ *                <li>
+ *                   <p>x-amz-server-side-encryption-customer-key</p>
+ *                </li>
+ *                <li>
+ *                   <p>x-amz-server-side-encryption-customer-key-MD5</p>
+ *                </li>
+ *             </ul>
+ *             <p>For more information about server-side encryption with CMKs stored in Amazon Web Services
+ *                KMS (SSE-KMS), see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html">Protecting Data Using Server-Side Encryption with CMKs stored in Amazon Web Services
+ *                   KMS</a>.</p>
+ *          </li>
+ *       </ul>
+ *    </dd>
+ *    <dt>Access-Control-List (ACL)-Specific Request Headers</dt>
+ *    <dd>
+ *       <p>You also can use the following access control–related headers with this
+ *          operation. By default, all objects are private. Only the owner has full access
+ *          control. When adding a new object, you can grant permissions to individual Amazon Web Services accounts or to predefined groups defined by Amazon S3. These permissions are then added
+ *          to the access control list (ACL) on the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. With this
+ *          operation, you can grant access permissions using one of the following two
+ *          methods:</p>
+ *       <ul>
+ *          <li>
+ *             <p>Specify a canned ACL (<code>x-amz-acl</code>) — Amazon S3 supports a set of
+ *                predefined ACLs, known as <i>canned ACLs</i>. Each canned ACL
+ *                has a predefined set of grantees and permissions. For more information, see
+ *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned
+ *                ACL</a>.</p>
+ *          </li>
+ *          <li>
+ *             <p>Specify access permissions explicitly — To explicitly grant access
+ *                permissions to specific Amazon Web Services accounts or groups, use the following headers.
+ *                Each header maps to specific permissions that Amazon S3 supports in an ACL. For
+ *                more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access
+ *                   Control List (ACL) Overview</a>. In the header, you specify a list of
+ *                grantees who get the specific permission. To grant permissions explicitly,
+ *                use:</p>
+ *             <ul>
+ *                <li>
+ *                   <p>x-amz-grant-read</p>
+ *                </li>
+ *                <li>
+ *                   <p>x-amz-grant-write</p>
+ *                </li>
+ *                <li>
+ *                   <p>x-amz-grant-read-acp</p>
+ *                </li>
+ *                <li>
+ *                   <p>x-amz-grant-write-acp</p>
+ *                </li>
+ *                <li>
+ *                   <p>x-amz-grant-full-control</p>
+ *                </li>
+ *             </ul>
+ *             <p>You specify each grantee as a type=value pair, where the type is one of
+ *                the following:</p>
+ *             <ul>
+ *                <li>
+ *                   <p>
+ *                      <code>id</code> – if the value specified is the canonical user ID
+ *                      of an Amazon Web Services account</p>
+ *                </li>
+ *                <li>
+ *                   <p>
+ *                      <code>uri</code> – if you are granting permissions to a predefined
+ *                      group</p>
+ *                </li>
+ *                <li>
+ *                   <p>
+ *                      <code>emailAddress</code> – if the value specified is the email
+ *                      address of an Amazon Web Services account</p>
+ *                   <note>
+ *                      <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
  *                      <ul>
  *                         <li>
- *                            <p>x-amz-server-side-encryption</p>
+ *                            <p>US East (N. Virginia)</p>
  *                         </li>
  *                         <li>
- *                            <p>x-amz-server-side-encryption-aws-kms-key-id</p>
+ *                            <p>US West (N. California)</p>
  *                         </li>
  *                         <li>
- *                            <p>x-amz-server-side-encryption-context</p>
+ *                            <p> US West (Oregon)</p>
+ *                         </li>
+ *                         <li>
+ *                            <p> Asia Pacific (Singapore)</p>
+ *                         </li>
+ *                         <li>
+ *                            <p>Asia Pacific (Sydney)</p>
+ *                         </li>
+ *                         <li>
+ *                            <p>Asia Pacific (Tokyo)</p>
+ *                         </li>
+ *                         <li>
+ *                            <p>Europe (Ireland)</p>
+ *                         </li>
+ *                         <li>
+ *                            <p>South America (São Paulo)</p>
  *                         </li>
  *                      </ul>
- *                      <note>
- *                         <p>If you specify <code>x-amz-server-side-encryption:aws:kms</code>, but
- *                            don't provide <code>x-amz-server-side-encryption-aws-kms-key-id</code>,
- *                            Amazon S3 uses the Amazon Web Services managed CMK in Amazon Web Services KMS to protect the data.</p>
- *                      </note>
- *                      <important>
- *                         <p>All GET and PUT requests for an object protected by Amazon Web Services KMS fail if
- *                            you don't make them with SSL or by using SigV4.</p>
- *                      </important>
- *                      <p>For more information about server-side encryption with CMKs stored in Amazon Web Services
- *                         KMS (SSE-KMS), see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html">Protecting Data Using Server-Side Encryption with CMKs stored in Amazon Web Services
- *                            KMS</a>.</p>
- *                   </li>
- *                   <li>
- *                      <p>Use customer-provided encryption keys – If you want to manage your own
- *                         encryption keys, provide all the following headers in the request.</p>
- *                      <ul>
- *                         <li>
- *                            <p>x-amz-server-side-encryption-customer-algorithm</p>
- *                         </li>
- *                         <li>
- *                            <p>x-amz-server-side-encryption-customer-key</p>
- *                         </li>
- *                         <li>
- *                            <p>x-amz-server-side-encryption-customer-key-MD5</p>
- *                         </li>
- *                      </ul>
- *                      <p>For more information about server-side encryption with CMKs stored in Amazon Web Services
- *                         KMS (SSE-KMS), see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html">Protecting Data Using Server-Side Encryption with CMKs stored in Amazon Web Services
- *                            KMS</a>.</p>
- *                   </li>
- *                </ul>
- *             </dd>
- *             <dt>Access-Control-List (ACL)-Specific Request Headers</dt>
- *             <dd>
- *                <p>You also can use the following access control–related headers with this
- *                   operation. By default, all objects are private. Only the owner has full access
- *                   control. When adding a new object, you can grant permissions to individual Amazon Web Services accounts or to predefined groups defined by Amazon S3. These permissions are then added
- *                   to the access control list (ACL) on the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. With this
- *                   operation, you can grant access permissions using one of the following two
- *                   methods:</p>
- *                <ul>
- *                   <li>
- *                      <p>Specify a canned ACL (<code>x-amz-acl</code>) — Amazon S3 supports a set of
- *                         predefined ACLs, known as <i>canned ACLs</i>. Each canned ACL
- *                         has a predefined set of grantees and permissions. For more information, see
- *                            <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned
- *                         ACL</a>.</p>
- *                   </li>
- *                   <li>
- *                      <p>Specify access permissions explicitly — To explicitly grant access
- *                         permissions to specific Amazon Web Services accounts or groups, use the following headers.
- *                         Each header maps to specific permissions that Amazon S3 supports in an ACL. For
- *                         more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access
- *                            Control List (ACL) Overview</a>. In the header, you specify a list of
- *                         grantees who get the specific permission. To grant permissions explicitly,
- *                         use:</p>
- *                      <ul>
- *                         <li>
- *                            <p>x-amz-grant-read</p>
- *                         </li>
- *                         <li>
- *                            <p>x-amz-grant-write</p>
- *                         </li>
- *                         <li>
- *                            <p>x-amz-grant-read-acp</p>
- *                         </li>
- *                         <li>
- *                            <p>x-amz-grant-write-acp</p>
- *                         </li>
- *                         <li>
- *                            <p>x-amz-grant-full-control</p>
- *                         </li>
- *                      </ul>
- *                      <p>You specify each grantee as a type=value pair, where the type is one of
- *                         the following:</p>
- *                      <ul>
- *                         <li>
- *                            <p>
- *                               <code>id</code> – if the value specified is the canonical user ID
- *                               of an Amazon Web Services account</p>
- *                         </li>
- *                         <li>
- *                            <p>
- *                               <code>uri</code> – if you are granting permissions to a predefined
- *                               group</p>
- *                         </li>
- *                         <li>
- *                            <p>
- *                               <code>emailAddress</code> – if the value specified is the email
- *                               address of an Amazon Web Services account</p>
- *                            <note>
- *                               <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
- *                               <ul>
- *                                  <li>
- *                                     <p>US East (N. Virginia)</p>
- *                                  </li>
- *                                  <li>
- *                                     <p>US West (N. California)</p>
- *                                  </li>
- *                                  <li>
- *                                     <p> US West (Oregon)</p>
- *                                  </li>
- *                                  <li>
- *                                     <p> Asia Pacific (Singapore)</p>
- *                                  </li>
- *                                  <li>
- *                                     <p>Asia Pacific (Sydney)</p>
- *                                  </li>
- *                                  <li>
- *                                     <p>Asia Pacific (Tokyo)</p>
- *                                  </li>
- *                                  <li>
- *                                     <p>Europe (Ireland)</p>
- *                                  </li>
- *                                  <li>
- *                                     <p>South America (São Paulo)</p>
- *                                  </li>
- *                               </ul>
- *                               <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
- *                            </note>
- *                         </li>
- *                      </ul>
- *                      <p>For example, the following <code>x-amz-grant-read</code> header grants the Amazon Web Services accounts identified by account IDs permissions to read object data and its metadata:</p>
- *                      <p>
- *                         <code>x-amz-grant-read: id="11112222333", id="444455556666" </code>
- *                      </p>
- *                   </li>
- *                </ul>
+ *                      <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
+ *                   </note>
+ *                </li>
+ *             </ul>
+ *             <p>For example, the following <code>x-amz-grant-read</code> header grants the Amazon Web Services accounts identified by account IDs permissions to read object data and its metadata:</p>
+ *             <p>
+ *                <code>x-amz-grant-read: id="11112222333", id="444455556666" </code>
+ *             </p>
+ *          </li>
+ *       </ul>
  *
- *             </dd>
- *          </dl>
+ *    </dd>
+ * </dl>
  *
- *          <p>The following operations are related to <code>CreateMultipartUpload</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>CreateMultipartUpload</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteBucketAnalyticsConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/DeleteBucketAnalyticsConfigurationCommand.ts
@@ -23,35 +23,35 @@ export interface DeleteBucketAnalyticsConfigurationCommandOutput extends __Metad
 
 /**
  * <p>Deletes an analytics configuration for the bucket (specified by the analytics
- *          configuration ID).</p>
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:PutAnalyticsConfiguration</code> action. The bucket owner has this permission
- *          by default. The bucket owner can grant this permission to others. For more information
- *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
+ * configuration ID).</p>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:PutAnalyticsConfiguration</code> action. The bucket owner has this permission
+ * by default. The bucket owner can grant this permission to others. For more information
+ * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
  *
- *          <p>For information about the Amazon S3 analytics feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
- *             Analysis</a>. </p>
+ * <p>For information about the Amazon S3 analytics feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
+ *    Analysis</a>. </p>
  *
- *          <p>The following operations are related to
- *          <code>DeleteBucketAnalyticsConfiguration</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAnalyticsConfiguration.html">GetBucketAnalyticsConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketAnalyticsConfigurations.html">ListBucketAnalyticsConfigurations</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html">PutBucketAnalyticsConfiguration</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to
+ * <code>DeleteBucketAnalyticsConfiguration</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAnalyticsConfiguration.html">GetBucketAnalyticsConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketAnalyticsConfigurations.html">ListBucketAnalyticsConfigurations</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html">PutBucketAnalyticsConfiguration</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteBucketCommand.ts
+++ b/clients/client-s3/src/commands/DeleteBucketCommand.ts
@@ -22,23 +22,23 @@ export interface DeleteBucketCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>Deletes the S3 bucket. All objects (including all object versions and delete markers) in
- *          the bucket must be deleted before the bucket itself can be deleted.</p>
+ * the bucket must be deleted before the bucket itself can be deleted.</p>
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteBucketCorsCommand.ts
+++ b/clients/client-s3/src/commands/DeleteBucketCorsCommand.ts
@@ -23,27 +23,27 @@ export interface DeleteBucketCorsCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>Deletes the <code>cors</code> configuration information set for the bucket.</p>
- *          <p>To use this operation, you must have permission to perform the
- *             <code>s3:PutBucketCORS</code> action. The bucket owner has this permission by default
- *          and can grant this permission to others. </p>
- *          <p>For information about <code>cors</code>, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html">Enabling
- *             Cross-Origin Resource Sharing</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * <p>To use this operation, you must have permission to perform the
+ *    <code>s3:PutBucketCORS</code> action. The bucket owner has this permission by default
+ * and can grant this permission to others. </p>
+ * <p>For information about <code>cors</code>, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html">Enabling
+ *    Cross-Origin Resource Sharing</a> in the <i>Amazon S3 User Guide</i>.</p>
  *
- *          <p class="title">
- *             <b>Related Resources:</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketCors.html">PutBucketCors</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTOPTIONSobject.html">RESTOPTIONSobject</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p class="title">
+ *    <b>Related Resources:</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketCors.html">PutBucketCors</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTOPTIONSobject.html">RESTOPTIONSobject</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteBucketEncryptionCommand.ts
+++ b/clients/client-s3/src/commands/DeleteBucketEncryptionCommand.ts
@@ -23,29 +23,29 @@ export interface DeleteBucketEncryptionCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>This implementation of the DELETE action removes default encryption from the bucket.
- *          For information about the Amazon S3 default encryption feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html">Amazon S3 Default Bucket Encryption</a> in the
- *             <i>Amazon S3 User Guide</i>.</p>
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:PutEncryptionConfiguration</code> action. The bucket owner has this permission
- *          by default. The bucket owner can grant this permission to others. For more information
- *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to your Amazon S3
- *             Resources</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * For information about the Amazon S3 default encryption feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html">Amazon S3 Default Bucket Encryption</a> in the
+ *    <i>Amazon S3 User Guide</i>.</p>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:PutEncryptionConfiguration</code> action. The bucket owner has this permission
+ * by default. The bucket owner can grant this permission to others. For more information
+ * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to your Amazon S3
+ *    Resources</a> in the <i>Amazon S3 User Guide</i>.</p>
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html">PutBucketEncryption</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html">GetBucketEncryption</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html">PutBucketEncryption</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html">GetBucketEncryption</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteBucketIntelligentTieringConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/DeleteBucketIntelligentTieringConfigurationCommand.ts
@@ -24,28 +24,28 @@ export interface DeleteBucketIntelligentTieringConfigurationCommandOutput extend
 
 /**
  * <p>Deletes the S3 Intelligent-Tiering configuration from the specified bucket.</p>
- *          <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
- *          <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
- *          <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
- *          <p>Operations related to
- *             <code>DeleteBucketIntelligentTieringConfiguration</code> include: </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html">GetBucketIntelligentTieringConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html">PutBucketIntelligentTieringConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html">ListBucketIntelligentTieringConfigurations</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
+ * <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
+ * <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
+ * <p>Operations related to
+ *    <code>DeleteBucketIntelligentTieringConfiguration</code> include: </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html">GetBucketIntelligentTieringConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html">PutBucketIntelligentTieringConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html">ListBucketIntelligentTieringConfigurations</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteBucketInventoryConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/DeleteBucketInventoryConfigurationCommand.ts
@@ -23,31 +23,31 @@ export interface DeleteBucketInventoryConfigurationCommandOutput extends __Metad
 
 /**
  * <p>Deletes an inventory configuration (identified by the inventory ID) from the
- *          bucket.</p>
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:PutInventoryConfiguration</code> action. The bucket owner has this permission
- *          by default. The bucket owner can grant this permission to others. For more information
- *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
- *          <p>For information about the Amazon S3 inventory feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3 Inventory</a>.</p>
- *          <p>Operations related to <code>DeleteBucketInventoryConfiguration</code> include: </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketInventoryConfiguration.html">GetBucketInventoryConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html">PutBucketInventoryConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketInventoryConfigurations.html">ListBucketInventoryConfigurations</a>
- *                </p>
- *             </li>
- *          </ul>
+ * bucket.</p>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:PutInventoryConfiguration</code> action. The bucket owner has this permission
+ * by default. The bucket owner can grant this permission to others. For more information
+ * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
+ * <p>For information about the Amazon S3 inventory feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3 Inventory</a>.</p>
+ * <p>Operations related to <code>DeleteBucketInventoryConfiguration</code> include: </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketInventoryConfiguration.html">GetBucketInventoryConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html">PutBucketInventoryConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketInventoryConfigurations.html">ListBucketInventoryConfigurations</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteBucketLifecycleCommand.ts
+++ b/clients/client-s3/src/commands/DeleteBucketLifecycleCommand.ts
@@ -23,31 +23,31 @@ export interface DeleteBucketLifecycleCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>Deletes the lifecycle configuration from the specified bucket. Amazon S3 removes all the
- *          lifecycle configuration rules in the lifecycle subresource associated with the bucket. Your
- *          objects never expire, and Amazon S3 no longer automatically deletes any objects on the basis of
- *          rules contained in the deleted lifecycle configuration.</p>
- *          <p>To use this operation, you must have permission to perform the
- *             <code>s3:PutLifecycleConfiguration</code> action. By default, the bucket owner has this
- *          permission and the bucket owner can grant this permission to others.</p>
+ * lifecycle configuration rules in the lifecycle subresource associated with the bucket. Your
+ * objects never expire, and Amazon S3 no longer automatically deletes any objects on the basis of
+ * rules contained in the deleted lifecycle configuration.</p>
+ * <p>To use this operation, you must have permission to perform the
+ *    <code>s3:PutLifecycleConfiguration</code> action. By default, the bucket owner has this
+ * permission and the bucket owner can grant this permission to others.</p>
  *
- *          <p>There is usually some time lag before lifecycle configuration deletion is fully
- *          propagated to all the Amazon S3 systems.</p>
+ * <p>There is usually some time lag before lifecycle configuration deletion is fully
+ * propagated to all the Amazon S3 systems.</p>
  *
- *          <p>For more information about the object expiration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#intro-lifecycle-rules-actions">Elements to
- *             Describe Lifecycle Actions</a>.</p>
- *          <p>Related actions include:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html">GetBucketLifecycleConfiguration</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>For more information about the object expiration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#intro-lifecycle-rules-actions">Elements to
+ *    Describe Lifecycle Actions</a>.</p>
+ * <p>Related actions include:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html">GetBucketLifecycleConfiguration</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteBucketMetricsConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/DeleteBucketMetricsConfigurationCommand.ts
@@ -23,41 +23,41 @@ export interface DeleteBucketMetricsConfigurationCommandOutput extends __Metadat
 
 /**
  * <p>Deletes a metrics configuration for the Amazon CloudWatch request metrics (specified by the
- *          metrics configuration ID) from the bucket. Note that this doesn't include the daily storage
- *          metrics.</p>
+ * metrics configuration ID) from the bucket. Note that this doesn't include the daily storage
+ * metrics.</p>
  *
- *          <p> To use this operation, you must have permissions to perform the
- *             <code>s3:PutMetricsConfiguration</code> action. The bucket owner has this permission by
- *          default. The bucket owner can grant this permission to others. For more information about
- *          permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
+ * <p> To use this operation, you must have permissions to perform the
+ *    <code>s3:PutMetricsConfiguration</code> action. The bucket owner has this permission by
+ * default. The bucket owner can grant this permission to others. For more information about
+ * permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
  *
- *          <p>For information about CloudWatch request metrics for Amazon S3, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon CloudWatch</a>. </p>
- *          <p>The following operations are related to
- *          <code>DeleteBucketMetricsConfiguration</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetricsConfiguration.html">GetBucketMetricsConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketMetricsConfigurations.html">ListBucketMetricsConfigurations</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
- *                   CloudWatch</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>For information about CloudWatch request metrics for Amazon S3, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon CloudWatch</a>. </p>
+ * <p>The following operations are related to
+ * <code>DeleteBucketMetricsConfiguration</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetricsConfiguration.html">GetBucketMetricsConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketMetricsConfigurations.html">ListBucketMetricsConfigurations</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
+ *          CloudWatch</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteBucketOwnershipControlsCommand.ts
+++ b/clients/client-s3/src/commands/DeleteBucketOwnershipControlsCommand.ts
@@ -23,24 +23,24 @@ export interface DeleteBucketOwnershipControlsCommandOutput extends __MetadataBe
 
 /**
  * <p>Removes <code>OwnershipControls</code> for an Amazon S3 bucket. To use this operation, you
- *          must have the <code>s3:PutBucketOwnershipControls</code> permission. For more information
- *          about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying
- *             Permissions in a Policy</a>.</p>
- *          <p>For information about Amazon S3 Object Ownership, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html">Using Object Ownership</a>. </p>
- *          <p>The following operations are related to
- *          <code>DeleteBucketOwnershipControls</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a>GetBucketOwnershipControls</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a>PutBucketOwnershipControls</a>
- *                </p>
- *             </li>
- *          </ul>
+ * must have the <code>s3:PutBucketOwnershipControls</code> permission. For more information
+ * about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying
+ *    Permissions in a Policy</a>.</p>
+ * <p>For information about Amazon S3 Object Ownership, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html">Using Object Ownership</a>. </p>
+ * <p>The following operations are related to
+ * <code>DeleteBucketOwnershipControls</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a>GetBucketOwnershipControls</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a>PutBucketOwnershipControls</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteBucketPolicyCommand.ts
+++ b/clients/client-s3/src/commands/DeleteBucketPolicyCommand.ts
@@ -23,38 +23,38 @@ export interface DeleteBucketPolicyCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>This implementation of the DELETE action uses the policy subresource to delete the
- *          policy of a specified bucket. If you are using an identity other than the root user of the
- *          Amazon Web Services account that owns the bucket, the calling identity must have the
- *             <code>DeleteBucketPolicy</code> permissions on the specified bucket and belong to the
- *          bucket owner's account to use this operation. </p>
+ * policy of a specified bucket. If you are using an identity other than the root user of the
+ * Amazon Web Services account that owns the bucket, the calling identity must have the
+ *    <code>DeleteBucketPolicy</code> permissions on the specified bucket and belong to the
+ * bucket owner's account to use this operation. </p>
  *
- *          <p>If you don't have <code>DeleteBucketPolicy</code> permissions, Amazon S3 returns a <code>403
- *             Access Denied</code> error. If you have the correct permissions, but you're not using an
- *          identity that belongs to the bucket owner's account, Amazon S3 returns a <code>405 Method Not
- *             Allowed</code> error. </p>
+ * <p>If you don't have <code>DeleteBucketPolicy</code> permissions, Amazon S3 returns a <code>403
+ *    Access Denied</code> error. If you have the correct permissions, but you're not using an
+ * identity that belongs to the bucket owner's account, Amazon S3 returns a <code>405 Method Not
+ *    Allowed</code> error. </p>
  *
- *          <important>
- *             <p>As a security precaution, the root user of the Amazon Web Services account that owns a bucket can
- *             always use this operation, even if the policy explicitly denies the root user the
- *             ability to perform this action.</p>
- *          </important>
+ * <important>
+ *    <p>As a security precaution, the root user of the Amazon Web Services account that owns a bucket can
+ *    always use this operation, even if the policy explicitly denies the root user the
+ *    ability to perform this action.</p>
+ * </important>
  *
- *          <p>For more information about bucket policies, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies and
- *             UserPolicies</a>. </p>
- *          <p>The following operations are related to <code>DeleteBucketPolicy</code>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>For more information about bucket policies, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies and
+ *    UserPolicies</a>. </p>
+ * <p>The following operations are related to <code>DeleteBucketPolicy</code>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteBucketReplicationCommand.ts
+++ b/clients/client-s3/src/commands/DeleteBucketReplicationCommand.ts
@@ -23,31 +23,31 @@ export interface DeleteBucketReplicationCommandOutput extends __MetadataBearer {
 
 /**
  * <p> Deletes the replication configuration from the bucket.</p>
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:PutReplicationConfiguration</code> action. The bucket owner has these
- *          permissions by default and can grant it to others. For more information about permissions,
- *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>. </p>
- *          <note>
- *             <p>It can take a while for the deletion of a replication configuration to fully
- *             propagate.</p>
- *          </note>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:PutReplicationConfiguration</code> action. The bucket owner has these
+ * permissions by default and can grant it to others. For more information about permissions,
+ * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>. </p>
+ * <note>
+ *    <p>It can take a while for the deletion of a replication configuration to fully
+ *    propagate.</p>
+ * </note>
  *
- *          <p> For information about replication configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html">Replication</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * <p> For information about replication configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html">Replication</a> in the <i>Amazon S3 User Guide</i>.</p>
  *
- *          <p>The following operations are related to <code>DeleteBucketReplication</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html">PutBucketReplication</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketReplication.html">GetBucketReplication</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>DeleteBucketReplication</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html">PutBucketReplication</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketReplication.html">GetBucketReplication</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteBucketTaggingCommand.ts
+++ b/clients/client-s3/src/commands/DeleteBucketTaggingCommand.ts
@@ -24,22 +24,22 @@ export interface DeleteBucketTaggingCommandOutput extends __MetadataBearer {}
 /**
  * <p>Deletes the tags from the bucket.</p>
  *
- *          <p>To use this operation, you must have permission to perform the
- *             <code>s3:PutBucketTagging</code> action. By default, the bucket owner has this
- *          permission and can grant this permission to others. </p>
- *          <p>The following operations are related to <code>DeleteBucketTagging</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html">GetBucketTagging</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketTagging.html">PutBucketTagging</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>To use this operation, you must have permission to perform the
+ *    <code>s3:PutBucketTagging</code> action. By default, the bucket owner has this
+ * permission and can grant this permission to others. </p>
+ * <p>The following operations are related to <code>DeleteBucketTagging</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html">GetBucketTagging</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketTagging.html">PutBucketTagging</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteBucketWebsiteCommand.ts
+++ b/clients/client-s3/src/commands/DeleteBucketWebsiteCommand.ts
@@ -23,32 +23,32 @@ export interface DeleteBucketWebsiteCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>This action removes the website configuration for a bucket. Amazon S3 returns a <code>200
- *             OK</code> response upon successfully deleting a website configuration on the specified
- *          bucket. You will get a <code>200 OK</code> response if the website configuration you are
- *          trying to delete does not exist on the bucket. Amazon S3 returns a <code>404</code> response if
- *          the bucket specified in the request does not exist.</p>
+ *    OK</code> response upon successfully deleting a website configuration on the specified
+ * bucket. You will get a <code>200 OK</code> response if the website configuration you are
+ * trying to delete does not exist on the bucket. Amazon S3 returns a <code>404</code> response if
+ * the bucket specified in the request does not exist.</p>
  *
- *          <p>This DELETE action requires the <code>S3:DeleteBucketWebsite</code> permission. By
- *          default, only the bucket owner can delete the website configuration attached to a bucket.
- *          However, bucket owners can grant other users permission to delete the website configuration
- *          by writing a bucket policy granting them the <code>S3:DeleteBucketWebsite</code>
- *          permission. </p>
+ * <p>This DELETE action requires the <code>S3:DeleteBucketWebsite</code> permission. By
+ * default, only the bucket owner can delete the website configuration attached to a bucket.
+ * However, bucket owners can grant other users permission to delete the website configuration
+ * by writing a bucket policy granting them the <code>S3:DeleteBucketWebsite</code>
+ * permission. </p>
  *
- *          <p>For more information about hosting websites, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html">Hosting Websites on Amazon S3</a>. </p>
+ * <p>For more information about hosting websites, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html">Hosting Websites on Amazon S3</a>. </p>
  *
- *          <p>The following operations are related to <code>DeleteBucketWebsite</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketWebsite.html">GetBucketWebsite</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketWebsite.html">PutBucketWebsite</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>DeleteBucketWebsite</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketWebsite.html">GetBucketWebsite</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketWebsite.html">PutBucketWebsite</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteObjectCommand.ts
+++ b/clients/client-s3/src/commands/DeleteObjectCommand.ts
@@ -23,36 +23,36 @@ export interface DeleteObjectCommandOutput extends DeleteObjectOutput, __Metadat
 
 /**
  * <p>Removes the null version (if there is one) of an object and inserts a delete marker,
- *          which becomes the latest version of the object. If there isn't a null version, Amazon S3 does
- *          not remove any objects but will still respond that the command was successful.</p>
+ * which becomes the latest version of the object. If there isn't a null version, Amazon S3 does
+ * not remove any objects but will still respond that the command was successful.</p>
  *
- *          <p>To remove a specific version, you must be the bucket owner and you must use the version
- *          Id subresource. Using this subresource permanently deletes the version. If the object
- *          deleted is a delete marker, Amazon S3 sets the response header,
- *          <code>x-amz-delete-marker</code>, to true. </p>
+ * <p>To remove a specific version, you must be the bucket owner and you must use the version
+ * Id subresource. Using this subresource permanently deletes the version. If the object
+ * deleted is a delete marker, Amazon S3 sets the response header,
+ * <code>x-amz-delete-marker</code>, to true. </p>
  *
- *          <p>If the object you want to delete is in a bucket where the bucket versioning
- *          configuration is MFA Delete enabled, you must include the <code>x-amz-mfa</code> request
- *          header in the DELETE <code>versionId</code> request. Requests that include
- *             <code>x-amz-mfa</code> must use HTTPS. </p>
+ * <p>If the object you want to delete is in a bucket where the bucket versioning
+ * configuration is MFA Delete enabled, you must include the <code>x-amz-mfa</code> request
+ * header in the DELETE <code>versionId</code> request. Requests that include
+ *    <code>x-amz-mfa</code> must use HTTPS. </p>
  *
- *          <p> For more information about MFA Delete, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMFADelete.html">Using MFA Delete</a>. To see sample requests that use versioning, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html#ExampleVersionObjectDelete">Sample Request</a>. </p>
+ * <p> For more information about MFA Delete, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMFADelete.html">Using MFA Delete</a>. To see sample requests that use versioning, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectDELETE.html#ExampleVersionObjectDelete">Sample Request</a>. </p>
  *
- *          <p>You can delete objects by explicitly calling DELETE Object or configure its
- *          lifecycle (<a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html">PutBucketLifecycle</a>) to
- *          enable Amazon S3 to remove them for you. If you want to block users or accounts from removing or
- *          deleting objects from your bucket, you must deny them the <code>s3:DeleteObject</code>,
- *             <code>s3:DeleteObjectVersion</code>, and <code>s3:PutLifeCycleConfiguration</code>
- *          actions. </p>
+ * <p>You can delete objects by explicitly calling DELETE Object or configure its
+ * lifecycle (<a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html">PutBucketLifecycle</a>) to
+ * enable Amazon S3 to remove them for you. If you want to block users or accounts from removing or
+ * deleting objects from your bucket, you must deny them the <code>s3:DeleteObject</code>,
+ *    <code>s3:DeleteObjectVersion</code>, and <code>s3:PutLifeCycleConfiguration</code>
+ * actions. </p>
  *
- *          <p>The following action is related to <code>DeleteObject</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following action is related to <code>DeleteObject</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteObjectTaggingCommand.ts
+++ b/clients/client-s3/src/commands/DeleteObjectTaggingCommand.ts
@@ -23,30 +23,30 @@ export interface DeleteObjectTaggingCommandOutput extends DeleteObjectTaggingOut
 
 /**
  * <p>Removes the entire tag set from the specified object. For more information about
- *          managing object tags, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html"> Object
- *             Tagging</a>.</p>
+ * managing object tags, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html"> Object
+ *    Tagging</a>.</p>
  *
- *          <p>To use this operation, you must have permission to perform the
- *             <code>s3:DeleteObjectTagging</code> action.</p>
+ * <p>To use this operation, you must have permission to perform the
+ *    <code>s3:DeleteObjectTagging</code> action.</p>
  *
- *          <p>To delete tags of a specific object version, add the <code>versionId</code> query
- *          parameter in the request. You will need permission for the
- *             <code>s3:DeleteObjectVersionTagging</code> action.</p>
+ * <p>To delete tags of a specific object version, add the <code>versionId</code> query
+ * parameter in the request. You will need permission for the
+ *    <code>s3:DeleteObjectVersionTagging</code> action.</p>
  *
- *          <p>The following operations are related to
- *          <code>DeleteBucketMetricsConfiguration</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectTagging.html">PutObjectTagging</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to
+ * <code>DeleteBucketMetricsConfiguration</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectTagging.html">PutObjectTagging</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeleteObjectsCommand.ts
+++ b/clients/client-s3/src/commands/DeleteObjectsCommand.ts
@@ -24,62 +24,62 @@ export interface DeleteObjectsCommandOutput extends DeleteObjectsOutput, __Metad
 
 /**
  * <p>This action enables you to delete multiple objects from a bucket using a single HTTP
- *          request. If you know the object keys that you want to delete, then this action provides
- *          a suitable alternative to sending individual delete requests, reducing per-request
- *          overhead.</p>
+ * request. If you know the object keys that you want to delete, then this action provides
+ * a suitable alternative to sending individual delete requests, reducing per-request
+ * overhead.</p>
  *
- *          <p>The request contains a list of up to 1000 keys that you want to delete. In the XML, you
- *          provide the object key names, and optionally, version IDs if you want to delete a specific
- *          version of the object from a versioning-enabled bucket. For each key, Amazon S3 performs a
- *          delete action and returns the result of that delete, success, or failure, in the
- *          response. Note that if the object specified in the request is not found, Amazon S3 returns the
- *          result as deleted.</p>
+ * <p>The request contains a list of up to 1000 keys that you want to delete. In the XML, you
+ * provide the object key names, and optionally, version IDs if you want to delete a specific
+ * version of the object from a versioning-enabled bucket. For each key, Amazon S3 performs a
+ * delete action and returns the result of that delete, success, or failure, in the
+ * response. Note that if the object specified in the request is not found, Amazon S3 returns the
+ * result as deleted.</p>
  *
- *          <p> The action supports two modes for the response: verbose and quiet. By default, the
- *          action uses verbose mode in which the response includes the result of deletion of each
- *          key in your request. In quiet mode the response includes only keys where the delete
- *          action encountered an error. For a successful deletion, the action does not return
- *          any information about the delete in the response body.</p>
+ * <p> The action supports two modes for the response: verbose and quiet. By default, the
+ * action uses verbose mode in which the response includes the result of deletion of each
+ * key in your request. In quiet mode the response includes only keys where the delete
+ * action encountered an error. For a successful deletion, the action does not return
+ * any information about the delete in the response body.</p>
  *
- *          <p>When performing this action on an MFA Delete enabled bucket, that attempts to delete
- *          any versioned objects, you must include an MFA token. If you do not provide one, the entire
- *          request will fail, even if there are non-versioned objects you are trying to delete. If you
- *          provide an invalid token, whether there are versioned keys in the request or not, the
- *          entire Multi-Object Delete request will fail. For information about MFA Delete, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html#MultiFactorAuthenticationDelete"> MFA
- *          Delete</a>.</p>
+ * <p>When performing this action on an MFA Delete enabled bucket, that attempts to delete
+ * any versioned objects, you must include an MFA token. If you do not provide one, the entire
+ * request will fail, even if there are non-versioned objects you are trying to delete. If you
+ * provide an invalid token, whether there are versioned keys in the request or not, the
+ * entire Multi-Object Delete request will fail. For information about MFA Delete, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html#MultiFactorAuthenticationDelete"> MFA
+ * Delete</a>.</p>
  *
- *          <p>Finally, the Content-MD5 header is required for all Multi-Object Delete requests. Amazon
- *          S3 uses the header value to ensure that your request body has not been altered in
- *          transit.</p>
+ * <p>Finally, the Content-MD5 header is required for all Multi-Object Delete requests. Amazon
+ * S3 uses the header value to ensure that your request body has not been altered in
+ * transit.</p>
  *
- *          <p>The following operations are related to <code>DeleteObjects</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>DeleteObjects</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/DeletePublicAccessBlockCommand.ts
+++ b/clients/client-s3/src/commands/DeletePublicAccessBlockCommand.ts
@@ -23,34 +23,34 @@ export interface DeletePublicAccessBlockCommandOutput extends __MetadataBearer {
 
 /**
  * <p>Removes the <code>PublicAccessBlock</code> configuration for an Amazon S3 bucket. To use this
- *          operation, you must have the <code>s3:PutBucketPublicAccessBlock</code> permission. For
- *          more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
+ * operation, you must have the <code>s3:PutBucketPublicAccessBlock</code> permission. For
+ * more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
  *
- *          <p>The following operations are related to <code>DeletePublicAccessBlock</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
- *                   Public Access</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutPublicAccessBlock.html">PutPublicAccessBlock</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicyStatus.html">GetBucketPolicyStatus</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>DeletePublicAccessBlock</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
+ *          Public Access</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutPublicAccessBlock.html">PutPublicAccessBlock</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicyStatus.html">GetBucketPolicyStatus</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketAccelerateConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketAccelerateConfigurationCommand.ts
@@ -25,32 +25,32 @@ export interface GetBucketAccelerateConfigurationCommandOutput
 
 /**
  * <p>This implementation of the GET action uses the <code>accelerate</code> subresource to
- *          return the Transfer Acceleration state of a bucket, which is either <code>Enabled</code> or
- *             <code>Suspended</code>. Amazon S3 Transfer Acceleration is a bucket-level feature that
- *          enables you to perform faster data transfers to and from Amazon S3.</p>
- *          <p>To use this operation, you must have permission to perform the
- *             <code>s3:GetAccelerateConfiguration</code> action. The bucket owner has this permission
- *          by default. The bucket owner can grant this permission to others. For more information
- *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to your Amazon S3
- *             Resources</a> in the <i>Amazon S3 User Guide</i>.</p>
- *          <p>You set the Transfer Acceleration state of an existing bucket to <code>Enabled</code> or
- *             <code>Suspended</code> by using the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAccelerateConfiguration.html">PutBucketAccelerateConfiguration</a> operation. </p>
- *          <p>A GET <code>accelerate</code> request does not return a state value for a bucket that
- *          has no transfer acceleration state. A bucket has no Transfer Acceleration state if a state
- *          has never been set on the bucket. </p>
+ * return the Transfer Acceleration state of a bucket, which is either <code>Enabled</code> or
+ *    <code>Suspended</code>. Amazon S3 Transfer Acceleration is a bucket-level feature that
+ * enables you to perform faster data transfers to and from Amazon S3.</p>
+ * <p>To use this operation, you must have permission to perform the
+ *    <code>s3:GetAccelerateConfiguration</code> action. The bucket owner has this permission
+ * by default. The bucket owner can grant this permission to others. For more information
+ * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to your Amazon S3
+ *    Resources</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * <p>You set the Transfer Acceleration state of an existing bucket to <code>Enabled</code> or
+ *    <code>Suspended</code> by using the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAccelerateConfiguration.html">PutBucketAccelerateConfiguration</a> operation. </p>
+ * <p>A GET <code>accelerate</code> request does not return a state value for a bucket that
+ * has no transfer acceleration state. A bucket has no Transfer Acceleration state if a state
+ * has never been set on the bucket. </p>
  *
- *          <p>For more information about transfer acceleration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html">Transfer Acceleration</a> in the
- *          Amazon S3 User Guide.</p>
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAccelerateConfiguration.html">PutBucketAccelerateConfiguration</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>For more information about transfer acceleration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html">Transfer Acceleration</a> in the
+ * Amazon S3 User Guide.</p>
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAccelerateConfiguration.html">PutBucketAccelerateConfiguration</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketAclCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketAclCommand.ts
@@ -23,21 +23,21 @@ export interface GetBucketAclCommandOutput extends GetBucketAclOutput, __Metadat
 
 /**
  * <p>This implementation of the <code>GET</code> action uses the <code>acl</code>
- *          subresource to return the access control list (ACL) of a bucket. To use <code>GET</code> to
- *          return the ACL of the bucket, you must have <code>READ_ACP</code> access to the bucket. If
- *             <code>READ_ACP</code> permission is granted to the anonymous user, you can return the
- *          ACL of the bucket without using an authorization header.</p>
+ * subresource to return the access control list (ACL) of a bucket. To use <code>GET</code> to
+ * return the ACL of the bucket, you must have <code>READ_ACP</code> access to the bucket. If
+ *    <code>READ_ACP</code> permission is granted to the anonymous user, you can return the
+ * ACL of the bucket without using an authorization header.</p>
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketAnalyticsConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketAnalyticsConfigurationCommand.ts
@@ -25,35 +25,35 @@ export interface GetBucketAnalyticsConfigurationCommandOutput
 
 /**
  * <p>This implementation of the GET action returns an analytics configuration (identified
- *          by the analytics configuration ID) from the bucket.</p>
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:GetAnalyticsConfiguration</code> action. The bucket owner has this permission
- *          by default. The bucket owner can grant this permission to others. For more information
- *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources"> Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a> in the <i>Amazon S3 User Guide</i>. </p>
- *          <p>For information about Amazon S3 analytics feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
- *             Analysis</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * by the analytics configuration ID) from the bucket.</p>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:GetAnalyticsConfiguration</code> action. The bucket owner has this permission
+ * by default. The bucket owner can grant this permission to others. For more information
+ * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources"> Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a> in the <i>Amazon S3 User Guide</i>. </p>
+ * <p>For information about Amazon S3 analytics feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
+ *    Analysis</a> in the <i>Amazon S3 User Guide</i>.</p>
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketAnalyticsConfiguration.html">DeleteBucketAnalyticsConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketAnalyticsConfigurations.html">ListBucketAnalyticsConfigurations</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html">PutBucketAnalyticsConfiguration</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketAnalyticsConfiguration.html">DeleteBucketAnalyticsConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketAnalyticsConfigurations.html">ListBucketAnalyticsConfigurations</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html">PutBucketAnalyticsConfiguration</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketCorsCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketCorsCommand.ts
@@ -24,25 +24,25 @@ export interface GetBucketCorsCommandOutput extends GetBucketCorsOutput, __Metad
 /**
  * <p>Returns the cors configuration information set for the bucket.</p>
  *
- *          <p> To use this operation, you must have permission to perform the s3:GetBucketCORS action.
- *          By default, the bucket owner has this permission and can grant it to others.</p>
+ * <p> To use this operation, you must have permission to perform the s3:GetBucketCORS action.
+ * By default, the bucket owner has this permission and can grant it to others.</p>
  *
- *          <p> For more information about cors, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html"> Enabling
- *             Cross-Origin Resource Sharing</a>.</p>
+ * <p> For more information about cors, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html"> Enabling
+ *    Cross-Origin Resource Sharing</a>.</p>
  *
- *          <p>The following operations are related to <code>GetBucketCors</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketCors.html">PutBucketCors</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketCors.html">DeleteBucketCors</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>GetBucketCors</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketCors.html">PutBucketCors</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketCors.html">DeleteBucketCors</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketEncryptionCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketEncryptionCommand.ts
@@ -23,27 +23,27 @@ export interface GetBucketEncryptionCommandOutput extends GetBucketEncryptionOut
 
 /**
  * <p>Returns the default encryption configuration for an Amazon S3 bucket. If the bucket does not
- *          have a default encryption configuration, GetBucketEncryption returns
- *          <code>ServerSideEncryptionConfigurationNotFoundError</code>. </p>
- *          <p>For information about the Amazon S3 default encryption feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html">Amazon S3 Default Bucket Encryption</a>.</p>
- *          <p> To use this operation, you must have permission to perform the
- *             <code>s3:GetEncryptionConfiguration</code> action. The bucket owner has this permission
- *          by default. The bucket owner can grant this permission to others. For more information
- *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
- *          <p>The following operations are related to <code>GetBucketEncryption</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html">PutBucketEncryption</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketEncryption.html">DeleteBucketEncryption</a>
- *                </p>
- *             </li>
- *          </ul>
+ * have a default encryption configuration, GetBucketEncryption returns
+ * <code>ServerSideEncryptionConfigurationNotFoundError</code>. </p>
+ * <p>For information about the Amazon S3 default encryption feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html">Amazon S3 Default Bucket Encryption</a>.</p>
+ * <p> To use this operation, you must have permission to perform the
+ *    <code>s3:GetEncryptionConfiguration</code> action. The bucket owner has this permission
+ * by default. The bucket owner can grant this permission to others. For more information
+ * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
+ * <p>The following operations are related to <code>GetBucketEncryption</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html">PutBucketEncryption</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketEncryption.html">DeleteBucketEncryption</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketIntelligentTieringConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketIntelligentTieringConfigurationCommand.ts
@@ -29,28 +29,28 @@ export interface GetBucketIntelligentTieringConfigurationCommandOutput
 
 /**
  * <p>Gets the S3 Intelligent-Tiering configuration from the specified bucket.</p>
- *          <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
- *          <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
- *          <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
- *          <p>Operations related to
- *             <code>GetBucketIntelligentTieringConfiguration</code> include: </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketIntelligentTieringConfiguration.html">DeleteBucketIntelligentTieringConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html">PutBucketIntelligentTieringConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html">ListBucketIntelligentTieringConfigurations</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
+ * <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
+ * <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
+ * <p>Operations related to
+ *    <code>GetBucketIntelligentTieringConfiguration</code> include: </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketIntelligentTieringConfiguration.html">DeleteBucketIntelligentTieringConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html">PutBucketIntelligentTieringConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html">ListBucketIntelligentTieringConfigurations</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketInventoryConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketInventoryConfigurationCommand.ts
@@ -25,35 +25,35 @@ export interface GetBucketInventoryConfigurationCommandOutput
 
 /**
  * <p>Returns an inventory configuration (identified by the inventory configuration ID) from
- *          the bucket.</p>
+ * the bucket.</p>
  *
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:GetInventoryConfiguration</code> action. The bucket owner has this permission
- *          by default and can grant this permission to others. For more information about permissions,
- *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:GetInventoryConfiguration</code> action. The bucket owner has this permission
+ * by default and can grant this permission to others. For more information about permissions,
+ * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
  *
- *          <p>For information about the Amazon S3 inventory feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3 Inventory</a>.</p>
+ * <p>For information about the Amazon S3 inventory feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3 Inventory</a>.</p>
  *
- *          <p>The following operations are related to
- *          <code>GetBucketInventoryConfiguration</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketInventoryConfiguration.html">DeleteBucketInventoryConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketInventoryConfigurations.html">ListBucketInventoryConfigurations</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html">PutBucketInventoryConfiguration</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to
+ * <code>GetBucketInventoryConfiguration</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketInventoryConfiguration.html">DeleteBucketInventoryConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketInventoryConfigurations.html">ListBucketInventoryConfigurations</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html">PutBucketInventoryConfiguration</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketLifecycleConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketLifecycleConfigurationCommand.ts
@@ -25,61 +25,61 @@ export interface GetBucketLifecycleConfigurationCommandOutput
 
 /**
  * <note>
- *             <p>Bucket lifecycle configuration now supports specifying a lifecycle rule using an
- *             object key name prefix, one or more object tags, or a combination of both. Accordingly,
- *             this section describes the latest API. The response describes the new filter element
- *             that you can use to specify a filter to select a subset of objects to which the rule
- *             applies. If you are using a previous version of the lifecycle configuration, it still
- *             works. For the earlier action, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycle.html">GetBucketLifecycle</a>.</p>
- *          </note>
- *          <p>Returns the lifecycle configuration information set on the bucket. For information about
- *          lifecycle configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Object
- *             Lifecycle Management</a>.</p>
+ *    <p>Bucket lifecycle configuration now supports specifying a lifecycle rule using an
+ *    object key name prefix, one or more object tags, or a combination of both. Accordingly,
+ *    this section describes the latest API. The response describes the new filter element
+ *    that you can use to specify a filter to select a subset of objects to which the rule
+ *    applies. If you are using a previous version of the lifecycle configuration, it still
+ *    works. For the earlier action, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycle.html">GetBucketLifecycle</a>.</p>
+ * </note>
+ * <p>Returns the lifecycle configuration information set on the bucket. For information about
+ * lifecycle configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Object
+ *    Lifecycle Management</a>.</p>
  *
- *          <p>To use this operation, you must have permission to perform the
- *             <code>s3:GetLifecycleConfiguration</code> action. The bucket owner has this permission,
- *          by default. The bucket owner can grant this permission to others. For more information
- *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
+ * <p>To use this operation, you must have permission to perform the
+ *    <code>s3:GetLifecycleConfiguration</code> action. The bucket owner has this permission,
+ * by default. The bucket owner can grant this permission to others. For more information
+ * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
  *
- *          <p>
- *             <code>GetBucketLifecycleConfiguration</code> has the following special error:</p>
- *          <ul>
- *             <li>
- *                <p>Error code: <code>NoSuchLifecycleConfiguration</code>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>Description: The lifecycle configuration does not exist.</p>
- *                   </li>
- *                   <li>
- *                      <p>HTTP Status Code: 404 Not Found</p>
- *                   </li>
- *                   <li>
- *                      <p>SOAP Fault Code Prefix: Client</p>
- *                   </li>
- *                </ul>
- *             </li>
- *          </ul>
- *          <p>The following operations are related to
- *          <code>GetBucketLifecycleConfiguration</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycle.html">GetBucketLifecycle</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html">PutBucketLifecycle</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketLifecycle.html">DeleteBucketLifecycle</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>
+ *    <code>GetBucketLifecycleConfiguration</code> has the following special error:</p>
+ * <ul>
+ *    <li>
+ *       <p>Error code: <code>NoSuchLifecycleConfiguration</code>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>Description: The lifecycle configuration does not exist.</p>
+ *          </li>
+ *          <li>
+ *             <p>HTTP Status Code: 404 Not Found</p>
+ *          </li>
+ *          <li>
+ *             <p>SOAP Fault Code Prefix: Client</p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ * </ul>
+ * <p>The following operations are related to
+ * <code>GetBucketLifecycleConfiguration</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycle.html">GetBucketLifecycle</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html">PutBucketLifecycle</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketLifecycle.html">DeleteBucketLifecycle</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketLocationCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketLocationCommand.ts
@@ -23,26 +23,26 @@ export interface GetBucketLocationCommandOutput extends GetBucketLocationOutput,
 
 /**
  * <p>Returns the Region the bucket resides in. You set the bucket's Region using the
- *             <code>LocationConstraint</code> request parameter in a <code>CreateBucket</code>
- *          request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>.</p>
+ *    <code>LocationConstraint</code> request parameter in a <code>CreateBucket</code>
+ * request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>.</p>
  *
- *          <p>To use this implementation of the operation, you must be the bucket owner.</p>
+ * <p>To use this implementation of the operation, you must be the bucket owner.</p>
  *
- *          <p>To use this API against an access point, provide the alias of the access point in place of the bucket name.</p>
+ * <p>To use this API against an access point, provide the alias of the access point in place of the bucket name.</p>
  *
- *          <p>The following operations are related to <code>GetBucketLocation</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>GetBucketLocation</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketLoggingCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketLoggingCommand.ts
@@ -23,21 +23,21 @@ export interface GetBucketLoggingCommandOutput extends GetBucketLoggingOutput, _
 
 /**
  * <p>Returns the logging status of a bucket and the permissions users have to view and modify
- *          that status. To use GET, you must be the bucket owner.</p>
+ * that status. To use GET, you must be the bucket owner.</p>
  *
- *          <p>The following operations are related to <code>GetBucketLogging</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLogging.html">PutBucketLogging</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>GetBucketLogging</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLogging.html">PutBucketLogging</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketMetricsConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketMetricsConfigurationCommand.ts
@@ -25,42 +25,42 @@ export interface GetBucketMetricsConfigurationCommandOutput
 
 /**
  * <p>Gets a metrics configuration (specified by the metrics configuration ID) from the
- *          bucket. Note that this doesn't include the daily storage metrics.</p>
+ * bucket. Note that this doesn't include the daily storage metrics.</p>
  *
- *          <p> To use this operation, you must have permissions to perform the
- *             <code>s3:GetMetricsConfiguration</code> action. The bucket owner has this permission by
- *          default. The bucket owner can grant this permission to others. For more information about
- *          permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
+ * <p> To use this operation, you must have permissions to perform the
+ *    <code>s3:GetMetricsConfiguration</code> action. The bucket owner has this permission by
+ * default. The bucket owner can grant this permission to others. For more information about
+ * permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
  *
- *          <p> For information about CloudWatch request metrics for Amazon S3, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
- *             CloudWatch</a>.</p>
+ * <p> For information about CloudWatch request metrics for Amazon S3, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
+ *    CloudWatch</a>.</p>
  *
- *          <p>The following operations are related to
- *          <code>GetBucketMetricsConfiguration</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html">DeleteBucketMetricsConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketMetricsConfigurations.html">ListBucketMetricsConfigurations</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
- *                   CloudWatch</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to
+ * <code>GetBucketMetricsConfiguration</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html">DeleteBucketMetricsConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketMetricsConfigurations.html">ListBucketMetricsConfigurations</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
+ *          CloudWatch</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketNotificationConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketNotificationConfigurationCommand.ts
@@ -23,26 +23,26 @@ export interface GetBucketNotificationConfigurationCommandOutput extends Notific
 
 /**
  * <p>Returns the notification configuration of a bucket.</p>
- *          <p>If notifications are not enabled on the bucket, the action returns an empty
- *             <code>NotificationConfiguration</code> element.</p>
+ * <p>If notifications are not enabled on the bucket, the action returns an empty
+ *    <code>NotificationConfiguration</code> element.</p>
  *
- *          <p>By default, you must be the bucket owner to read the notification configuration of a
- *          bucket. However, the bucket owner can use a bucket policy to grant permission to other
- *          users to read this configuration with the <code>s3:GetBucketNotification</code>
- *          permission.</p>
+ * <p>By default, you must be the bucket owner to read the notification configuration of a
+ * bucket. However, the bucket owner can use a bucket policy to grant permission to other
+ * users to read this configuration with the <code>s3:GetBucketNotification</code>
+ * permission.</p>
  *
- *          <p>For more information about setting and reading the notification configuration on a
- *          bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Setting Up Notification of
- *             Bucket Events</a>. For more information about bucket policies, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies</a>.</p>
+ * <p>For more information about setting and reading the notification configuration on a
+ * bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Setting Up Notification of
+ *    Bucket Events</a>. For more information about bucket policies, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies</a>.</p>
  *
- *          <p>The following action is related to <code>GetBucketNotification</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketNotification.html">PutBucketNotification</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following action is related to <code>GetBucketNotification</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketNotification.html">PutBucketNotification</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketOwnershipControlsCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketOwnershipControlsCommand.ts
@@ -23,23 +23,23 @@ export interface GetBucketOwnershipControlsCommandOutput extends GetBucketOwners
 
 /**
  * <p>Retrieves <code>OwnershipControls</code> for an Amazon S3 bucket. To use this operation, you
- *          must have the <code>s3:GetBucketOwnershipControls</code> permission. For more information
- *          about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying
- *             Permissions in a Policy</a>. </p>
- *          <p>For information about Amazon S3 Object Ownership, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html">Using Object Ownership</a>. </p>
- *          <p>The following operations are related to <code>GetBucketOwnershipControls</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a>PutBucketOwnershipControls</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a>DeleteBucketOwnershipControls</a>
- *                </p>
- *             </li>
- *          </ul>
+ * must have the <code>s3:GetBucketOwnershipControls</code> permission. For more information
+ * about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying
+ *    Permissions in a Policy</a>. </p>
+ * <p>For information about Amazon S3 Object Ownership, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html">Using Object Ownership</a>. </p>
+ * <p>The following operations are related to <code>GetBucketOwnershipControls</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a>PutBucketOwnershipControls</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a>DeleteBucketOwnershipControls</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketPolicyCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketPolicyCommand.ts
@@ -23,32 +23,32 @@ export interface GetBucketPolicyCommandOutput extends GetBucketPolicyOutput, __M
 
 /**
  * <p>Returns the policy of a specified bucket. If you are using an identity other than the
- *          root user of the Amazon Web Services account that owns the bucket, the calling identity must have the
- *             <code>GetBucketPolicy</code> permissions on the specified bucket and belong to the
- *          bucket owner's account in order to use this operation.</p>
+ * root user of the Amazon Web Services account that owns the bucket, the calling identity must have the
+ *    <code>GetBucketPolicy</code> permissions on the specified bucket and belong to the
+ * bucket owner's account in order to use this operation.</p>
  *
- *          <p>If you don't have <code>GetBucketPolicy</code> permissions, Amazon S3 returns a <code>403
- *             Access Denied</code> error. If you have the correct permissions, but you're not using an
- *          identity that belongs to the bucket owner's account, Amazon S3 returns a <code>405 Method Not
- *             Allowed</code> error.</p>
+ * <p>If you don't have <code>GetBucketPolicy</code> permissions, Amazon S3 returns a <code>403
+ *    Access Denied</code> error. If you have the correct permissions, but you're not using an
+ * identity that belongs to the bucket owner's account, Amazon S3 returns a <code>405 Method Not
+ *    Allowed</code> error.</p>
  *
- *          <important>
- *             <p>As a security precaution, the root user of the Amazon Web Services account that owns a bucket can
- *             always use this operation, even if the policy explicitly denies the root user the
- *             ability to perform this action.</p>
- *          </important>
+ * <important>
+ *    <p>As a security precaution, the root user of the Amazon Web Services account that owns a bucket can
+ *    always use this operation, even if the policy explicitly denies the root user the
+ *    ability to perform this action.</p>
+ * </important>
  *
- *          <p>For more information about bucket policies, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies and User
- *             Policies</a>.</p>
+ * <p>For more information about bucket policies, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies and User
+ *    Policies</a>.</p>
  *
- *          <p>The following action is related to <code>GetBucketPolicy</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following action is related to <code>GetBucketPolicy</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketPolicyStatusCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketPolicyStatusCommand.ts
@@ -23,36 +23,36 @@ export interface GetBucketPolicyStatusCommandOutput extends GetBucketPolicyStatu
 
 /**
  * <p>Retrieves the policy status for an Amazon S3 bucket, indicating whether the bucket is public.
- *          In order to use this operation, you must have the <code>s3:GetBucketPolicyStatus</code>
- *          permission. For more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a
- *          Policy</a>.</p>
+ * In order to use this operation, you must have the <code>s3:GetBucketPolicyStatus</code>
+ * permission. For more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a
+ * Policy</a>.</p>
  *
- *          <p> For more information about when Amazon S3 considers a bucket public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a>. </p>
+ * <p> For more information about when Amazon S3 considers a bucket public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a>. </p>
  *
- *          <p>The following operations are related to <code>GetBucketPolicyStatus</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
- *                   Public Access</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutPublicAccessBlock.html">PutPublicAccessBlock</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletePublicAccessBlock.html">DeletePublicAccessBlock</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>GetBucketPolicyStatus</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
+ *          Public Access</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutPublicAccessBlock.html">PutPublicAccessBlock</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletePublicAccessBlock.html">DeletePublicAccessBlock</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketReplicationCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketReplicationCommand.ts
@@ -23,40 +23,40 @@ export interface GetBucketReplicationCommandOutput extends GetBucketReplicationO
 
 /**
  * <p>Returns the replication configuration of a bucket.</p>
- *          <note>
- *             <p> It can take a while to propagate the put or delete a replication configuration to
- *             all Amazon S3 systems. Therefore, a get request soon after put or delete can return a wrong
- *             result. </p>
- *          </note>
- *          <p> For information about replication configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html">Replication</a> in the
- *             <i>Amazon S3 User Guide</i>.</p>
+ * <note>
+ *    <p> It can take a while to propagate the put or delete a replication configuration to
+ *    all Amazon S3 systems. Therefore, a get request soon after put or delete can return a wrong
+ *    result. </p>
+ * </note>
+ * <p> For information about replication configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html">Replication</a> in the
+ *    <i>Amazon S3 User Guide</i>.</p>
  *
- *          <p>This action requires permissions for the <code>s3:GetReplicationConfiguration</code>
- *          action. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies and User
- *             Policies</a>.</p>
+ * <p>This action requires permissions for the <code>s3:GetReplicationConfiguration</code>
+ * action. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies and User
+ *    Policies</a>.</p>
  *
- *          <p>If you include the <code>Filter</code> element in a replication configuration, you must
- *          also include the <code>DeleteMarkerReplication</code> and <code>Priority</code> elements.
- *          The response also returns those elements.</p>
+ * <p>If you include the <code>Filter</code> element in a replication configuration, you must
+ * also include the <code>DeleteMarkerReplication</code> and <code>Priority</code> elements.
+ * The response also returns those elements.</p>
  *
- *          <p>For information about <code>GetBucketReplication</code> errors, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ReplicationErrorCodeList">List of
- *             replication-related error codes</a>
- *          </p>
+ * <p>For information about <code>GetBucketReplication</code> errors, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ReplicationErrorCodeList">List of
+ *    replication-related error codes</a>
+ * </p>
  *
  *
- *          <p>The following operations are related to <code>GetBucketReplication</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html">PutBucketReplication</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketReplication.html">DeleteBucketReplication</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>GetBucketReplication</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html">PutBucketReplication</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketReplication.html">DeleteBucketReplication</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketRequestPaymentCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketRequestPaymentCommand.ts
@@ -23,16 +23,16 @@ export interface GetBucketRequestPaymentCommandOutput extends GetBucketRequestPa
 
 /**
  * <p>Returns the request payment configuration of a bucket. To use this version of the
- *          operation, you must be the bucket owner. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html">Requester Pays Buckets</a>.</p>
+ * operation, you must be the bucket owner. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html">Requester Pays Buckets</a>.</p>
  *
- *          <p>The following operations are related to <code>GetBucketRequestPayment</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>GetBucketRequestPayment</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketTaggingCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketTaggingCommand.ts
@@ -23,37 +23,37 @@ export interface GetBucketTaggingCommandOutput extends GetBucketTaggingOutput, _
 
 /**
  * <p>Returns the tag set associated with the bucket.</p>
- *          <p>To use this operation, you must have permission to perform the
- *             <code>s3:GetBucketTagging</code> action. By default, the bucket owner has this
- *          permission and can grant this permission to others.</p>
+ * <p>To use this operation, you must have permission to perform the
+ *    <code>s3:GetBucketTagging</code> action. By default, the bucket owner has this
+ * permission and can grant this permission to others.</p>
  *
- *          <p>
- *             <code>GetBucketTagging</code> has the following special error:</p>
- *          <ul>
- *             <li>
- *                <p>Error code: <code>NoSuchTagSetError</code>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>Description: There is no tag set associated with the bucket.</p>
- *                   </li>
- *                </ul>
- *             </li>
- *          </ul>
+ * <p>
+ *    <code>GetBucketTagging</code> has the following special error:</p>
+ * <ul>
+ *    <li>
+ *       <p>Error code: <code>NoSuchTagSetError</code>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>Description: There is no tag set associated with the bucket.</p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ * </ul>
  *
- *          <p>The following operations are related to <code>GetBucketTagging</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketTagging.html">PutBucketTagging</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketTagging.html">DeleteBucketTagging</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>GetBucketTagging</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketTagging.html">PutBucketTagging</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketTagging.html">DeleteBucketTagging</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketVersioningCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketVersioningCommand.ts
@@ -23,30 +23,30 @@ export interface GetBucketVersioningCommandOutput extends GetBucketVersioningOut
 
 /**
  * <p>Returns the versioning state of a bucket.</p>
- *          <p>To retrieve the versioning state of a bucket, you must be the bucket owner.</p>
+ * <p>To retrieve the versioning state of a bucket, you must be the bucket owner.</p>
  *
- *          <p>This implementation also returns the MFA Delete status of the versioning state. If the
- *          MFA Delete status is <code>enabled</code>, the bucket owner must use an authentication
- *          device to change the versioning state of the bucket.</p>
+ * <p>This implementation also returns the MFA Delete status of the versioning state. If the
+ * MFA Delete status is <code>enabled</code>, the bucket owner must use an authentication
+ * device to change the versioning state of the bucket.</p>
  *
- *          <p>The following operations are related to <code>GetBucketVersioning</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>GetBucketVersioning</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetBucketWebsiteCommand.ts
+++ b/clients/client-s3/src/commands/GetBucketWebsiteCommand.ts
@@ -23,26 +23,26 @@ export interface GetBucketWebsiteCommandOutput extends GetBucketWebsiteOutput, _
 
 /**
  * <p>Returns the website configuration for a bucket. To host website on Amazon S3, you can
- *          configure a bucket as website by adding a website configuration. For more information about
- *          hosting websites, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html">Hosting Websites on
- *             Amazon S3</a>. </p>
- *          <p>This GET action requires the <code>S3:GetBucketWebsite</code> permission. By default,
- *          only the bucket owner can read the bucket website configuration. However, bucket owners can
- *          allow other users to read the website configuration by writing a bucket policy granting
- *          them the <code>S3:GetBucketWebsite</code> permission.</p>
- *          <p>The following operations are related to <code>DeleteBucketWebsite</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketWebsite.html">DeleteBucketWebsite</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketWebsite.html">PutBucketWebsite</a>
- *                </p>
- *             </li>
- *          </ul>
+ * configure a bucket as website by adding a website configuration. For more information about
+ * hosting websites, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html">Hosting Websites on
+ *    Amazon S3</a>. </p>
+ * <p>This GET action requires the <code>S3:GetBucketWebsite</code> permission. By default,
+ * only the bucket owner can read the bucket website configuration. However, bucket owners can
+ * allow other users to read the website configuration by writing a bucket policy granting
+ * them the <code>S3:GetBucketWebsite</code> permission.</p>
+ * <p>The following operations are related to <code>DeleteBucketWebsite</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketWebsite.html">DeleteBucketWebsite</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketWebsite.html">PutBucketWebsite</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetObjectAclCommand.ts
+++ b/clients/client-s3/src/commands/GetObjectAclCommand.ts
@@ -23,32 +23,32 @@ export interface GetObjectAclCommandOutput extends GetObjectAclOutput, __Metadat
 
 /**
  * <p>Returns the access control list (ACL) of an object. To use this operation, you must have
- *             <code>READ_ACP</code> access to the object.</p>
- *          <p>This action is not supported by Amazon S3 on Outposts.</p>
- *             <p>
- *             <b>Versioning</b>
- *          </p>
- *          <p>By default, GET returns ACL information about the current version of an object. To
- *          return ACL information about a different version, use the versionId subresource.</p>
+ *    <code>READ_ACP</code> access to the object.</p>
+ * <p>This action is not supported by Amazon S3 on Outposts.</p>
+ *    <p>
+ *    <b>Versioning</b>
+ * </p>
+ * <p>By default, GET returns ACL information about the current version of an object. To
+ * return ACL information about a different version, use the versionId subresource.</p>
  *
- *          <p>The following operations are related to <code>GetObjectAcl</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>GetObjectAcl</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetObjectCommand.ts
+++ b/clients/client-s3/src/commands/GetObjectCommand.ts
@@ -21,186 +21,186 @@ export interface GetObjectCommandOutput extends GetObjectOutput, __MetadataBeare
 
 /**
  * <p>Retrieves objects from Amazon S3. To use <code>GET</code>, you must have <code>READ</code>
- *          access to the object. If you grant <code>READ</code> access to the anonymous user, you can
- *          return the object without using an authorization header.</p>
+ * access to the object. If you grant <code>READ</code> access to the anonymous user, you can
+ * return the object without using an authorization header.</p>
  *
- *          <p>An Amazon S3 bucket has no directory hierarchy such as you would find in a typical computer
- *          file system. You can, however, create a logical hierarchy by using object key names that
- *          imply a folder structure. For example, instead of naming an object <code>sample.jpg</code>,
- *          you can name it <code>photos/2006/February/sample.jpg</code>.</p>
+ * <p>An Amazon S3 bucket has no directory hierarchy such as you would find in a typical computer
+ * file system. You can, however, create a logical hierarchy by using object key names that
+ * imply a folder structure. For example, instead of naming an object <code>sample.jpg</code>,
+ * you can name it <code>photos/2006/February/sample.jpg</code>.</p>
  *
- *          <p>To get an object from such a logical hierarchy, specify the full key name for the object
- *          in the <code>GET</code> operation. For a virtual hosted-style request example, if you have
- *          the object <code>photos/2006/February/sample.jpg</code>, specify the resource as
- *             <code>/photos/2006/February/sample.jpg</code>. For a path-style request example, if you
- *          have the object <code>photos/2006/February/sample.jpg</code> in the bucket named
- *             <code>examplebucket</code>, specify the resource as
- *             <code>/examplebucket/photos/2006/February/sample.jpg</code>. For more information about
- *          request types, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#VirtualHostingSpecifyBucket">HTTP Host Header Bucket Specification</a>.</p>
+ * <p>To get an object from such a logical hierarchy, specify the full key name for the object
+ * in the <code>GET</code> operation. For a virtual hosted-style request example, if you have
+ * the object <code>photos/2006/February/sample.jpg</code>, specify the resource as
+ *    <code>/photos/2006/February/sample.jpg</code>. For a path-style request example, if you
+ * have the object <code>photos/2006/February/sample.jpg</code> in the bucket named
+ *    <code>examplebucket</code>, specify the resource as
+ *    <code>/examplebucket/photos/2006/February/sample.jpg</code>. For more information about
+ * request types, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#VirtualHostingSpecifyBucket">HTTP Host Header Bucket Specification</a>.</p>
  *
- *          <p>To distribute large files to many people, you can save bandwidth costs by using
- *          BitTorrent. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3Torrent.html">Amazon S3
- *             Torrent</a>. For more information about returning the ACL of an object, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html">GetObjectAcl</a>.</p>
+ * <p>To distribute large files to many people, you can save bandwidth costs by using
+ * BitTorrent. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3Torrent.html">Amazon S3
+ *    Torrent</a>. For more information about returning the ACL of an object, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html">GetObjectAcl</a>.</p>
  *
- *          <p>If the object you are retrieving is stored in the S3 Glacier or
- *          S3 Glacier Deep Archive storage class, or S3 Intelligent-Tiering Archive or
- *          S3 Intelligent-Tiering Deep Archive tiers, before you can retrieve the object you must first restore a
- *          copy using <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a>. Otherwise, this action returns an
- *             <code>InvalidObjectStateError</code> error. For information about restoring archived
- *          objects, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html">Restoring Archived
- *             Objects</a>.</p>
+ * <p>If the object you are retrieving is stored in the S3 Glacier or
+ * S3 Glacier Deep Archive storage class, or S3 Intelligent-Tiering Archive or
+ * S3 Intelligent-Tiering Deep Archive tiers, before you can retrieve the object you must first restore a
+ * copy using <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a>. Otherwise, this action returns an
+ *    <code>InvalidObjectStateError</code> error. For information about restoring archived
+ * objects, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html">Restoring Archived
+ *    Objects</a>.</p>
  *
- *          <p>Encryption request headers, like <code>x-amz-server-side-encryption</code>, should not
- *          be sent for GET requests if your object uses server-side encryption with CMKs stored in Amazon Web Services
- *          KMS (SSE-KMS) or server-side encryption with Amazon S3–managed encryption keys (SSE-S3). If your
- *          object does use these types of keys, you’ll get an HTTP 400 BadRequest error.</p>
- *          <p>If you encrypt an object by using server-side encryption with customer-provided
- *          encryption keys (SSE-C) when you store the object in Amazon S3, then when you GET the object,
- *          you must use the following headers:</p>
- *          <ul>
- *             <li>
- *                <p>x-amz-server-side-encryption-customer-algorithm</p>
- *             </li>
- *             <li>
- *                <p>x-amz-server-side-encryption-customer-key</p>
- *             </li>
- *             <li>
- *                <p>x-amz-server-side-encryption-customer-key-MD5</p>
- *             </li>
- *          </ul>
- *          <p>For more information about SSE-C, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html">Server-Side Encryption (Using
- *             Customer-Provided Encryption Keys)</a>.</p>
+ * <p>Encryption request headers, like <code>x-amz-server-side-encryption</code>, should not
+ * be sent for GET requests if your object uses server-side encryption with CMKs stored in Amazon Web Services
+ * KMS (SSE-KMS) or server-side encryption with Amazon S3–managed encryption keys (SSE-S3). If your
+ * object does use these types of keys, you’ll get an HTTP 400 BadRequest error.</p>
+ * <p>If you encrypt an object by using server-side encryption with customer-provided
+ * encryption keys (SSE-C) when you store the object in Amazon S3, then when you GET the object,
+ * you must use the following headers:</p>
+ * <ul>
+ *    <li>
+ *       <p>x-amz-server-side-encryption-customer-algorithm</p>
+ *    </li>
+ *    <li>
+ *       <p>x-amz-server-side-encryption-customer-key</p>
+ *    </li>
+ *    <li>
+ *       <p>x-amz-server-side-encryption-customer-key-MD5</p>
+ *    </li>
+ * </ul>
+ * <p>For more information about SSE-C, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html">Server-Side Encryption (Using
+ *    Customer-Provided Encryption Keys)</a>.</p>
  *
- *          <p>Assuming you have the relevant permission to read object tags, the response also returns the
- *             <code>x-amz-tagging-count</code> header that provides the count of number of tags
- *          associated with the object. You can use <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a> to retrieve
- *          the tag set associated with an object.</p>
+ * <p>Assuming you have the relevant permission to read object tags, the response also returns the
+ *    <code>x-amz-tagging-count</code> header that provides the count of number of tags
+ * associated with the object. You can use <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a> to retrieve
+ * the tag set associated with an object.</p>
  *
- *          <p>
- *             <b>Permissions</b>
- *          </p>
- *          <p>You need the relevant read object (or version) permission for this operation. For more
- *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions
- *             in a Policy</a>. If the object you request does not exist, the error Amazon S3 returns
- *          depends on whether you also have the <code>s3:ListBucket</code> permission.</p>
- *          <ul>
- *             <li>
- *                <p>If you have the <code>s3:ListBucket</code> permission on the bucket, Amazon S3 will
- *                return an HTTP status code 404 ("no such key") error.</p>
- *             </li>
- *             <li>
- *                <p>If you don’t have the <code>s3:ListBucket</code> permission, Amazon S3 will return an
- *                HTTP status code 403 ("access denied") error.</p>
- *             </li>
- *          </ul>
- *
- *
- *          <p>
- *             <b>Versioning</b>
- *          </p>
- *          <p>By default, the GET action returns the current version of an object. To return a
- *          different version, use the <code>versionId</code> subresource.</p>
- *
- *          <note>
- *             <ul>
- *                <li>
- *                   <p>You need the <code>s3:GetObjectVersion</code> permission to access a specific version of an object.
- *             </p>
- *                </li>
- *                <li>
- *                   <p>If the current version of the object is a delete marker, Amazon S3 behaves as if the
- *             object was deleted and includes <code>x-amz-delete-marker: true</code> in the
- *             response.</p>
- *                </li>
- *             </ul>
- *          </note>
+ * <p>
+ *    <b>Permissions</b>
+ * </p>
+ * <p>You need the relevant read object (or version) permission for this operation. For more
+ * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions
+ *    in a Policy</a>. If the object you request does not exist, the error Amazon S3 returns
+ * depends on whether you also have the <code>s3:ListBucket</code> permission.</p>
+ * <ul>
+ *    <li>
+ *       <p>If you have the <code>s3:ListBucket</code> permission on the bucket, Amazon S3 will
+ *       return an HTTP status code 404 ("no such key") error.</p>
+ *    </li>
+ *    <li>
+ *       <p>If you don’t have the <code>s3:ListBucket</code> permission, Amazon S3 will return an
+ *       HTTP status code 403 ("access denied") error.</p>
+ *    </li>
+ * </ul>
  *
  *
- *          <p>For more information about versioning, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html">PutBucketVersioning</a>. </p>
+ * <p>
+ *    <b>Versioning</b>
+ * </p>
+ * <p>By default, the GET action returns the current version of an object. To return a
+ * different version, use the <code>versionId</code> subresource.</p>
  *
- *          <p>
- *             <b>Overriding Response Header Values</b>
- *          </p>
- *          <p>There are times when you want to override certain response header values in a GET
- *          response. For example, you might override the Content-Disposition response header value in
- *          your GET request.</p>
+ * <note>
+ *    <ul>
+ *       <li>
+ *          <p>You need the <code>s3:GetObjectVersion</code> permission to access a specific version of an object.
+ *    </p>
+ *       </li>
+ *       <li>
+ *          <p>If the current version of the object is a delete marker, Amazon S3 behaves as if the
+ *    object was deleted and includes <code>x-amz-delete-marker: true</code> in the
+ *    response.</p>
+ *       </li>
+ *    </ul>
+ * </note>
  *
- *          <p>You can override values for a set of response headers using the following query
- *          parameters. These response header values are sent only on a successful request, that is,
- *          when status code 200 OK is returned. The set of headers you can override using these
- *          parameters is a subset of the headers that Amazon S3 accepts when you create an object. The
- *          response headers that you can override for the GET response are <code>Content-Type</code>,
- *             <code>Content-Language</code>, <code>Expires</code>, <code>Cache-Control</code>,
- *             <code>Content-Disposition</code>, and <code>Content-Encoding</code>. To override these
- *          header values in the GET response, you use the following request parameters.</p>
  *
- *          <note>
- *             <p>You must sign the request, either using an Authorization header or a presigned URL,
- *             when using these parameters. They cannot be used with an unsigned (anonymous)
- *             request.</p>
- *          </note>
- *          <ul>
- *             <li>
- *                <p>
- *                   <code>response-content-type</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>response-content-language</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>response-expires</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>response-cache-control</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>response-content-disposition</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>response-content-encoding</code>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>For more information about versioning, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html">PutBucketVersioning</a>. </p>
  *
- *          <p>
- *             <b>Additional Considerations about Request Headers</b>
- *          </p>
+ * <p>
+ *    <b>Overriding Response Header Values</b>
+ * </p>
+ * <p>There are times when you want to override certain response header values in a GET
+ * response. For example, you might override the Content-Disposition response header value in
+ * your GET request.</p>
  *
- *          <p>If both of the <code>If-Match</code> and <code>If-Unmodified-Since</code> headers are
- *          present in the request as follows: <code>If-Match</code> condition evaluates to
- *             <code>true</code>, and; <code>If-Unmodified-Since</code> condition evaluates to
- *             <code>false</code>; then, S3 returns 200 OK and the data requested. </p>
+ * <p>You can override values for a set of response headers using the following query
+ * parameters. These response header values are sent only on a successful request, that is,
+ * when status code 200 OK is returned. The set of headers you can override using these
+ * parameters is a subset of the headers that Amazon S3 accepts when you create an object. The
+ * response headers that you can override for the GET response are <code>Content-Type</code>,
+ *    <code>Content-Language</code>, <code>Expires</code>, <code>Cache-Control</code>,
+ *    <code>Content-Disposition</code>, and <code>Content-Encoding</code>. To override these
+ * header values in the GET response, you use the following request parameters.</p>
  *
- *          <p>If both of the <code>If-None-Match</code> and <code>If-Modified-Since</code> headers are
- *          present in the request as follows:<code> If-None-Match</code> condition evaluates to
- *             <code>false</code>, and; <code>If-Modified-Since</code> condition evaluates to
- *             <code>true</code>; then, S3 returns 304 Not Modified response code.</p>
+ * <note>
+ *    <p>You must sign the request, either using an Authorization header or a presigned URL,
+ *    when using these parameters. They cannot be used with an unsigned (anonymous)
+ *    request.</p>
+ * </note>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <code>response-content-type</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>response-content-language</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>response-expires</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>response-cache-control</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>response-content-disposition</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>response-content-encoding</code>
+ *       </p>
+ *    </li>
+ * </ul>
  *
- *          <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+ * <p>
+ *    <b>Additional Considerations about Request Headers</b>
+ * </p>
  *
- *          <p>The following operations are related to <code>GetObject</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html">ListBuckets</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html">GetObjectAcl</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>If both of the <code>If-Match</code> and <code>If-Unmodified-Since</code> headers are
+ * present in the request as follows: <code>If-Match</code> condition evaluates to
+ *    <code>true</code>, and; <code>If-Unmodified-Since</code> condition evaluates to
+ *    <code>false</code>; then, S3 returns 200 OK and the data requested. </p>
+ *
+ * <p>If both of the <code>If-None-Match</code> and <code>If-Modified-Since</code> headers are
+ * present in the request as follows:<code> If-None-Match</code> condition evaluates to
+ *    <code>false</code>, and; <code>If-Modified-Since</code> condition evaluates to
+ *    <code>true</code>; then, S3 returns 304 Not Modified response code.</p>
+ *
+ * <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+ *
+ * <p>The following operations are related to <code>GetObject</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html">ListBuckets</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html">GetObjectAcl</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetObjectLegalHoldCommand.ts
+++ b/clients/client-s3/src/commands/GetObjectLegalHoldCommand.ts
@@ -23,7 +23,7 @@ export interface GetObjectLegalHoldCommandOutput extends GetObjectLegalHoldOutpu
 
 /**
  * <p>Gets an object's current Legal Hold status. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking Objects</a>.</p>
- *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+ * <p>This action is not supported by Amazon S3 on Outposts.</p>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetObjectLockConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/GetObjectLockConfigurationCommand.ts
@@ -23,9 +23,9 @@ export interface GetObjectLockConfigurationCommandOutput extends GetObjectLockCo
 
 /**
  * <p>Gets the Object Lock configuration for a bucket. The rule specified in the Object Lock
- *          configuration will be applied by default to every new object placed in the specified
- *          bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking
- *             Objects</a>.</p>
+ * configuration will be applied by default to every new object placed in the specified
+ * bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking
+ *    Objects</a>.</p>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetObjectRetentionCommand.ts
+++ b/clients/client-s3/src/commands/GetObjectRetentionCommand.ts
@@ -23,7 +23,7 @@ export interface GetObjectRetentionCommandOutput extends GetObjectRetentionOutpu
 
 /**
  * <p>Retrieves an object's retention settings. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking Objects</a>.</p>
- *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+ * <p>This action is not supported by Amazon S3 on Outposts.</p>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetObjectTaggingCommand.ts
+++ b/clients/client-s3/src/commands/GetObjectTaggingCommand.ts
@@ -23,33 +23,33 @@ export interface GetObjectTaggingCommandOutput extends GetObjectTaggingOutput, _
 
 /**
  * <p>Returns the tag-set of an object. You send the GET request against the tagging
- *          subresource associated with the object.</p>
+ * subresource associated with the object.</p>
  *
- *          <p>To use this operation, you must have permission to perform the
- *             <code>s3:GetObjectTagging</code> action. By default, the GET action returns
- *          information about current version of an object. For a versioned bucket, you can have
- *          multiple versions of an object in your bucket. To retrieve tags of any other version, use
- *          the versionId query parameter. You also need permission for the
- *             <code>s3:GetObjectVersionTagging</code> action.</p>
+ * <p>To use this operation, you must have permission to perform the
+ *    <code>s3:GetObjectTagging</code> action. By default, the GET action returns
+ * information about current version of an object. For a versioned bucket, you can have
+ * multiple versions of an object in your bucket. To retrieve tags of any other version, use
+ * the versionId query parameter. You also need permission for the
+ *    <code>s3:GetObjectVersionTagging</code> action.</p>
  *
- *          <p> By default, the bucket owner has this permission and can grant this permission to
- *          others.</p>
+ * <p> By default, the bucket owner has this permission and can grant this permission to
+ * others.</p>
  *
- *          <p> For information about the Amazon S3 object tagging feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html">Object Tagging</a>.</p>
+ * <p> For information about the Amazon S3 object tagging feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html">Object Tagging</a>.</p>
  *
- *          <p>The following action is related to <code>GetObjectTagging</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectTagging.html">PutObjectTagging</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectTagging.html">DeleteObjectTagging</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following action is related to <code>GetObjectTagging</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectTagging.html">PutObjectTagging</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectTagging.html">DeleteObjectTagging</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetObjectTorrentCommand.ts
+++ b/clients/client-s3/src/commands/GetObjectTorrentCommand.ts
@@ -23,22 +23,22 @@ export interface GetObjectTorrentCommandOutput extends GetObjectTorrentOutput, _
 
 /**
  * <p>Returns torrent files from a bucket. BitTorrent can save you bandwidth when you're
- *          distributing large files. For more information about BitTorrent, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3Torrent.html">Using BitTorrent with Amazon S3</a>.</p>
- *          <note>
- *             <p>You can get torrent only for objects that are less than 5 GB in size, and that are
- *             not encrypted using server-side encryption with a customer-provided encryption
- *             key.</p>
- *          </note>
- *          <p>To use GET, you must have READ access to the object.</p>
- *          <p>This action is not supported by Amazon S3 on Outposts.</p>
- *          <p>The following action is related to <code>GetObjectTorrent</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
- *                </p>
- *             </li>
- *          </ul>
+ * distributing large files. For more information about BitTorrent, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3Torrent.html">Using BitTorrent with Amazon S3</a>.</p>
+ * <note>
+ *    <p>You can get torrent only for objects that are less than 5 GB in size, and that are
+ *    not encrypted using server-side encryption with a customer-provided encryption
+ *    key.</p>
+ * </note>
+ * <p>To use GET, you must have READ access to the object.</p>
+ * <p>This action is not supported by Amazon S3 on Outposts.</p>
+ * <p>The following action is related to <code>GetObjectTorrent</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/GetPublicAccessBlockCommand.ts
+++ b/clients/client-s3/src/commands/GetPublicAccessBlockCommand.ts
@@ -23,45 +23,45 @@ export interface GetPublicAccessBlockCommandOutput extends GetPublicAccessBlockO
 
 /**
  * <p>Retrieves the <code>PublicAccessBlock</code> configuration for an Amazon S3 bucket. To use
- *          this operation, you must have the <code>s3:GetBucketPublicAccessBlock</code> permission.
- *          For more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a
- *          Policy</a>.</p>
+ * this operation, you must have the <code>s3:GetBucketPublicAccessBlock</code> permission.
+ * For more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a
+ * Policy</a>.</p>
  *
- *          <important>
- *             <p>When Amazon S3 evaluates the <code>PublicAccessBlock</code> configuration for a bucket or
- *             an object, it checks the <code>PublicAccessBlock</code> configuration for both the
- *             bucket (or the bucket that contains the object) and the bucket owner's account. If the
- *                <code>PublicAccessBlock</code> settings are different between the bucket and the
- *             account, Amazon S3 uses the most restrictive combination of the bucket-level and
- *             account-level settings.</p>
- *          </important>
+ * <important>
+ *    <p>When Amazon S3 evaluates the <code>PublicAccessBlock</code> configuration for a bucket or
+ *    an object, it checks the <code>PublicAccessBlock</code> configuration for both the
+ *    bucket (or the bucket that contains the object) and the bucket owner's account. If the
+ *       <code>PublicAccessBlock</code> settings are different between the bucket and the
+ *    account, Amazon S3 uses the most restrictive combination of the bucket-level and
+ *    account-level settings.</p>
+ * </important>
  *
- *          <p>For more information about when Amazon S3 considers a bucket or an object public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a>.</p>
+ * <p>For more information about when Amazon S3 considers a bucket or an object public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a>.</p>
  *
- *          <p>The following operations are related to <code>GetPublicAccessBlock</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
- *                   Public Access</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutPublicAccessBlock.html">PutPublicAccessBlock</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletePublicAccessBlock.html">DeletePublicAccessBlock</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>GetPublicAccessBlock</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
+ *          Public Access</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutPublicAccessBlock.html">PutPublicAccessBlock</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletePublicAccessBlock.html">DeletePublicAccessBlock</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/HeadBucketCommand.ts
+++ b/clients/client-s3/src/commands/HeadBucketCommand.ts
@@ -23,21 +23,21 @@ export interface HeadBucketCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>This action is useful to determine if a bucket exists and you have permission to
- *          access it. The action returns a <code>200 OK</code> if the bucket exists and you have
- *          permission to access it.</p>
+ * access it. The action returns a <code>200 OK</code> if the bucket exists and you have
+ * permission to access it.</p>
  *
  *
- *          <p>If the bucket does not exist or you do not have permission to access it, the <code>HEAD</code> request
- *          returns a generic <code>404 Not Found</code> or <code>403 Forbidden</code> code. A message body is not
- *          included, so you cannot determine the exception beyond these error codes.</p>
+ * <p>If the bucket does not exist or you do not have permission to access it, the <code>HEAD</code> request
+ * returns a generic <code>404 Not Found</code> or <code>403 Forbidden</code> code. A message body is not
+ * included, so you cannot determine the exception beyond these error codes.</p>
  *
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:ListBucket</code> action. The bucket owner has this permission by default and
- *          can grant this permission to others. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:ListBucket</code> action. The bucket owner has this permission by default and
+ * can grant this permission to others. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
  *
  *
- *          <p>To use this API against an access point, you must provide the alias of the access point in place of the bucket name or specify the access point ARN. When using the access point ARN, you must direct requests to the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com. When using the Amazon Web Services SDKs, you provide the ARN in place of the bucket name. For more information see, <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a>.</p>
+ * <p>To use this API against an access point, you must provide the alias of the access point in place of the bucket name or specify the access point ARN. When using the access point ARN, you must direct requests to the access point hostname. The access point hostname takes the form AccessPointName-AccountId.s3-accesspoint.Region.amazonaws.com. When using the Amazon Web Services SDKs, you provide the ARN in place of the bucket name. For more information see, <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a>.</p>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/HeadObjectCommand.ts
+++ b/clients/client-s3/src/commands/HeadObjectCommand.ts
@@ -24,117 +24,117 @@ export interface HeadObjectCommandOutput extends HeadObjectOutput, __MetadataBea
 
 /**
  * <p>The HEAD action retrieves metadata from an object without returning the object
- *          itself. This action is useful if you're only interested in an object's metadata. To use
- *          HEAD, you must have READ access to the object.</p>
+ * itself. This action is useful if you're only interested in an object's metadata. To use
+ * HEAD, you must have READ access to the object.</p>
  *
- *          <p>A <code>HEAD</code> request has the same options as a <code>GET</code> action on an
- *          object. The response is identical to the <code>GET</code> response except that there is no
- *          response body. Because of this, if the <code>HEAD</code> request generates an error, it
- *          returns a generic <code>404 Not Found</code> or <code>403 Forbidden</code> code. It is not
- *          possible to retrieve the exact exception beyond these error codes.</p>
+ * <p>A <code>HEAD</code> request has the same options as a <code>GET</code> action on an
+ * object. The response is identical to the <code>GET</code> response except that there is no
+ * response body. Because of this, if the <code>HEAD</code> request generates an error, it
+ * returns a generic <code>404 Not Found</code> or <code>403 Forbidden</code> code. It is not
+ * possible to retrieve the exact exception beyond these error codes.</p>
  *
- *          <p>If you encrypt an object by using server-side encryption with customer-provided
- *          encryption keys (SSE-C) when you store the object in Amazon S3, then when you retrieve the
- *          metadata from the object, you must use the following headers:</p>
- *          <ul>
- *             <li>
- *                <p>x-amz-server-side-encryption-customer-algorithm</p>
- *             </li>
- *             <li>
- *                <p>x-amz-server-side-encryption-customer-key</p>
- *             </li>
- *             <li>
- *                <p>x-amz-server-side-encryption-customer-key-MD5</p>
- *             </li>
- *          </ul>
- *          <p>For more information about SSE-C, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html">Server-Side Encryption (Using
- *             Customer-Provided Encryption Keys)</a>.</p>
- *          <note>
- *             <ul>
- *                <li>
- *                   <p>Encryption request headers, like <code>x-amz-server-side-encryption</code>, should
- *             not be sent for GET requests if your object uses server-side encryption with CMKs stored
- *             in Amazon Web Services KMS (SSE-KMS) or server-side encryption with Amazon S3–managed encryption keys
- *             (SSE-S3). If your object does use these types of keys, you’ll get an HTTP 400 BadRequest
- *             error.</p>
- *                </li>
- *                <li>
- *                   <p>
- *                The last modified property in this case is the creation date of the object.</p>
- *                </li>
- *             </ul>
- *          </note>
- *
- *
- *          <p>Request headers are limited to 8 KB in size. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonRequestHeaders.html">Common Request
- *             Headers</a>.</p>
- *          <p>Consider the following when using request headers:</p>
- *          <ul>
- *             <li>
- *                <p> Consideration 1 – If both of the <code>If-Match</code> and
- *                   <code>If-Unmodified-Since</code> headers are present in the request as
- *                follows:</p>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <code>If-Match</code> condition evaluates to <code>true</code>, and;</p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <code>If-Unmodified-Since</code> condition evaluates to
- *                      <code>false</code>;</p>
- *                   </li>
- *                </ul>
- *                <p>Then Amazon S3 returns <code>200 OK</code> and the data requested.</p>
- *             </li>
- *             <li>
- *                <p> Consideration 2 – If both of the <code>If-None-Match</code> and
- *                   <code>If-Modified-Since</code> headers are present in the request as
- *                follows:</p>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <code>If-None-Match</code> condition evaluates to <code>false</code>,
- *                      and;</p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <code>If-Modified-Since</code> condition evaluates to
- *                      <code>true</code>;</p>
- *                   </li>
- *                </ul>
- *                <p>Then Amazon S3 returns the <code>304 Not Modified</code> response code.</p>
- *             </li>
- *          </ul>
- *
- *          <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
- *
+ * <p>If you encrypt an object by using server-side encryption with customer-provided
+ * encryption keys (SSE-C) when you store the object in Amazon S3, then when you retrieve the
+ * metadata from the object, you must use the following headers:</p>
+ * <ul>
+ *    <li>
+ *       <p>x-amz-server-side-encryption-customer-algorithm</p>
+ *    </li>
+ *    <li>
+ *       <p>x-amz-server-side-encryption-customer-key</p>
+ *    </li>
+ *    <li>
+ *       <p>x-amz-server-side-encryption-customer-key-MD5</p>
+ *    </li>
+ * </ul>
+ * <p>For more information about SSE-C, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html">Server-Side Encryption (Using
+ *    Customer-Provided Encryption Keys)</a>.</p>
+ * <note>
+ *    <ul>
+ *       <li>
+ *          <p>Encryption request headers, like <code>x-amz-server-side-encryption</code>, should
+ *    not be sent for GET requests if your object uses server-side encryption with CMKs stored
+ *    in Amazon Web Services KMS (SSE-KMS) or server-side encryption with Amazon S3–managed encryption keys
+ *    (SSE-S3). If your object does use these types of keys, you’ll get an HTTP 400 BadRequest
+ *    error.</p>
+ *       </li>
+ *       <li>
  *          <p>
- *             <b>Permissions</b>
- *          </p>
- *          <p>You need the relevant read object (or version) permission for this operation. For more
- *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions
- *             in a Policy</a>. If the object you request does not exist, the error Amazon S3 returns
- *          depends on whether you also have the s3:ListBucket permission.</p>
- *          <ul>
- *             <li>
- *                <p>If you have the <code>s3:ListBucket</code> permission on the bucket, Amazon S3 returns
- *                an HTTP status code 404 ("no such key") error.</p>
- *             </li>
- *             <li>
- *                <p>If you don’t have the <code>s3:ListBucket</code> permission, Amazon S3 returns an HTTP
- *                status code 403 ("access denied") error.</p>
- *             </li>
- *          </ul>
+ *       The last modified property in this case is the creation date of the object.</p>
+ *       </li>
+ *    </ul>
+ * </note>
  *
- *          <p>The following action is related to <code>HeadObject</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
- *                </p>
- *             </li>
- *          </ul>
+ *
+ * <p>Request headers are limited to 8 KB in size. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonRequestHeaders.html">Common Request
+ *    Headers</a>.</p>
+ * <p>Consider the following when using request headers:</p>
+ * <ul>
+ *    <li>
+ *       <p> Consideration 1 – If both of the <code>If-Match</code> and
+ *          <code>If-Unmodified-Since</code> headers are present in the request as
+ *       follows:</p>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <code>If-Match</code> condition evaluates to <code>true</code>, and;</p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <code>If-Unmodified-Since</code> condition evaluates to
+ *             <code>false</code>;</p>
+ *          </li>
+ *       </ul>
+ *       <p>Then Amazon S3 returns <code>200 OK</code> and the data requested.</p>
+ *    </li>
+ *    <li>
+ *       <p> Consideration 2 – If both of the <code>If-None-Match</code> and
+ *          <code>If-Modified-Since</code> headers are present in the request as
+ *       follows:</p>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <code>If-None-Match</code> condition evaluates to <code>false</code>,
+ *             and;</p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <code>If-Modified-Since</code> condition evaluates to
+ *             <code>true</code>;</p>
+ *          </li>
+ *       </ul>
+ *       <p>Then Amazon S3 returns the <code>304 Not Modified</code> response code.</p>
+ *    </li>
+ * </ul>
+ *
+ * <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+ *
+ * <p>
+ *    <b>Permissions</b>
+ * </p>
+ * <p>You need the relevant read object (or version) permission for this operation. For more
+ * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions
+ *    in a Policy</a>. If the object you request does not exist, the error Amazon S3 returns
+ * depends on whether you also have the s3:ListBucket permission.</p>
+ * <ul>
+ *    <li>
+ *       <p>If you have the <code>s3:ListBucket</code> permission on the bucket, Amazon S3 returns
+ *       an HTTP status code 404 ("no such key") error.</p>
+ *    </li>
+ *    <li>
+ *       <p>If you don’t have the <code>s3:ListBucket</code> permission, Amazon S3 returns an HTTP
+ *       status code 403 ("access denied") error.</p>
+ *    </li>
+ * </ul>
+ *
+ * <p>The following action is related to <code>HeadObject</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/ListBucketAnalyticsConfigurationsCommand.ts
+++ b/clients/client-s3/src/commands/ListBucketAnalyticsConfigurationsCommand.ts
@@ -25,45 +25,45 @@ export interface ListBucketAnalyticsConfigurationsCommandOutput
 
 /**
  * <p>Lists the analytics configurations for the bucket. You can have up to 1,000 analytics
- *          configurations per bucket.</p>
+ * configurations per bucket.</p>
  *
- *          <p>This action supports list pagination and does not return more than 100 configurations
- *          at a time. You should always check the <code>IsTruncated</code> element in the response. If
- *          there are no more configurations to list, <code>IsTruncated</code> is set to false. If
- *          there are more configurations to list, <code>IsTruncated</code> is set to true, and there
- *          will be a value in <code>NextContinuationToken</code>. You use the
- *             <code>NextContinuationToken</code> value to continue the pagination of the list by
- *          passing the value in continuation-token in the request to <code>GET</code> the next
- *          page.</p>
+ * <p>This action supports list pagination and does not return more than 100 configurations
+ * at a time. You should always check the <code>IsTruncated</code> element in the response. If
+ * there are no more configurations to list, <code>IsTruncated</code> is set to false. If
+ * there are more configurations to list, <code>IsTruncated</code> is set to true, and there
+ * will be a value in <code>NextContinuationToken</code>. You use the
+ *    <code>NextContinuationToken</code> value to continue the pagination of the list by
+ * passing the value in continuation-token in the request to <code>GET</code> the next
+ * page.</p>
  *
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:GetAnalyticsConfiguration</code> action. The bucket owner has this permission
- *          by default. The bucket owner can grant this permission to others. For more information
- *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:GetAnalyticsConfiguration</code> action. The bucket owner has this permission
+ * by default. The bucket owner can grant this permission to others. For more information
+ * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
  *
- *          <p>For information about Amazon S3 analytics feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
- *             Analysis</a>. </p>
+ * <p>For information about Amazon S3 analytics feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
+ *    Analysis</a>. </p>
  *
- *          <p>The following operations are related to
- *          <code>ListBucketAnalyticsConfigurations</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAnalyticsConfiguration.html">GetBucketAnalyticsConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketAnalyticsConfiguration.html">DeleteBucketAnalyticsConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html">PutBucketAnalyticsConfiguration</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to
+ * <code>ListBucketAnalyticsConfigurations</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAnalyticsConfiguration.html">GetBucketAnalyticsConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketAnalyticsConfiguration.html">DeleteBucketAnalyticsConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAnalyticsConfiguration.html">PutBucketAnalyticsConfiguration</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/ListBucketIntelligentTieringConfigurationsCommand.ts
+++ b/clients/client-s3/src/commands/ListBucketIntelligentTieringConfigurationsCommand.ts
@@ -29,28 +29,28 @@ export interface ListBucketIntelligentTieringConfigurationsCommandOutput
 
 /**
  * <p>Lists the S3 Intelligent-Tiering configuration from the specified bucket.</p>
- *          <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
- *          <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
- *          <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
- *          <p>Operations related to
- *             <code>ListBucketIntelligentTieringConfigurations</code> include: </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketIntelligentTieringConfiguration.html">DeleteBucketIntelligentTieringConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html">PutBucketIntelligentTieringConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html">GetBucketIntelligentTieringConfiguration</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
+ * <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
+ * <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
+ * <p>Operations related to
+ *    <code>ListBucketIntelligentTieringConfigurations</code> include: </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketIntelligentTieringConfiguration.html">DeleteBucketIntelligentTieringConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketIntelligentTieringConfiguration.html">PutBucketIntelligentTieringConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html">GetBucketIntelligentTieringConfiguration</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/ListBucketInventoryConfigurationsCommand.ts
+++ b/clients/client-s3/src/commands/ListBucketInventoryConfigurationsCommand.ts
@@ -25,44 +25,44 @@ export interface ListBucketInventoryConfigurationsCommandOutput
 
 /**
  * <p>Returns a list of inventory configurations for the bucket. You can have up to 1,000
- *          analytics configurations per bucket.</p>
+ * analytics configurations per bucket.</p>
  *
- *          <p>This action supports list pagination and does not return more than 100 configurations
- *          at a time. Always check the <code>IsTruncated</code> element in the response. If there are
- *          no more configurations to list, <code>IsTruncated</code> is set to false. If there are more
- *          configurations to list, <code>IsTruncated</code> is set to true, and there is a value in
- *             <code>NextContinuationToken</code>. You use the <code>NextContinuationToken</code> value
- *          to continue the pagination of the list by passing the value in continuation-token in the
- *          request to <code>GET</code> the next page.</p>
+ * <p>This action supports list pagination and does not return more than 100 configurations
+ * at a time. Always check the <code>IsTruncated</code> element in the response. If there are
+ * no more configurations to list, <code>IsTruncated</code> is set to false. If there are more
+ * configurations to list, <code>IsTruncated</code> is set to true, and there is a value in
+ *    <code>NextContinuationToken</code>. You use the <code>NextContinuationToken</code> value
+ * to continue the pagination of the list by passing the value in continuation-token in the
+ * request to <code>GET</code> the next page.</p>
  *
- *          <p> To use this operation, you must have permissions to perform the
- *             <code>s3:GetInventoryConfiguration</code> action. The bucket owner has this permission
- *          by default. The bucket owner can grant this permission to others. For more information
- *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
+ * <p> To use this operation, you must have permissions to perform the
+ *    <code>s3:GetInventoryConfiguration</code> action. The bucket owner has this permission
+ * by default. The bucket owner can grant this permission to others. For more information
+ * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
  *
- *          <p>For information about the Amazon S3 inventory feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3 Inventory</a>
- *          </p>
+ * <p>For information about the Amazon S3 inventory feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3 Inventory</a>
+ * </p>
  *
- *          <p>The following operations are related to
- *          <code>ListBucketInventoryConfigurations</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketInventoryConfiguration.html">GetBucketInventoryConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketInventoryConfiguration.html">DeleteBucketInventoryConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html">PutBucketInventoryConfiguration</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to
+ * <code>ListBucketInventoryConfigurations</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketInventoryConfiguration.html">GetBucketInventoryConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketInventoryConfiguration.html">DeleteBucketInventoryConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html">PutBucketInventoryConfiguration</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/ListBucketMetricsConfigurationsCommand.ts
+++ b/clients/client-s3/src/commands/ListBucketMetricsConfigurationsCommand.ts
@@ -25,46 +25,46 @@ export interface ListBucketMetricsConfigurationsCommandOutput
 
 /**
  * <p>Lists the metrics configurations for the bucket. The metrics configurations are only for
- *          the request metrics of the bucket and do not provide information on daily storage metrics.
- *          You can have up to 1,000 configurations per bucket.</p>
+ * the request metrics of the bucket and do not provide information on daily storage metrics.
+ * You can have up to 1,000 configurations per bucket.</p>
  *
- *          <p>This action supports list pagination and does not return more than 100 configurations
- *          at a time. Always check the <code>IsTruncated</code> element in the response. If there are
- *          no more configurations to list, <code>IsTruncated</code> is set to false. If there are more
- *          configurations to list, <code>IsTruncated</code> is set to true, and there is a value in
- *             <code>NextContinuationToken</code>. You use the <code>NextContinuationToken</code> value
- *          to continue the pagination of the list by passing the value in
- *             <code>continuation-token</code> in the request to <code>GET</code> the next page.</p>
+ * <p>This action supports list pagination and does not return more than 100 configurations
+ * at a time. Always check the <code>IsTruncated</code> element in the response. If there are
+ * no more configurations to list, <code>IsTruncated</code> is set to false. If there are more
+ * configurations to list, <code>IsTruncated</code> is set to true, and there is a value in
+ *    <code>NextContinuationToken</code>. You use the <code>NextContinuationToken</code> value
+ * to continue the pagination of the list by passing the value in
+ *    <code>continuation-token</code> in the request to <code>GET</code> the next page.</p>
  *
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:GetMetricsConfiguration</code> action. The bucket owner has this permission by
- *          default. The bucket owner can grant this permission to others. For more information about
- *          permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:GetMetricsConfiguration</code> action. The bucket owner has this permission by
+ * default. The bucket owner can grant this permission to others. For more information about
+ * permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
  *
- *          <p>For more information about metrics configurations and CloudWatch request metrics, see
- *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
- *             CloudWatch</a>.</p>
+ * <p>For more information about metrics configurations and CloudWatch request metrics, see
+ *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
+ *    CloudWatch</a>.</p>
  *
- *          <p>The following operations are related to
- *          <code>ListBucketMetricsConfigurations</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetricsConfiguration.html">GetBucketMetricsConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html">DeleteBucketMetricsConfiguration</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to
+ * <code>ListBucketMetricsConfigurations</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketMetricsConfiguration.html">GetBucketMetricsConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html">DeleteBucketMetricsConfiguration</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/ListMultipartUploadsCommand.ts
+++ b/clients/client-s3/src/commands/ListMultipartUploadsCommand.ts
@@ -23,56 +23,56 @@ export interface ListMultipartUploadsCommandOutput extends ListMultipartUploadsO
 
 /**
  * <p>This action lists in-progress multipart uploads. An in-progress multipart upload is a
- *          multipart upload that has been initiated using the Initiate Multipart Upload request, but
- *          has not yet been completed or aborted.</p>
+ * multipart upload that has been initiated using the Initiate Multipart Upload request, but
+ * has not yet been completed or aborted.</p>
  *
- *          <p>This action returns at most 1,000 multipart uploads in the response. 1,000 multipart
- *          uploads is the maximum number of uploads a response can include, which is also the default
- *          value. You can further limit the number of uploads in a response by specifying the
- *             <code>max-uploads</code> parameter in the response. If additional multipart uploads
- *          satisfy the list criteria, the response will contain an <code>IsTruncated</code> element
- *          with the value true. To list the additional multipart uploads, use the
- *             <code>key-marker</code> and <code>upload-id-marker</code> request parameters.</p>
+ * <p>This action returns at most 1,000 multipart uploads in the response. 1,000 multipart
+ * uploads is the maximum number of uploads a response can include, which is also the default
+ * value. You can further limit the number of uploads in a response by specifying the
+ *    <code>max-uploads</code> parameter in the response. If additional multipart uploads
+ * satisfy the list criteria, the response will contain an <code>IsTruncated</code> element
+ * with the value true. To list the additional multipart uploads, use the
+ *    <code>key-marker</code> and <code>upload-id-marker</code> request parameters.</p>
  *
- *          <p>In the response, the uploads are sorted by key. If your application has initiated more
- *          than one multipart upload using the same object key, then uploads in the response are first
- *          sorted by key. Additionally, uploads are sorted in ascending order within each key by the
- *          upload initiation time.</p>
+ * <p>In the response, the uploads are sorted by key. If your application has initiated more
+ * than one multipart upload using the same object key, then uploads in the response are first
+ * sorted by key. Additionally, uploads are sorted in ascending order within each key by the
+ * upload initiation time.</p>
  *
- *          <p>For more information on multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
- *             Upload</a>.</p>
+ * <p>For more information on multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
+ *    Upload</a>.</p>
  *
- *          <p>For information on permissions required to use the multipart upload API, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
- *          Permissions</a>.</p>
+ * <p>For information on permissions required to use the multipart upload API, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
+ * Permissions</a>.</p>
  *
- *          <p>The following operations are related to <code>ListMultipartUploads</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>ListMultipartUploads</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/ListObjectVersionsCommand.ts
+++ b/clients/client-s3/src/commands/ListObjectVersionsCommand.ts
@@ -23,44 +23,44 @@ export interface ListObjectVersionsCommandOutput extends ListObjectVersionsOutpu
 
 /**
  * <p>Returns metadata about all versions of the objects in a bucket. You can also use request
- *          parameters as selection criteria to return metadata about a subset of all the object
- *          versions.</p>
- *          <important>
- *             <p>
- *             To use this operation, you must have permissions to perform the
- *             <code>s3:ListBucketVersions</code> action. Be aware of the name difference.
- *          </p>
- *          </important>
- *          <note>
- *             <p> A 200 OK response can contain valid or invalid XML. Make sure to design your
- *             application to parse the contents of the response and handle it appropriately.</p>
- *          </note>
- *          <p>To use this operation, you must have READ access to the bucket.</p>
- *          <p>This action is not supported by Amazon S3 on Outposts.</p>
- *          <p>The following operations are related to
- *             <code>ListObjectVersions</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjectsV2</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
- *                </p>
- *             </li>
- *          </ul>
+ * parameters as selection criteria to return metadata about a subset of all the object
+ * versions.</p>
+ * <important>
+ *    <p>
+ *    To use this operation, you must have permissions to perform the
+ *    <code>s3:ListBucketVersions</code> action. Be aware of the name difference.
+ * </p>
+ * </important>
+ * <note>
+ *    <p> A 200 OK response can contain valid or invalid XML. Make sure to design your
+ *    application to parse the contents of the response and handle it appropriately.</p>
+ * </note>
+ * <p>To use this operation, you must have READ access to the bucket.</p>
+ * <p>This action is not supported by Amazon S3 on Outposts.</p>
+ * <p>The following operations are related to
+ *    <code>ListObjectVersions</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjectsV2</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/ListObjectsCommand.ts
+++ b/clients/client-s3/src/commands/ListObjectsCommand.ts
@@ -23,43 +23,43 @@ export interface ListObjectsCommandOutput extends ListObjectsOutput, __MetadataB
 
 /**
  * <p>Returns some or all (up to 1,000) of the objects in a bucket. You can use the request
- *          parameters as selection criteria to return a subset of the objects in a bucket. A 200 OK
- *          response can contain valid or invalid XML. Be sure to design your application to parse the
- *          contents of the response and handle it appropriately.</p>
- *          <important>
- *             <p>This action has been revised. We recommend that you use the newer version, <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjectsV2</a>, when developing applications. For backward compatibility,
- *             Amazon S3 continues to support <code>ListObjects</code>.</p>
- *          </important>
+ * parameters as selection criteria to return a subset of the objects in a bucket. A 200 OK
+ * response can contain valid or invalid XML. Be sure to design your application to parse the
+ * contents of the response and handle it appropriately.</p>
+ * <important>
+ *    <p>This action has been revised. We recommend that you use the newer version, <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjectsV2</a>, when developing applications. For backward compatibility,
+ *    Amazon S3 continues to support <code>ListObjects</code>.</p>
+ * </important>
  *
  *
- *          <p>The following operations are related to <code>ListObjects</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjectsV2</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html">ListBuckets</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>ListObjects</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html">ListObjectsV2</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html">ListBuckets</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/ListObjectsV2Command.ts
+++ b/clients/client-s3/src/commands/ListObjectsV2Command.ts
@@ -23,47 +23,47 @@ export interface ListObjectsV2CommandOutput extends ListObjectsV2Output, __Metad
 
 /**
  * <p>Returns some or all (up to 1,000) of the objects in a bucket with each request. You can use
- *          the request parameters as selection criteria to return a subset of the objects in a bucket. A
- *          <code>200 OK</code> response can contain valid or invalid XML. Make sure to design your
- *          application to parse the contents of the response and handle it appropriately.
- *          Objects are returned sorted in an ascending order of the respective key names in the list.
- *          For more information about listing objects, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/ListingKeysUsingAPIs.html">Listing object keys
- *             programmatically</a>
- *          </p>
+ * the request parameters as selection criteria to return a subset of the objects in a bucket. A
+ * <code>200 OK</code> response can contain valid or invalid XML. Make sure to design your
+ * application to parse the contents of the response and handle it appropriately.
+ * Objects are returned sorted in an ascending order of the respective key names in the list.
+ * For more information about listing objects, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/ListingKeysUsingAPIs.html">Listing object keys
+ *    programmatically</a>
+ * </p>
  *
- *          <p>To use this operation, you must have READ access to the bucket.</p>
+ * <p>To use this operation, you must have READ access to the bucket.</p>
  *
- *          <p>To use this action in an Identity and Access Management (IAM) policy, you must
- *          have permissions to perform the <code>s3:ListBucket</code> action. The bucket owner has
- *          this permission by default and can grant this permission to others. For more information
- *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
- *          <important>
- *             <p>This section describes the latest revision of this action. We recommend that you use this
- *             revised API for application development. For backward compatibility, Amazon S3 continues to
- *             support the prior version of this API, <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects</a>.</p>
- *          </important>
+ * <p>To use this action in an Identity and Access Management (IAM) policy, you must
+ * have permissions to perform the <code>s3:ListBucket</code> action. The bucket owner has
+ * this permission by default and can grant this permission to others. For more information
+ * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
+ * <important>
+ *    <p>This section describes the latest revision of this action. We recommend that you use this
+ *    revised API for application development. For backward compatibility, Amazon S3 continues to
+ *    support the prior version of this API, <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html">ListObjects</a>.</p>
+ * </important>
  *
- *          <p>To get a list of your buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html">ListBuckets</a>.</p>
+ * <p>To get a list of your buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBuckets.html">ListBuckets</a>.</p>
  *
- *          <p>The following operations are related to <code>ListObjectsV2</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>ListObjectsV2</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/ListPartsCommand.ts
+++ b/clients/client-s3/src/commands/ListPartsCommand.ts
@@ -20,50 +20,50 @@ export interface ListPartsCommandOutput extends ListPartsOutput, __MetadataBeare
 
 /**
  * <p>Lists the parts that have been uploaded for a specific multipart upload. This operation
- *          must include the upload ID, which you obtain by sending the initiate multipart upload
- *          request (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>).
- *          This request returns a maximum of 1,000 uploaded parts. The default number of parts
- *          returned is 1,000 parts. You can restrict the number of parts returned by specifying the
- *             <code>max-parts</code> request parameter. If your multipart upload consists of more than
- *          1,000 parts, the response returns an <code>IsTruncated</code> field with the value of true,
- *          and a <code>NextPartNumberMarker</code> element. In subsequent <code>ListParts</code>
- *          requests you can include the part-number-marker query string parameter and set its value to
- *          the <code>NextPartNumberMarker</code> field value from the previous response.</p>
+ * must include the upload ID, which you obtain by sending the initiate multipart upload
+ * request (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>).
+ * This request returns a maximum of 1,000 uploaded parts. The default number of parts
+ * returned is 1,000 parts. You can restrict the number of parts returned by specifying the
+ *    <code>max-parts</code> request parameter. If your multipart upload consists of more than
+ * 1,000 parts, the response returns an <code>IsTruncated</code> field with the value of true,
+ * and a <code>NextPartNumberMarker</code> element. In subsequent <code>ListParts</code>
+ * requests you can include the part-number-marker query string parameter and set its value to
+ * the <code>NextPartNumberMarker</code> field value from the previous response.</p>
  *
- *          <p>For more information on multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
- *             Upload</a>.</p>
+ * <p>For more information on multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
+ *    Upload</a>.</p>
  *
- *          <p>For information on permissions required to use the multipart upload API, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
- *          Permissions</a>.</p>
+ * <p>For information on permissions required to use the multipart upload API, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
+ * Permissions</a>.</p>
  *
- *          <p>The following operations are related to <code>ListParts</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>ListParts</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketAccelerateConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketAccelerateConfigurationCommand.ts
@@ -23,51 +23,51 @@ export interface PutBucketAccelerateConfigurationCommandOutput extends __Metadat
 
 /**
  * <p>Sets the accelerate configuration of an existing bucket. Amazon S3 Transfer Acceleration is a
- *          bucket-level feature that enables you to perform faster data transfers to Amazon S3.</p>
+ * bucket-level feature that enables you to perform faster data transfers to Amazon S3.</p>
  *
- *          <p> To use this operation, you must have permission to perform the
- *          s3:PutAccelerateConfiguration action. The bucket owner has this permission by default. The
- *          bucket owner can grant this permission to others. For more information about permissions,
- *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
+ * <p> To use this operation, you must have permission to perform the
+ * s3:PutAccelerateConfiguration action. The bucket owner has this permission by default. The
+ * bucket owner can grant this permission to others. For more information about permissions,
+ * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
  *
- *          <p> The Transfer Acceleration state of a bucket can be set to one of the following two
- *          values:</p>
- *          <ul>
- *             <li>
- *                <p> Enabled – Enables accelerated data transfers to the bucket.</p>
- *             </li>
- *             <li>
- *                <p> Suspended – Disables accelerated data transfers to the bucket.</p>
- *             </li>
- *          </ul>
+ * <p> The Transfer Acceleration state of a bucket can be set to one of the following two
+ * values:</p>
+ * <ul>
+ *    <li>
+ *       <p> Enabled – Enables accelerated data transfers to the bucket.</p>
+ *    </li>
+ *    <li>
+ *       <p> Suspended – Disables accelerated data transfers to the bucket.</p>
+ *    </li>
+ * </ul>
  *
  *
- *          <p>The <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAccelerateConfiguration.html">GetBucketAccelerateConfiguration</a> action returns the transfer acceleration
- *          state of a bucket.</p>
+ * <p>The <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAccelerateConfiguration.html">GetBucketAccelerateConfiguration</a> action returns the transfer acceleration
+ * state of a bucket.</p>
  *
- *          <p>After setting the Transfer Acceleration state of a bucket to Enabled, it might take up
- *          to thirty minutes before the data transfer rates to the bucket increase.</p>
+ * <p>After setting the Transfer Acceleration state of a bucket to Enabled, it might take up
+ * to thirty minutes before the data transfer rates to the bucket increase.</p>
  *
- *          <p> The name of the bucket used for Transfer Acceleration must be DNS-compliant and must
- *          not contain periods (".").</p>
+ * <p> The name of the bucket used for Transfer Acceleration must be DNS-compliant and must
+ * not contain periods (".").</p>
  *
- *          <p> For more information about transfer acceleration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html">Transfer Acceleration</a>.</p>
+ * <p> For more information about transfer acceleration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html">Transfer Acceleration</a>.</p>
  *
- *          <p>The following operations are related to
- *          <code>PutBucketAccelerateConfiguration</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAccelerateConfiguration.html">GetBucketAccelerateConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to
+ * <code>PutBucketAccelerateConfiguration</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAccelerateConfiguration.html">GetBucketAccelerateConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketAclCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketAclCommand.ts
@@ -24,195 +24,195 @@ export interface PutBucketAclCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>Sets the permissions on an existing bucket using access control lists (ACL). For more
- *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. To set
- *          the ACL of a bucket, you must have <code>WRITE_ACP</code> permission.</p>
+ * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Using ACLs</a>. To set
+ * the ACL of a bucket, you must have <code>WRITE_ACP</code> permission.</p>
  *
- *          <p>You can use one of the following two ways to set a bucket's permissions:</p>
- *          <ul>
- *             <li>
- *                <p>Specify the ACL in the request body</p>
- *             </li>
- *             <li>
- *                <p>Specify permissions using request headers</p>
- *             </li>
- *          </ul>
+ * <p>You can use one of the following two ways to set a bucket's permissions:</p>
+ * <ul>
+ *    <li>
+ *       <p>Specify the ACL in the request body</p>
+ *    </li>
+ *    <li>
+ *       <p>Specify permissions using request headers</p>
+ *    </li>
+ * </ul>
  *
- *          <note>
- *             <p>You cannot specify access permission using both the body and the request
- *             headers.</p>
- *          </note>
+ * <note>
+ *    <p>You cannot specify access permission using both the body and the request
+ *    headers.</p>
+ * </note>
  *
- *          <p>Depending on your application needs, you may choose to set the ACL on a bucket using
- *          either the request body or the headers. For example, if you have an existing application
- *          that updates a bucket ACL using the request body, then you can continue to use that
- *          approach.</p>
+ * <p>Depending on your application needs, you may choose to set the ACL on a bucket using
+ * either the request body or the headers. For example, if you have an existing application
+ * that updates a bucket ACL using the request body, then you can continue to use that
+ * approach.</p>
  *
  *
- *          <p>
- *             <b>Access Permissions</b>
- *          </p>
- *          <p>You can set access permissions using one of the following methods:</p>
- *          <ul>
- *             <li>
- *                <p>Specify a canned ACL with the <code>x-amz-acl</code> request header. Amazon S3 supports
- *                a set of predefined ACLs, known as <i>canned ACLs</i>. Each canned ACL
- *                has a predefined set of grantees and permissions. Specify the canned ACL name as the
- *                value of <code>x-amz-acl</code>. If you use this header, you cannot use other access
- *                control-specific headers in your request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
- *             </li>
- *             <li>
- *                <p>Specify access permissions explicitly with the <code>x-amz-grant-read</code>,
- *                   <code>x-amz-grant-read-acp</code>, <code>x-amz-grant-write-acp</code>, and
- *                   <code>x-amz-grant-full-control</code> headers. When using these headers, you
- *                specify explicit access permissions and grantees (Amazon Web Services accounts or Amazon S3 groups) who
- *                will receive the permission. If you use these ACL-specific headers, you cannot use
- *                the <code>x-amz-acl</code> header to set a canned ACL. These parameters map to the
- *                set of permissions that Amazon S3 supports in an ACL. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL)
- *                Overview</a>.</p>
- *                <p>You specify each grantee as a type=value pair, where the type is one of the
- *                following:</p>
+ * <p>
+ *    <b>Access Permissions</b>
+ * </p>
+ * <p>You can set access permissions using one of the following methods:</p>
+ * <ul>
+ *    <li>
+ *       <p>Specify a canned ACL with the <code>x-amz-acl</code> request header. Amazon S3 supports
+ *       a set of predefined ACLs, known as <i>canned ACLs</i>. Each canned ACL
+ *       has a predefined set of grantees and permissions. Specify the canned ACL name as the
+ *       value of <code>x-amz-acl</code>. If you use this header, you cannot use other access
+ *       control-specific headers in your request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
+ *    </li>
+ *    <li>
+ *       <p>Specify access permissions explicitly with the <code>x-amz-grant-read</code>,
+ *          <code>x-amz-grant-read-acp</code>, <code>x-amz-grant-write-acp</code>, and
+ *          <code>x-amz-grant-full-control</code> headers. When using these headers, you
+ *       specify explicit access permissions and grantees (Amazon Web Services accounts or Amazon S3 groups) who
+ *       will receive the permission. If you use these ACL-specific headers, you cannot use
+ *       the <code>x-amz-acl</code> header to set a canned ACL. These parameters map to the
+ *       set of permissions that Amazon S3 supports in an ACL. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL)
+ *       Overview</a>.</p>
+ *       <p>You specify each grantee as a type=value pair, where the type is one of the
+ *       following:</p>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <code>id</code> – if the value specified is the canonical user ID of an Amazon Web Services account</p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <code>uri</code> – if you are granting permissions to a predefined
+ *             group</p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <code>emailAddress</code> – if the value specified is the email address of
+ *             an Amazon Web Services account</p>
+ *             <note>
+ *                <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
  *                <ul>
  *                   <li>
- *                      <p>
- *                         <code>id</code> – if the value specified is the canonical user ID of an Amazon Web Services account</p>
+ *                      <p>US East (N. Virginia)</p>
  *                   </li>
  *                   <li>
- *                      <p>
- *                         <code>uri</code> – if you are granting permissions to a predefined
- *                      group</p>
+ *                      <p>US West (N. California)</p>
  *                   </li>
  *                   <li>
- *                      <p>
- *                         <code>emailAddress</code> – if the value specified is the email address of
- *                      an Amazon Web Services account</p>
- *                      <note>
- *                         <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
- *                         <ul>
- *                            <li>
- *                               <p>US East (N. Virginia)</p>
- *                            </li>
- *                            <li>
- *                               <p>US West (N. California)</p>
- *                            </li>
- *                            <li>
- *                               <p> US West (Oregon)</p>
- *                            </li>
- *                            <li>
- *                               <p> Asia Pacific (Singapore)</p>
- *                            </li>
- *                            <li>
- *                               <p>Asia Pacific (Sydney)</p>
- *                            </li>
- *                            <li>
- *                               <p>Asia Pacific (Tokyo)</p>
- *                            </li>
- *                            <li>
- *                               <p>Europe (Ireland)</p>
- *                            </li>
- *                            <li>
- *                               <p>South America (São Paulo)</p>
- *                            </li>
- *                         </ul>
- *                         <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
- *                      </note>
+ *                      <p> US West (Oregon)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p> Asia Pacific (Singapore)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p>Asia Pacific (Sydney)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p>Asia Pacific (Tokyo)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p>Europe (Ireland)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p>South America (São Paulo)</p>
  *                   </li>
  *                </ul>
- *                <p>For example, the following <code>x-amz-grant-write</code> header grants create,
- *                overwrite, and delete objects permission to LogDelivery group predefined by Amazon S3 and
- *                two Amazon Web Services accounts identified by their email addresses.</p>
- *                <p>
- *                   <code>x-amz-grant-write: uri="http://acs.amazonaws.com/groups/s3/LogDelivery",
- *                   id="111122223333", id="555566667777" </code>
- *                </p>
+ *                <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
+ *             </note>
+ *          </li>
+ *       </ul>
+ *       <p>For example, the following <code>x-amz-grant-write</code> header grants create,
+ *       overwrite, and delete objects permission to LogDelivery group predefined by Amazon S3 and
+ *       two Amazon Web Services accounts identified by their email addresses.</p>
+ *       <p>
+ *          <code>x-amz-grant-write: uri="http://acs.amazonaws.com/groups/s3/LogDelivery",
+ *          id="111122223333", id="555566667777" </code>
+ *       </p>
  *
- *             </li>
- *          </ul>
- *          <p>You can use either a canned ACL or specify access permissions explicitly. You cannot do
- *          both.</p>
- *          <p>
- *             <b>Grantee Values</b>
- *          </p>
- *          <p>You can specify the person (grantee) to whom you're assigning access rights (using
- *          request elements) in the following ways:</p>
+ *    </li>
+ * </ul>
+ * <p>You can use either a canned ACL or specify access permissions explicitly. You cannot do
+ * both.</p>
+ * <p>
+ *    <b>Grantee Values</b>
+ * </p>
+ * <p>You can specify the person (grantee) to whom you're assigning access rights (using
+ * request elements) in the following ways:</p>
+ * <ul>
+ *    <li>
+ *       <p>By the person's ID:</p>
+ *       <p>
+ *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ *          xsi:type="CanonicalUser"><ID><>ID<></ID><DisplayName><>GranteesEmail<></DisplayName>
+ *          </Grantee></code>
+ *       </p>
+ *       <p>DisplayName is optional and ignored in the request</p>
+ *    </li>
+ *    <li>
+ *       <p>By URI:</p>
+ *       <p>
+ *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ *          xsi:type="Group"><URI><>http://acs.amazonaws.com/groups/global/AuthenticatedUsers<></URI></Grantee></code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>By Email address:</p>
+ *       <p>
+ *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ *          xsi:type="AmazonCustomerByEmail"><EmailAddress><>Grantees@email.com<></EmailAddress>lt;/Grantee></code>
+ *       </p>
+ *       <p>The grantee is resolved to the CanonicalUser and, in a response to a GET Object
+ *       acl request, appears as the CanonicalUser. </p>
+ *       <note>
+ *          <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
  *          <ul>
  *             <li>
- *                <p>By the person's ID:</p>
- *                <p>
- *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- *                   xsi:type="CanonicalUser"><ID><>ID<></ID><DisplayName><>GranteesEmail<></DisplayName>
- *                   </Grantee></code>
- *                </p>
- *                <p>DisplayName is optional and ignored in the request</p>
+ *                <p>US East (N. Virginia)</p>
  *             </li>
  *             <li>
- *                <p>By URI:</p>
- *                <p>
- *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- *                   xsi:type="Group"><URI><>http://acs.amazonaws.com/groups/global/AuthenticatedUsers<></URI></Grantee></code>
- *                </p>
+ *                <p>US West (N. California)</p>
  *             </li>
  *             <li>
- *                <p>By Email address:</p>
- *                <p>
- *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- *                   xsi:type="AmazonCustomerByEmail"><EmailAddress><>Grantees@email.com<></EmailAddress>lt;/Grantee></code>
- *                </p>
- *                <p>The grantee is resolved to the CanonicalUser and, in a response to a GET Object
- *                acl request, appears as the CanonicalUser. </p>
- *                <note>
- *                   <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
- *                   <ul>
- *                      <li>
- *                         <p>US East (N. Virginia)</p>
- *                      </li>
- *                      <li>
- *                         <p>US West (N. California)</p>
- *                      </li>
- *                      <li>
- *                         <p> US West (Oregon)</p>
- *                      </li>
- *                      <li>
- *                         <p> Asia Pacific (Singapore)</p>
- *                      </li>
- *                      <li>
- *                         <p>Asia Pacific (Sydney)</p>
- *                      </li>
- *                      <li>
- *                         <p>Asia Pacific (Tokyo)</p>
- *                      </li>
- *                      <li>
- *                         <p>Europe (Ireland)</p>
- *                      </li>
- *                      <li>
- *                         <p>South America (São Paulo)</p>
- *                      </li>
- *                   </ul>
- *                   <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
- *                </note>
+ *                <p> US West (Oregon)</p>
+ *             </li>
+ *             <li>
+ *                <p> Asia Pacific (Singapore)</p>
+ *             </li>
+ *             <li>
+ *                <p>Asia Pacific (Sydney)</p>
+ *             </li>
+ *             <li>
+ *                <p>Asia Pacific (Tokyo)</p>
+ *             </li>
+ *             <li>
+ *                <p>Europe (Ireland)</p>
+ *             </li>
+ *             <li>
+ *                <p>South America (São Paulo)</p>
  *             </li>
  *          </ul>
+ *          <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
+ *       </note>
+ *    </li>
+ * </ul>
  *
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html">GetObjectAcl</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html">GetObjectAcl</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketAnalyticsConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketAnalyticsConfigurationCommand.ts
@@ -23,121 +23,121 @@ export interface PutBucketAnalyticsConfigurationCommandOutput extends __Metadata
 
 /**
  * <p>Sets an analytics configuration for the bucket (specified by the analytics configuration
- *          ID). You can have up to 1,000 analytics configurations per bucket.</p>
+ * ID). You can have up to 1,000 analytics configurations per bucket.</p>
  *
- *          <p>You can choose to have storage class analysis export analysis reports sent to a
- *          comma-separated values (CSV) flat file. See the <code>DataExport</code> request element.
- *          Reports are updated daily and are based on the object filters that you configure. When
- *          selecting data export, you specify a destination bucket and an optional destination prefix
- *          where the file is written. You can export the data to a destination bucket in a different
- *          account. However, the destination bucket must be in the same Region as the bucket that you
- *          are making the PUT analytics configuration to. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
- *             Analysis</a>. </p>
+ * <p>You can choose to have storage class analysis export analysis reports sent to a
+ * comma-separated values (CSV) flat file. See the <code>DataExport</code> request element.
+ * Reports are updated daily and are based on the object filters that you configure. When
+ * selecting data export, you specify a destination bucket and an optional destination prefix
+ * where the file is written. You can export the data to a destination bucket in a different
+ * account. However, the destination bucket must be in the same Region as the bucket that you
+ * are making the PUT analytics configuration to. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/analytics-storage-class.html">Amazon S3 Analytics – Storage Class
+ *    Analysis</a>. </p>
  *
- *          <important>
- *             <p>You must create a bucket policy on the destination bucket where the exported file is
- *             written to grant permissions to Amazon S3 to write objects to the bucket. For an example
- *             policy, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html#example-bucket-policies-use-case-9">Granting Permissions for Amazon S3 Inventory and Storage Class Analysis</a>.</p>
- *          </important>
+ * <important>
+ *    <p>You must create a bucket policy on the destination bucket where the exported file is
+ *    written to grant permissions to Amazon S3 to write objects to the bucket. For an example
+ *    policy, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html#example-bucket-policies-use-case-9">Granting Permissions for Amazon S3 Inventory and Storage Class Analysis</a>.</p>
+ * </important>
  *
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:PutAnalyticsConfiguration</code> action. The bucket owner has this permission
- *          by default. The bucket owner can grant this permission to others. For more information
- *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
- *
- *
- *          <p class="title">
- *             <b>Special Errors</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>HTTP Error: HTTP 400 Bad Request</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Code: InvalidArgument</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause: Invalid argument.</i>
- *                      </p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>HTTP Error: HTTP 400 Bad Request</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Code: TooManyConfigurations</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause: You are attempting to create a new configuration but have
- *                         already reached the 1,000-configuration limit.</i>
- *                      </p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>HTTP Error: HTTP 403 Forbidden</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Code: AccessDenied</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause: You are not the owner of the specified bucket, or you do
- *                         not have the s3:PutAnalyticsConfiguration bucket permission to set the
- *                         configuration on the bucket.</i>
- *                      </p>
- *                   </li>
- *                </ul>
- *             </li>
- *          </ul>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:PutAnalyticsConfiguration</code> action. The bucket owner has this permission
+ * by default. The bucket owner can grant this permission to others. For more information
+ * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
  *
  *
+ * <p class="title">
+ *    <b>Special Errors</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>HTTP Error: HTTP 400 Bad Request</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Code: InvalidArgument</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause: Invalid argument.</i>
+ *             </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>HTTP Error: HTTP 400 Bad Request</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Code: TooManyConfigurations</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause: You are attempting to create a new configuration but have
+ *                already reached the 1,000-configuration limit.</i>
+ *             </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>HTTP Error: HTTP 403 Forbidden</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Code: AccessDenied</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause: You are not the owner of the specified bucket, or you do
+ *                not have the s3:PutAnalyticsConfiguration bucket permission to set the
+ *                configuration on the bucket.</i>
+ *             </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ * </ul>
  *
  *
  *
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAnalyticsConfiguration.html">GetBucketAnalyticsConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketAnalyticsConfiguration.html">DeleteBucketAnalyticsConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketAnalyticsConfigurations.html">ListBucketAnalyticsConfigurations</a>
- *                </p>
- *             </li>
- *          </ul>
+ *
+ *
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketAnalyticsConfiguration.html">GetBucketAnalyticsConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketAnalyticsConfiguration.html">DeleteBucketAnalyticsConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketAnalyticsConfigurations.html">ListBucketAnalyticsConfigurations</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketCorsCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketCorsCommand.ts
@@ -24,62 +24,62 @@ export interface PutBucketCorsCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>Sets the <code>cors</code> configuration for your bucket. If the configuration exists,
- *          Amazon S3 replaces it.</p>
- *          <p>To use this operation, you must be allowed to perform the <code>s3:PutBucketCORS</code>
- *          action. By default, the bucket owner has this permission and can grant it to others.</p>
- *          <p>You set this configuration on a bucket so that the bucket can service cross-origin
- *          requests. For example, you might want to enable a request whose origin is
- *             <code>http://www.example.com</code> to access your Amazon S3 bucket at
- *             <code>my.example.bucket.com</code> by using the browser's <code>XMLHttpRequest</code>
- *          capability.</p>
- *          <p>To enable cross-origin resource sharing (CORS) on a bucket, you add the
- *             <code>cors</code> subresource to the bucket. The <code>cors</code> subresource is an XML
- *          document in which you configure rules that identify origins and the HTTP methods that can
- *          be executed on your bucket. The document is limited to 64 KB in size. </p>
- *          <p>When Amazon S3 receives a cross-origin request (or a pre-flight OPTIONS request) against a
- *          bucket, it evaluates the <code>cors</code> configuration on the bucket and uses the first
- *             <code>CORSRule</code> rule that matches the incoming browser request to enable a
- *          cross-origin request. For a rule to match, the following conditions must be met:</p>
- *          <ul>
- *             <li>
- *                <p>The request's <code>Origin</code> header must match <code>AllowedOrigin</code>
- *                elements.</p>
- *             </li>
- *             <li>
- *                <p>The request method (for example, GET, PUT, HEAD, and so on) or the
- *                   <code>Access-Control-Request-Method</code> header in case of a pre-flight
- *                   <code>OPTIONS</code> request must be one of the <code>AllowedMethod</code>
- *                elements. </p>
- *             </li>
- *             <li>
- *                <p>Every header specified in the <code>Access-Control-Request-Headers</code> request
- *                header of a pre-flight request must match an <code>AllowedHeader</code> element.
- *             </p>
- *             </li>
- *          </ul>
- *          <p> For more information about CORS, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html">Enabling
- *             Cross-Origin Resource Sharing</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * Amazon S3 replaces it.</p>
+ * <p>To use this operation, you must be allowed to perform the <code>s3:PutBucketCORS</code>
+ * action. By default, the bucket owner has this permission and can grant it to others.</p>
+ * <p>You set this configuration on a bucket so that the bucket can service cross-origin
+ * requests. For example, you might want to enable a request whose origin is
+ *    <code>http://www.example.com</code> to access your Amazon S3 bucket at
+ *    <code>my.example.bucket.com</code> by using the browser's <code>XMLHttpRequest</code>
+ * capability.</p>
+ * <p>To enable cross-origin resource sharing (CORS) on a bucket, you add the
+ *    <code>cors</code> subresource to the bucket. The <code>cors</code> subresource is an XML
+ * document in which you configure rules that identify origins and the HTTP methods that can
+ * be executed on your bucket. The document is limited to 64 KB in size. </p>
+ * <p>When Amazon S3 receives a cross-origin request (or a pre-flight OPTIONS request) against a
+ * bucket, it evaluates the <code>cors</code> configuration on the bucket and uses the first
+ *    <code>CORSRule</code> rule that matches the incoming browser request to enable a
+ * cross-origin request. For a rule to match, the following conditions must be met:</p>
+ * <ul>
+ *    <li>
+ *       <p>The request's <code>Origin</code> header must match <code>AllowedOrigin</code>
+ *       elements.</p>
+ *    </li>
+ *    <li>
+ *       <p>The request method (for example, GET, PUT, HEAD, and so on) or the
+ *          <code>Access-Control-Request-Method</code> header in case of a pre-flight
+ *          <code>OPTIONS</code> request must be one of the <code>AllowedMethod</code>
+ *       elements. </p>
+ *    </li>
+ *    <li>
+ *       <p>Every header specified in the <code>Access-Control-Request-Headers</code> request
+ *       header of a pre-flight request must match an <code>AllowedHeader</code> element.
+ *    </p>
+ *    </li>
+ * </ul>
+ * <p> For more information about CORS, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html">Enabling
+ *    Cross-Origin Resource Sharing</a> in the <i>Amazon S3 User Guide</i>.</p>
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketCors.html">GetBucketCors</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketCors.html">DeleteBucketCors</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTOPTIONSobject.html">RESTOPTIONSobject</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketCors.html">GetBucketCors</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketCors.html">DeleteBucketCors</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTOPTIONSobject.html">RESTOPTIONSobject</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketEncryptionCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketEncryptionCommand.ts
@@ -24,38 +24,38 @@ export interface PutBucketEncryptionCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>This action uses the <code>encryption</code> subresource to configure default
- *          encryption and Amazon S3 Bucket Key for an existing bucket.</p>
- *          <p>Default encryption for a bucket can use server-side encryption with Amazon S3-managed keys
- *          (SSE-S3) or Amazon Web Services KMS customer master keys (SSE-KMS). If you specify default encryption
- *          using SSE-KMS, you can also configure Amazon S3 Bucket Key. For information about default
- *          encryption, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html">Amazon S3 default bucket encryption</a>
- *          in the <i>Amazon S3 User Guide</i>. For more information about S3 Bucket Keys,
- *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.</p>
- *          <important>
- *             <p>This action requires Amazon Web Services Signature Version 4. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html"> Authenticating Requests (Amazon Web Services Signature
- *                Version 4)</a>. </p>
- *          </important>
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:PutEncryptionConfiguration</code> action. The bucket owner has this permission
- *          by default. The bucket owner can grant this permission to others. For more information
- *          about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a> in the Amazon S3 User Guide. </p>
+ * encryption and Amazon S3 Bucket Key for an existing bucket.</p>
+ * <p>Default encryption for a bucket can use server-side encryption with Amazon S3-managed keys
+ * (SSE-S3) or Amazon Web Services KMS customer master keys (SSE-KMS). If you specify default encryption
+ * using SSE-KMS, you can also configure Amazon S3 Bucket Key. For information about default
+ * encryption, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html">Amazon S3 default bucket encryption</a>
+ * in the <i>Amazon S3 User Guide</i>. For more information about S3 Bucket Keys,
+ * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * <important>
+ *    <p>This action requires Amazon Web Services Signature Version 4. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html"> Authenticating Requests (Amazon Web Services Signature
+ *       Version 4)</a>. </p>
+ * </important>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:PutEncryptionConfiguration</code> action. The bucket owner has this permission
+ * by default. The bucket owner can grant this permission to others. For more information
+ * about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a> in the Amazon S3 User Guide. </p>
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html">GetBucketEncryption</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketEncryption.html">DeleteBucketEncryption</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketEncryption.html">GetBucketEncryption</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketEncryption.html">DeleteBucketEncryption</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketIntelligentTieringConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketIntelligentTieringConfigurationCommand.ts
@@ -25,87 +25,87 @@ export interface PutBucketIntelligentTieringConfigurationCommandOutput extends _
 /**
  * <p>Puts a S3 Intelligent-Tiering configuration to the specified bucket.
  *       You can have up to 1,000 S3 Intelligent-Tiering configurations per bucket.</p>
- *          <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
- *          <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
- *          <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
- *          <p>Operations related to
- *             <code>PutBucketIntelligentTieringConfiguration</code> include: </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketIntelligentTieringConfiguration.html">DeleteBucketIntelligentTieringConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html">GetBucketIntelligentTieringConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html">ListBucketIntelligentTieringConfigurations</a>
- *                </p>
- *             </li>
- *          </ul>
- *          <note>
- *             <p>You only need S3 Intelligent-Tiering enabled on a bucket if you want to automatically
- *             move objects stored in the S3 Intelligent-Tiering storage class to the
- *             Archive Access or Deep Archive Access tier.</p>
- *          </note>
+ * <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by automatically moving data to the most cost-effective storage access tier, without additional operational overhead. S3 Intelligent-Tiering delivers automatic cost savings by moving data between access tiers, when access patterns change.</p>
+ * <p>The S3 Intelligent-Tiering storage class is suitable for objects larger than 128 KB that you plan to store for at least 30 days. If the size of an object is less than 128 KB, it is not eligible for auto-tiering. Smaller objects can be stored, but they are always charged at the frequent access tier rates in the S3 Intelligent-Tiering storage class. </p>
+ * <p>If you delete an object before the end of the 30-day minimum storage duration period, you are charged for 30 days. For more information, see  <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for automatically optimizing frequently and infrequently accessed objects</a>.</p>
+ * <p>Operations related to
+ *    <code>PutBucketIntelligentTieringConfiguration</code> include: </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketIntelligentTieringConfiguration.html">DeleteBucketIntelligentTieringConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketIntelligentTieringConfiguration.html">GetBucketIntelligentTieringConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketIntelligentTieringConfigurations.html">ListBucketIntelligentTieringConfigurations</a>
+ *       </p>
+ *    </li>
+ * </ul>
+ * <note>
+ *    <p>You only need S3 Intelligent-Tiering enabled on a bucket if you want to automatically
+ *    move objects stored in the S3 Intelligent-Tiering storage class to the
+ *    Archive Access or Deep Archive Access tier.</p>
+ * </note>
  *
- *          <p class="title">
- *             <b>Special Errors</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p class="title">
- *                   <b>HTTP 400 Bad Request Error</b>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code:</i> InvalidArgument</p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause:</i> Invalid Argument</p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <p class="title">
- *                   <b>HTTP 400 Bad Request Error</b>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code:</i> TooManyConfigurations</p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause:</i> You are attempting to create a new configuration
- *                      but have already reached the 1,000-configuration limit. </p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <p class="title">
- *                   <b>HTTP 403 Forbidden Error</b>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code:</i> AccessDenied</p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause:</i> You are not the owner of the specified bucket,
- *                      or you do not have the <code>s3:PutIntelligentTieringConfiguration</code> bucket
- *                      permission to set the configuration on the bucket. </p>
- *                   </li>
- *                </ul>
- *             </li>
- *          </ul>
+ * <p class="title">
+ *    <b>Special Errors</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p class="title">
+ *          <b>HTTP 400 Bad Request Error</b>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code:</i> InvalidArgument</p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause:</i> Invalid Argument</p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <p class="title">
+ *          <b>HTTP 400 Bad Request Error</b>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code:</i> TooManyConfigurations</p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause:</i> You are attempting to create a new configuration
+ *             but have already reached the 1,000-configuration limit. </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <p class="title">
+ *          <b>HTTP 403 Forbidden Error</b>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code:</i> AccessDenied</p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause:</i> You are not the owner of the specified bucket,
+ *             or you do not have the <code>s3:PutIntelligentTieringConfiguration</code> bucket
+ *             permission to set the configuration on the bucket. </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketInventoryConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketInventoryConfigurationCommand.ts
@@ -23,106 +23,106 @@ export interface PutBucketInventoryConfigurationCommandOutput extends __Metadata
 
 /**
  * <p>This implementation of the <code>PUT</code> action adds an inventory configuration
- *          (identified by the inventory ID) to the bucket. You can have up to 1,000 inventory
- *          configurations per bucket. </p>
- *          <p>Amazon S3 inventory generates inventories of the objects in the bucket on a daily or weekly
- *          basis, and the results are published to a flat file. The bucket that is inventoried is
- *          called the <i>source</i> bucket, and the bucket where the inventory flat file
- *          is stored is called the <i>destination</i> bucket. The
- *             <i>destination</i> bucket must be in the same Amazon Web Services Region as the
- *             <i>source</i> bucket. </p>
- *          <p>When you configure an inventory for a <i>source</i> bucket, you specify
- *          the <i>destination</i> bucket where you want the inventory to be stored, and
- *          whether to generate the inventory daily or weekly. You can also configure what object
- *          metadata to include and whether to inventory all object versions or only current versions.
- *          For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3
- *             Inventory</a> in the Amazon S3 User Guide.</p>
- *          <important>
- *             <p>You must create a bucket policy on the <i>destination</i> bucket to
- *             grant permissions to Amazon S3 to write objects to the bucket in the defined location. For an
- *             example policy, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html#example-bucket-policies-use-case-9">
- *                Granting Permissions for Amazon S3 Inventory and Storage Class Analysis</a>.</p>
- *          </important>
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:PutInventoryConfiguration</code> action. The bucket owner has this permission
- *          by default and can grant this permission to others. For more information about permissions,
- *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a> in the Amazon S3 User Guide.</p>
+ * (identified by the inventory ID) to the bucket. You can have up to 1,000 inventory
+ * configurations per bucket. </p>
+ * <p>Amazon S3 inventory generates inventories of the objects in the bucket on a daily or weekly
+ * basis, and the results are published to a flat file. The bucket that is inventoried is
+ * called the <i>source</i> bucket, and the bucket where the inventory flat file
+ * is stored is called the <i>destination</i> bucket. The
+ *    <i>destination</i> bucket must be in the same Amazon Web Services Region as the
+ *    <i>source</i> bucket. </p>
+ * <p>When you configure an inventory for a <i>source</i> bucket, you specify
+ * the <i>destination</i> bucket where you want the inventory to be stored, and
+ * whether to generate the inventory daily or weekly. You can also configure what object
+ * metadata to include and whether to inventory all object versions or only current versions.
+ * For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html">Amazon S3
+ *    Inventory</a> in the Amazon S3 User Guide.</p>
+ * <important>
+ *    <p>You must create a bucket policy on the <i>destination</i> bucket to
+ *    grant permissions to Amazon S3 to write objects to the bucket in the defined location. For an
+ *    example policy, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html#example-bucket-policies-use-case-9">
+ *       Granting Permissions for Amazon S3 Inventory and Storage Class Analysis</a>.</p>
+ * </important>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:PutInventoryConfiguration</code> action. The bucket owner has this permission
+ * by default and can grant this permission to others. For more information about permissions,
+ * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a> in the Amazon S3 User Guide.</p>
  *
- *          <p class="title">
- *             <b>Special Errors</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p class="title">
- *                   <b>HTTP 400 Bad Request Error</b>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code:</i> InvalidArgument</p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause:</i> Invalid Argument</p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <p class="title">
- *                   <b>HTTP 400 Bad Request Error</b>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code:</i> TooManyConfigurations</p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause:</i> You are attempting to create a new configuration
- *                      but have already reached the 1,000-configuration limit. </p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <p class="title">
- *                   <b>HTTP 403 Forbidden Error</b>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code:</i> AccessDenied</p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause:</i> You are not the owner of the specified bucket,
- *                      or you do not have the <code>s3:PutInventoryConfiguration</code> bucket
- *                      permission to set the configuration on the bucket. </p>
- *                   </li>
- *                </ul>
- *             </li>
- *          </ul>
+ * <p class="title">
+ *    <b>Special Errors</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p class="title">
+ *          <b>HTTP 400 Bad Request Error</b>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code:</i> InvalidArgument</p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause:</i> Invalid Argument</p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <p class="title">
+ *          <b>HTTP 400 Bad Request Error</b>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code:</i> TooManyConfigurations</p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause:</i> You are attempting to create a new configuration
+ *             but have already reached the 1,000-configuration limit. </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <p class="title">
+ *          <b>HTTP 403 Forbidden Error</b>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code:</i> AccessDenied</p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause:</i> You are not the owner of the specified bucket,
+ *             or you do not have the <code>s3:PutInventoryConfiguration</code> bucket
+ *             permission to set the configuration on the bucket. </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ * </ul>
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketInventoryConfiguration.html">GetBucketInventoryConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketInventoryConfiguration.html">DeleteBucketInventoryConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketInventoryConfigurations.html">ListBucketInventoryConfigurations</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketInventoryConfiguration.html">GetBucketInventoryConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketInventoryConfiguration.html">DeleteBucketInventoryConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketInventoryConfigurations.html">ListBucketInventoryConfigurations</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketLifecycleConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketLifecycleConfigurationCommand.ts
@@ -24,99 +24,99 @@ export interface PutBucketLifecycleConfigurationCommandOutput extends __Metadata
 
 /**
  * <p>Creates a new lifecycle configuration for the bucket or replaces an existing lifecycle
- *          configuration. For information about lifecycle configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html">Managing your storage
- *             lifecycle</a>.</p>
+ * configuration. For information about lifecycle configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html">Managing your storage
+ *    lifecycle</a>.</p>
  *
- *          <note>
- *             <p>Bucket lifecycle configuration now supports specifying a lifecycle rule using an
- *             object key name prefix, one or more object tags, or a combination of both. Accordingly,
- *             this section describes the latest API. The previous version of the API supported
- *             filtering based only on an object key name prefix, which is supported for backward
- *             compatibility. For the related API description, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html">PutBucketLifecycle</a>.</p>
- *          </note>
- *
- *
- *
- *          <p>
- *             <b>Rules</b>
- *          </p>
- *          <p>You specify the lifecycle configuration in your request body. The lifecycle
- *          configuration is specified as XML consisting of one or more rules. Each rule consists of
- *          the following:</p>
- *
- *          <ul>
- *             <li>
- *                <p>Filter identifying a subset of objects to which the rule applies. The filter can
- *                be based on a key name prefix, object tags, or a combination of both.</p>
- *             </li>
- *             <li>
- *                <p>Status whether the rule is in effect.</p>
- *             </li>
- *             <li>
- *                <p>One or more lifecycle transition and expiration actions that you want Amazon S3 to
- *                perform on the objects identified by the filter. If the state of your bucket is
- *                versioning-enabled or versioning-suspended, you can have many versions of the same
- *                object (one current version and zero or more noncurrent versions). Amazon S3 provides
- *                predefined actions that you can specify for current and noncurrent object
- *                versions.</p>
- *             </li>
- *          </ul>
- *
- *          <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Object
- *             Lifecycle Management</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html">Lifecycle Configuration Elements</a>.</p>
+ * <note>
+ *    <p>Bucket lifecycle configuration now supports specifying a lifecycle rule using an
+ *    object key name prefix, one or more object tags, or a combination of both. Accordingly,
+ *    this section describes the latest API. The previous version of the API supported
+ *    filtering based only on an object key name prefix, which is supported for backward
+ *    compatibility. For the related API description, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycle.html">PutBucketLifecycle</a>.</p>
+ * </note>
  *
  *
- *          <p>
- *             <b>Permissions</b>
- *          </p>
+ *
+ * <p>
+ *    <b>Rules</b>
+ * </p>
+ * <p>You specify the lifecycle configuration in your request body. The lifecycle
+ * configuration is specified as XML consisting of one or more rules. Each rule consists of
+ * the following:</p>
+ *
+ * <ul>
+ *    <li>
+ *       <p>Filter identifying a subset of objects to which the rule applies. The filter can
+ *       be based on a key name prefix, object tags, or a combination of both.</p>
+ *    </li>
+ *    <li>
+ *       <p>Status whether the rule is in effect.</p>
+ *    </li>
+ *    <li>
+ *       <p>One or more lifecycle transition and expiration actions that you want Amazon S3 to
+ *       perform on the objects identified by the filter. If the state of your bucket is
+ *       versioning-enabled or versioning-suspended, you can have many versions of the same
+ *       object (one current version and zero or more noncurrent versions). Amazon S3 provides
+ *       predefined actions that you can specify for current and noncurrent object
+ *       versions.</p>
+ *    </li>
+ * </ul>
+ *
+ * <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Object
+ *    Lifecycle Management</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html">Lifecycle Configuration Elements</a>.</p>
  *
  *
- *          <p>By default, all Amazon S3 resources are private, including buckets, objects, and related
- *          subresources (for example, lifecycle configuration and website configuration). Only the
- *          resource owner (that is, the Amazon Web Services account that created it) can access the resource. The
- *          resource owner can optionally grant access permissions to others by writing an access
- *          policy. For this operation, a user must get the s3:PutLifecycleConfiguration
- *          permission.</p>
- *
- *          <p>You can also explicitly deny permissions. Explicit deny also supersedes any other
- *          permissions. If you want to block users or accounts from removing or deleting objects from
- *          your bucket, you must deny them permissions for the following actions:</p>
- *
- *          <ul>
- *             <li>
- *                <p>s3:DeleteObject</p>
- *             </li>
- *             <li>
- *                <p>s3:DeleteObjectVersion</p>
- *             </li>
- *             <li>
- *                <p>s3:PutLifecycleConfiguration</p>
- *             </li>
- *          </ul>
+ * <p>
+ *    <b>Permissions</b>
+ * </p>
  *
  *
- *          <p>For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
+ * <p>By default, all Amazon S3 resources are private, including buckets, objects, and related
+ * subresources (for example, lifecycle configuration and website configuration). Only the
+ * resource owner (that is, the Amazon Web Services account that created it) can access the resource. The
+ * resource owner can optionally grant access permissions to others by writing an access
+ * policy. For this operation, a user must get the s3:PutLifecycleConfiguration
+ * permission.</p>
  *
- *          <p>The following are related to <code>PutBucketLifecycleConfiguration</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/lifecycle-configuration-examples.html">Examples of
- *                   Lifecycle Configuration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html">GetBucketLifecycleConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketLifecycle.html">DeleteBucketLifecycle</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>You can also explicitly deny permissions. Explicit deny also supersedes any other
+ * permissions. If you want to block users or accounts from removing or deleting objects from
+ * your bucket, you must deny them permissions for the following actions:</p>
+ *
+ * <ul>
+ *    <li>
+ *       <p>s3:DeleteObject</p>
+ *    </li>
+ *    <li>
+ *       <p>s3:DeleteObjectVersion</p>
+ *    </li>
+ *    <li>
+ *       <p>s3:PutLifecycleConfiguration</p>
+ *    </li>
+ * </ul>
+ *
+ *
+ * <p>For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
+ *
+ * <p>The following are related to <code>PutBucketLifecycleConfiguration</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/lifecycle-configuration-examples.html">Examples of
+ *          Lifecycle Configuration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html">GetBucketLifecycleConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketLifecycle.html">DeleteBucketLifecycle</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketLoggingCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketLoggingCommand.ts
@@ -24,85 +24,85 @@ export interface PutBucketLoggingCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>Set the logging parameters for a bucket and to specify permissions for who can view and
- *          modify the logging parameters. All logs are saved to buckets in the same Amazon Web Services Region as the
- *          source bucket. To set the logging status of a bucket, you must be the bucket owner.</p>
+ * modify the logging parameters. All logs are saved to buckets in the same Amazon Web Services Region as the
+ * source bucket. To set the logging status of a bucket, you must be the bucket owner.</p>
  *
- *          <p>The bucket owner is automatically granted FULL_CONTROL to all logs. You use the
- *             <code>Grantee</code> request element to grant access to other people. The
- *             <code>Permissions</code> request element specifies the kind of access the grantee has to
- *          the logs.</p>
+ * <p>The bucket owner is automatically granted FULL_CONTROL to all logs. You use the
+ *    <code>Grantee</code> request element to grant access to other people. The
+ *    <code>Permissions</code> request element specifies the kind of access the grantee has to
+ * the logs.</p>
  *
- *          <p>
- *             <b>Grantee Values</b>
- *          </p>
- *          <p>You can specify the person (grantee) to whom you're assigning access rights (using
- *          request elements) in the following ways:</p>
+ * <p>
+ *    <b>Grantee Values</b>
+ * </p>
+ * <p>You can specify the person (grantee) to whom you're assigning access rights (using
+ * request elements) in the following ways:</p>
  *
- *          <ul>
- *             <li>
- *                <p>By the person's ID:</p>
- *                <p>
- *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- *                   xsi:type="CanonicalUser"><ID><>ID<></ID><DisplayName><>GranteesEmail<></DisplayName>
- *                   </Grantee></code>
- *                </p>
- *                <p>DisplayName is optional and ignored in the request.</p>
- *             </li>
- *             <li>
- *                <p>By Email address:</p>
- *                <p>
- *                   <code> <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- *                   xsi:type="AmazonCustomerByEmail"><EmailAddress><>Grantees@email.com<></EmailAddress></Grantee></code>
- *                </p>
- *                <p>The grantee is resolved to the CanonicalUser and, in a response to a GET Object
- *                acl request, appears as the CanonicalUser.</p>
- *             </li>
- *             <li>
- *                <p>By URI:</p>
- *                <p>
- *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- *                   xsi:type="Group"><URI><>http://acs.amazonaws.com/groups/global/AuthenticatedUsers<></URI></Grantee></code>
- *                </p>
- *             </li>
- *          </ul>
+ * <ul>
+ *    <li>
+ *       <p>By the person's ID:</p>
+ *       <p>
+ *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ *          xsi:type="CanonicalUser"><ID><>ID<></ID><DisplayName><>GranteesEmail<></DisplayName>
+ *          </Grantee></code>
+ *       </p>
+ *       <p>DisplayName is optional and ignored in the request.</p>
+ *    </li>
+ *    <li>
+ *       <p>By Email address:</p>
+ *       <p>
+ *          <code> <Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ *          xsi:type="AmazonCustomerByEmail"><EmailAddress><>Grantees@email.com<></EmailAddress></Grantee></code>
+ *       </p>
+ *       <p>The grantee is resolved to the CanonicalUser and, in a response to a GET Object
+ *       acl request, appears as the CanonicalUser.</p>
+ *    </li>
+ *    <li>
+ *       <p>By URI:</p>
+ *       <p>
+ *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ *          xsi:type="Group"><URI><>http://acs.amazonaws.com/groups/global/AuthenticatedUsers<></URI></Grantee></code>
+ *       </p>
+ *    </li>
+ * </ul>
  *
  *
- *          <p>To enable logging, you use LoggingEnabled and its children request elements. To disable
- *          logging, you use an empty BucketLoggingStatus request element:</p>
+ * <p>To enable logging, you use LoggingEnabled and its children request elements. To disable
+ * logging, you use an empty BucketLoggingStatus request element:</p>
  *
- *          <p>
- *             <code><BucketLoggingStatus xmlns="http://doc.s3.amazonaws.com/2006-03-01"
- *             /></code>
- *          </p>
+ * <p>
+ *    <code><BucketLoggingStatus xmlns="http://doc.s3.amazonaws.com/2006-03-01"
+ *    /></code>
+ * </p>
  *
- *          <p>For more information about server access logging, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerLogs.html">Server Access Logging</a>. </p>
+ * <p>For more information about server access logging, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerLogs.html">Server Access Logging</a>. </p>
  *
- *          <p>For more information about creating a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>. For more
- *          information about returning the logging status of a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLogging.html">GetBucketLogging</a>.</p>
+ * <p>For more information about creating a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>. For more
+ * information about returning the logging status of a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLogging.html">GetBucketLogging</a>.</p>
  *
- *          <p>The following operations are related to <code>PutBucketLogging</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLogging.html">GetBucketLogging</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>PutBucketLogging</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLogging.html">GetBucketLogging</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketMetricsConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketMetricsConfigurationCommand.ts
@@ -23,56 +23,56 @@ export interface PutBucketMetricsConfigurationCommandOutput extends __MetadataBe
 
 /**
  * <p>Sets a metrics configuration (specified by the metrics configuration ID) for the bucket.
- *          You can have up to 1,000 metrics configurations per bucket. If you're updating an existing
- *          metrics configuration, note that this is a full replacement of the existing metrics
- *          configuration. If you don't include the elements you want to keep, they are erased.</p>
+ * You can have up to 1,000 metrics configurations per bucket. If you're updating an existing
+ * metrics configuration, note that this is a full replacement of the existing metrics
+ * configuration. If you don't include the elements you want to keep, they are erased.</p>
  *
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:PutMetricsConfiguration</code> action. The bucket owner has this permission by
- *          default. The bucket owner can grant this permission to others. For more information about
- *          permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:PutMetricsConfiguration</code> action. The bucket owner has this permission by
+ * default. The bucket owner can grant this permission to others. For more information about
+ * permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
  *
- *          <p>For information about CloudWatch request metrics for Amazon S3, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
- *             CloudWatch</a>.</p>
+ * <p>For information about CloudWatch request metrics for Amazon S3, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html">Monitoring Metrics with Amazon
+ *    CloudWatch</a>.</p>
  *
- *          <p>The following operations are related to
- *          <code>PutBucketMetricsConfiguration</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html">DeleteBucketMetricsConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketMetricsConfigurations.html">ListBucketMetricsConfigurations</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to
+ * <code>PutBucketMetricsConfiguration</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketMetricsConfiguration.html">DeleteBucketMetricsConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketMetricsConfiguration.html">PutBucketMetricsConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListBucketMetricsConfigurations.html">ListBucketMetricsConfigurations</a>
+ *       </p>
+ *    </li>
+ * </ul>
  *
- *          <p>
- *             <code>GetBucketLifecycle</code> has the following special error:</p>
- *          <ul>
- *             <li>
- *                <p>Error code: <code>TooManyConfigurations</code>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>Description: You are attempting to create a new configuration but have
- *                      already reached the 1,000-configuration limit.</p>
- *                   </li>
- *                   <li>
- *                      <p>HTTP Status Code: HTTP 400 Bad Request</p>
- *                   </li>
- *                </ul>
- *             </li>
- *          </ul>
+ * <p>
+ *    <code>GetBucketLifecycle</code> has the following special error:</p>
+ * <ul>
+ *    <li>
+ *       <p>Error code: <code>TooManyConfigurations</code>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>Description: You are attempting to create a new configuration but have
+ *             already reached the 1,000-configuration limit.</p>
+ *          </li>
+ *          <li>
+ *             <p>HTTP Status Code: HTTP 400 Bad Request</p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketNotificationConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketNotificationConfigurationCommand.ts
@@ -23,67 +23,67 @@ export interface PutBucketNotificationConfigurationCommandOutput extends __Metad
 
 /**
  * <p>Enables notifications of specified events for a bucket. For more information about event
- *          notifications, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Event
- *             Notifications</a>.</p>
+ * notifications, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Event
+ *    Notifications</a>.</p>
  *
- *          <p>Using this API, you can replace an existing notification configuration. The
- *          configuration is an XML file that defines the event types that you want Amazon S3 to publish and
- *          the destination where you want Amazon S3 to publish an event notification when it detects an
- *          event of the specified type.</p>
+ * <p>Using this API, you can replace an existing notification configuration. The
+ * configuration is an XML file that defines the event types that you want Amazon S3 to publish and
+ * the destination where you want Amazon S3 to publish an event notification when it detects an
+ * event of the specified type.</p>
  *
- *          <p>By default, your bucket has no event notifications configured. That is, the notification
- *          configuration will be an empty <code>NotificationConfiguration</code>.</p>
+ * <p>By default, your bucket has no event notifications configured. That is, the notification
+ * configuration will be an empty <code>NotificationConfiguration</code>.</p>
  *
- *          <p>
- *             <code><NotificationConfiguration></code>
- *          </p>
- *          <p>
- *             <code></NotificationConfiguration></code>
- *          </p>
- *          <p>This action replaces the existing notification configuration with the configuration
- *          you include in the request body.</p>
+ * <p>
+ *    <code><NotificationConfiguration></code>
+ * </p>
+ * <p>
+ *    <code></NotificationConfiguration></code>
+ * </p>
+ * <p>This action replaces the existing notification configuration with the configuration
+ * you include in the request body.</p>
  *
- *          <p>After Amazon S3 receives this request, it first verifies that any Amazon Simple Notification
- *          Service (Amazon SNS) or Amazon Simple Queue Service (Amazon SQS) destination exists, and
- *          that the bucket owner has permission to publish to it by sending a test notification. In
- *          the case of Lambda destinations, Amazon S3 verifies that the Lambda function permissions
- *          grant Amazon S3 permission to invoke the function from the Amazon S3 bucket. For more information,
- *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Notifications for Amazon S3
- *             Events</a>.</p>
+ * <p>After Amazon S3 receives this request, it first verifies that any Amazon Simple Notification
+ * Service (Amazon SNS) or Amazon Simple Queue Service (Amazon SQS) destination exists, and
+ * that the bucket owner has permission to publish to it by sending a test notification. In
+ * the case of Lambda destinations, Amazon S3 verifies that the Lambda function permissions
+ * grant Amazon S3 permission to invoke the function from the Amazon S3 bucket. For more information,
+ * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Notifications for Amazon S3
+ *    Events</a>.</p>
  *
- *          <p>You can disable notifications by adding the empty NotificationConfiguration
- *          element.</p>
+ * <p>You can disable notifications by adding the empty NotificationConfiguration
+ * element.</p>
  *
- *          <p>By default, only the bucket owner can configure notifications on a bucket. However,
- *          bucket owners can use a bucket policy to grant permission to other users to set this
- *          configuration with <code>s3:PutBucketNotification</code> permission.</p>
+ * <p>By default, only the bucket owner can configure notifications on a bucket. However,
+ * bucket owners can use a bucket policy to grant permission to other users to set this
+ * configuration with <code>s3:PutBucketNotification</code> permission.</p>
  *
- *          <note>
- *             <p>The PUT notification is an atomic operation. For example, suppose your notification
- *             configuration includes SNS topic, SQS queue, and Lambda function configurations. When
- *             you send a PUT request with this configuration, Amazon S3 sends test messages to your SNS
- *             topic. If the message fails, the entire PUT action will fail, and Amazon S3 will not add
- *             the configuration to your bucket.</p>
- *          </note>
+ * <note>
+ *    <p>The PUT notification is an atomic operation. For example, suppose your notification
+ *    configuration includes SNS topic, SQS queue, and Lambda function configurations. When
+ *    you send a PUT request with this configuration, Amazon S3 sends test messages to your SNS
+ *    topic. If the message fails, the entire PUT action will fail, and Amazon S3 will not add
+ *    the configuration to your bucket.</p>
+ * </note>
  *
- *          <p>
- *             <b>Responses</b>
- *          </p>
- *          <p>If the configuration in the request body includes only one
- *             <code>TopicConfiguration</code> specifying only the
- *             <code>s3:ReducedRedundancyLostObject</code> event type, the response will also include
- *          the <code>x-amz-sns-test-message-id</code> header containing the message ID of the test
- *          notification sent to the topic.</p>
+ * <p>
+ *    <b>Responses</b>
+ * </p>
+ * <p>If the configuration in the request body includes only one
+ *    <code>TopicConfiguration</code> specifying only the
+ *    <code>s3:ReducedRedundancyLostObject</code> event type, the response will also include
+ * the <code>x-amz-sns-test-message-id</code> header containing the message ID of the test
+ * notification sent to the topic.</p>
  *
- *          <p>The following action is related to
- *          <code>PutBucketNotificationConfiguration</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketNotificationConfiguration.html">GetBucketNotificationConfiguration</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following action is related to
+ * <code>PutBucketNotificationConfiguration</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketNotificationConfiguration.html">GetBucketNotificationConfiguration</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketOwnershipControlsCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketOwnershipControlsCommand.ts
@@ -24,22 +24,22 @@ export interface PutBucketOwnershipControlsCommandOutput extends __MetadataBeare
 
 /**
  * <p>Creates or modifies <code>OwnershipControls</code> for an Amazon S3 bucket. To use this
- *          operation, you must have the <code>s3:PutBucketOwnershipControls</code> permission. For
- *          more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a Policy</a>. </p>
- *          <p>For information about Amazon S3 Object Ownership, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html">Using Object Ownership</a>. </p>
- *          <p>The following operations are related to <code>PutBucketOwnershipControls</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a>GetBucketOwnershipControls</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a>DeleteBucketOwnershipControls</a>
- *                </p>
- *             </li>
- *          </ul>
+ * operation, you must have the <code>s3:PutBucketOwnershipControls</code> permission. For
+ * more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a Policy</a>. </p>
+ * <p>For information about Amazon S3 Object Ownership, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html">Using Object Ownership</a>. </p>
+ * <p>The following operations are related to <code>PutBucketOwnershipControls</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a>GetBucketOwnershipControls</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a>DeleteBucketOwnershipControls</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketPolicyCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketPolicyCommand.ts
@@ -24,35 +24,35 @@ export interface PutBucketPolicyCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>Applies an Amazon S3 bucket policy to an Amazon S3 bucket. If you are using an identity other than
- *          the root user of the Amazon Web Services account that owns the bucket, the calling identity must have the
- *             <code>PutBucketPolicy</code> permissions on the specified bucket and belong to the
- *          bucket owner's account in order to use this operation.</p>
+ * the root user of the Amazon Web Services account that owns the bucket, the calling identity must have the
+ *    <code>PutBucketPolicy</code> permissions on the specified bucket and belong to the
+ * bucket owner's account in order to use this operation.</p>
  *
- *          <p>If you don't have <code>PutBucketPolicy</code> permissions, Amazon S3 returns a <code>403
- *             Access Denied</code> error. If you have the correct permissions, but you're not using an
- *          identity that belongs to the bucket owner's account, Amazon S3 returns a <code>405 Method Not
- *             Allowed</code> error.</p>
+ * <p>If you don't have <code>PutBucketPolicy</code> permissions, Amazon S3 returns a <code>403
+ *    Access Denied</code> error. If you have the correct permissions, but you're not using an
+ * identity that belongs to the bucket owner's account, Amazon S3 returns a <code>405 Method Not
+ *    Allowed</code> error.</p>
  *
- *          <important>
- *             <p> As a security precaution, the root user of the Amazon Web Services account that owns a bucket can
- *             always use this operation, even if the policy explicitly denies the root user the
- *             ability to perform this action. </p>
- *          </important>
- *          <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/example-bucket-policies.html">Bucket policy examples</a>.</p>
+ * <important>
+ *    <p> As a security precaution, the root user of the Amazon Web Services account that owns a bucket can
+ *    always use this operation, even if the policy explicitly denies the root user the
+ *    ability to perform this action. </p>
+ * </important>
+ * <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/example-bucket-policies.html">Bucket policy examples</a>.</p>
  *
- *          <p>The following operations are related to <code>PutBucketPolicy</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>PutBucketPolicy</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketReplicationCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketReplicationCommand.ts
@@ -24,75 +24,75 @@ export interface PutBucketReplicationCommandOutput extends __MetadataBearer {}
 
 /**
  * <p> Creates a replication configuration or replaces an existing one. For more information,
- *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html">Replication</a> in the <i>Amazon S3 User Guide</i>. </p>
+ * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html">Replication</a> in the <i>Amazon S3 User Guide</i>. </p>
  *
- *          <p>Specify the replication configuration in the request body. In the replication
- *          configuration, you provide the name of the destination bucket or buckets where you want
- *          Amazon S3 to replicate objects, the IAM role that Amazon S3 can assume to replicate objects on your
- *          behalf, and other relevant information.</p>
+ * <p>Specify the replication configuration in the request body. In the replication
+ * configuration, you provide the name of the destination bucket or buckets where you want
+ * Amazon S3 to replicate objects, the IAM role that Amazon S3 can assume to replicate objects on your
+ * behalf, and other relevant information.</p>
  *
  *
- *          <p>A replication configuration must include at least one rule, and can contain a maximum of
- *          1,000. Each rule identifies a subset of objects to replicate by filtering the objects in
- *          the source bucket. To choose additional subsets of objects to replicate, add a rule for
- *          each subset.</p>
+ * <p>A replication configuration must include at least one rule, and can contain a maximum of
+ * 1,000. Each rule identifies a subset of objects to replicate by filtering the objects in
+ * the source bucket. To choose additional subsets of objects to replicate, add a rule for
+ * each subset.</p>
  *
- *          <p>To specify a subset of the objects in the source bucket to apply a replication rule to,
- *          add the Filter element as a child of the Rule element. You can filter objects based on an
- *          object key prefix, one or more object tags, or both. When you add the Filter element in the
- *          configuration, you must also add the following elements:
- *             <code>DeleteMarkerReplication</code>, <code>Status</code>, and
- *          <code>Priority</code>.</p>
- *          <note>
- *             <p>If you are using an earlier version of the replication configuration, Amazon S3 handles
- *             replication of delete markers differently. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-backward-compat-considerations">Backward Compatibility</a>.</p>
- *          </note>
- *          <p>For information about enabling versioning on a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html">Using Versioning</a>.</p>
+ * <p>To specify a subset of the objects in the source bucket to apply a replication rule to,
+ * add the Filter element as a child of the Rule element. You can filter objects based on an
+ * object key prefix, one or more object tags, or both. When you add the Filter element in the
+ * configuration, you must also add the following elements:
+ *    <code>DeleteMarkerReplication</code>, <code>Status</code>, and
+ * <code>Priority</code>.</p>
+ * <note>
+ *    <p>If you are using an earlier version of the replication configuration, Amazon S3 handles
+ *    replication of delete markers differently. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-backward-compat-considerations">Backward Compatibility</a>.</p>
+ * </note>
+ * <p>For information about enabling versioning on a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html">Using Versioning</a>.</p>
  *
- *          <p>
- *             <b>Handling Replication of Encrypted Objects</b>
- *          </p>
- *          <p>By default, Amazon S3 doesn't replicate objects that are stored at rest using server-side
- *          encryption with CMKs stored in Amazon Web Services KMS. To replicate Amazon Web Services KMS-encrypted objects, add the
- *          following: <code>SourceSelectionCriteria</code>, <code>SseKmsEncryptedObjects</code>,
- *             <code>Status</code>, <code>EncryptionConfiguration</code>, and
- *             <code>ReplicaKmsKeyID</code>. For information about replication configuration, see
- *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-config-for-kms-objects.html">Replicating Objects
- *             Created with SSE Using CMKs stored in Amazon Web Services KMS</a>.</p>
+ * <p>
+ *    <b>Handling Replication of Encrypted Objects</b>
+ * </p>
+ * <p>By default, Amazon S3 doesn't replicate objects that are stored at rest using server-side
+ * encryption with CMKs stored in Amazon Web Services KMS. To replicate Amazon Web Services KMS-encrypted objects, add the
+ * following: <code>SourceSelectionCriteria</code>, <code>SseKmsEncryptedObjects</code>,
+ *    <code>Status</code>, <code>EncryptionConfiguration</code>, and
+ *    <code>ReplicaKmsKeyID</code>. For information about replication configuration, see
+ *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-config-for-kms-objects.html">Replicating Objects
+ *    Created with SSE Using CMKs stored in Amazon Web Services KMS</a>.</p>
  *
- *          <p>For information on <code>PutBucketReplication</code> errors, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ReplicationErrorCodeList">List of
- *             replication-related error codes</a>
- *          </p>
+ * <p>For information on <code>PutBucketReplication</code> errors, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ReplicationErrorCodeList">List of
+ *    replication-related error codes</a>
+ * </p>
  *
- *          <p>
- *             <b>Permissions</b>
- *          </p>
- *          <p>To create a <code>PutBucketReplication</code> request, you must have <code>s3:PutReplicationConfiguration</code>
- *          permissions for the bucket.
- *          </p>
- *          <p>By default, a resource owner, in this case the Amazon Web Services account that created the bucket, can
- *          perform this operation. The resource owner can also grant others permissions to perform the
- *          operation. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a Policy</a>
- *          and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your
- *             Amazon S3 Resources</a>.</p>
- *          <note>
- *             <p>To perform this operation, the user or role performing the action must have the
- *                <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html">iam:PassRole</a> permission.</p>
- *          </note>
+ * <p>
+ *    <b>Permissions</b>
+ * </p>
+ * <p>To create a <code>PutBucketReplication</code> request, you must have <code>s3:PutReplicationConfiguration</code>
+ * permissions for the bucket.
+ * </p>
+ * <p>By default, a resource owner, in this case the Amazon Web Services account that created the bucket, can
+ * perform this operation. The resource owner can also grant others permissions to perform the
+ * operation. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a Policy</a>
+ * and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your
+ *    Amazon S3 Resources</a>.</p>
+ * <note>
+ *    <p>To perform this operation, the user or role performing the action must have the
+ *       <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html">iam:PassRole</a> permission.</p>
+ * </note>
  *
- *          <p>The following operations are related to <code>PutBucketReplication</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketReplication.html">GetBucketReplication</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketReplication.html">DeleteBucketReplication</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>PutBucketReplication</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketReplication.html">GetBucketReplication</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketReplication.html">DeleteBucketReplication</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketRequestPaymentCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketRequestPaymentCommand.ts
@@ -24,24 +24,24 @@ export interface PutBucketRequestPaymentCommandOutput extends __MetadataBearer {
 
 /**
  * <p>Sets the request payment configuration for a bucket. By default, the bucket owner pays
- *          for downloads from the bucket. This configuration parameter enables the bucket owner (only)
- *          to specify that the person requesting the download will be charged for the download. For
- *          more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html">Requester Pays
- *             Buckets</a>.</p>
+ * for downloads from the bucket. This configuration parameter enables the bucket owner (only)
+ * to specify that the person requesting the download will be charged for the download. For
+ * more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html">Requester Pays
+ *    Buckets</a>.</p>
  *
- *          <p>The following operations are related to <code>PutBucketRequestPayment</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketRequestPayment.html">GetBucketRequestPayment</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>PutBucketRequestPayment</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketRequestPayment.html">GetBucketRequestPayment</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketTaggingCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketTaggingCommand.ts
@@ -24,84 +24,84 @@ export interface PutBucketTaggingCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>Sets the tags for a bucket.</p>
- *          <p>Use tags to organize your Amazon Web Services bill to reflect your own cost structure. To do this, sign
- *          up to get your Amazon Web Services account bill with tag key values included. Then, to see the cost of
- *          combined resources, organize your billing information according to resources with the same
- *          tag key values. For example, you can tag several resources with a specific application
- *          name, and then organize your billing information to see the total cost of that application
- *          across several services. For more information, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html">Cost Allocation
- *             and Tagging</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CostAllocTagging.html">Using Cost Allocation in Amazon S3 Bucket
- *                Tags</a>.</p>
+ * <p>Use tags to organize your Amazon Web Services bill to reflect your own cost structure. To do this, sign
+ * up to get your Amazon Web Services account bill with tag key values included. Then, to see the cost of
+ * combined resources, organize your billing information according to resources with the same
+ * tag key values. For example, you can tag several resources with a specific application
+ * name, and then organize your billing information to see the total cost of that application
+ * across several services. For more information, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html">Cost Allocation
+ *    and Tagging</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/CostAllocTagging.html">Using Cost Allocation in Amazon S3 Bucket
+ *       Tags</a>.</p>
  *
- *          <note>
- *             <p>
- *             When this operation sets the tags for a bucket, it will overwrite any current tags the
- *             bucket already has. You cannot use this operation to add tags to an existing list of tags.</p>
- *          </note>
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:PutBucketTagging</code> action. The bucket owner has this permission by default
- *          and can grant this permission to others. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a>.</p>
+ * <note>
+ *    <p>
+ *    When this operation sets the tags for a bucket, it will overwrite any current tags the
+ *    bucket already has. You cannot use this operation to add tags to an existing list of tags.</p>
+ * </note>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:PutBucketTagging</code> action. The bucket owner has this permission by default
+ * and can grant this permission to others. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a>.</p>
  *
- *          <p>
- *             <code>PutBucketTagging</code> has the following special errors:</p>
- *          <ul>
- *             <li>
- *                <p>Error code: <code>InvalidTagError</code>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>Description: The tag provided was not a valid tag. This error can occur if
- *                      the tag did not pass input validation. For information about tag restrictions,
- *                      see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html">User-Defined Tag Restrictions</a> and <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/aws-tag-restrictions.html">Amazon Web Services-Generated Cost Allocation Tag Restrictions</a>.</p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <p>Error code: <code>MalformedXMLError</code>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>Description: The XML provided does not match the schema.</p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <p>Error code: <code>OperationAbortedError </code>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>Description: A conflicting conditional action is currently in progress
- *                      against this resource. Please try again.</p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <p>Error code: <code>InternalError</code>
- *                </p>
- *                <ul>
- *                   <li>
- *                      <p>Description: The service was unable to apply the provided tag to the
- *                      bucket.</p>
- *                   </li>
- *                </ul>
- *             </li>
- *          </ul>
+ * <p>
+ *    <code>PutBucketTagging</code> has the following special errors:</p>
+ * <ul>
+ *    <li>
+ *       <p>Error code: <code>InvalidTagError</code>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>Description: The tag provided was not a valid tag. This error can occur if
+ *             the tag did not pass input validation. For information about tag restrictions,
+ *             see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html">User-Defined Tag Restrictions</a> and <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/aws-tag-restrictions.html">Amazon Web Services-Generated Cost Allocation Tag Restrictions</a>.</p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <p>Error code: <code>MalformedXMLError</code>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>Description: The XML provided does not match the schema.</p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <p>Error code: <code>OperationAbortedError </code>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>Description: A conflicting conditional action is currently in progress
+ *             against this resource. Please try again.</p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <p>Error code: <code>InternalError</code>
+ *       </p>
+ *       <ul>
+ *          <li>
+ *             <p>Description: The service was unable to apply the provided tag to the
+ *             bucket.</p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ * </ul>
  *
  *
- *          <p>The following operations are related to <code>PutBucketTagging</code>:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html">GetBucketTagging</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketTagging.html">DeleteBucketTagging</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>The following operations are related to <code>PutBucketTagging</code>:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html">GetBucketTagging</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketTagging.html">DeleteBucketTagging</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketVersioningCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketVersioningCommand.ts
@@ -24,54 +24,54 @@ export interface PutBucketVersioningCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>Sets the versioning state of an existing bucket. To set the versioning state, you must
- *          be the bucket owner.</p>
- *          <p>You can set the versioning state with one of the following values:</p>
+ * be the bucket owner.</p>
+ * <p>You can set the versioning state with one of the following values:</p>
  *
- *          <p>
- *             <b>Enabled</b>—Enables versioning for the objects in the
- *          bucket. All objects added to the bucket receive a unique version ID.</p>
+ * <p>
+ *    <b>Enabled</b>—Enables versioning for the objects in the
+ * bucket. All objects added to the bucket receive a unique version ID.</p>
  *
- *          <p>
- *             <b>Suspended</b>—Disables versioning for the objects in the
- *          bucket. All objects added to the bucket receive the version ID null.</p>
+ * <p>
+ *    <b>Suspended</b>—Disables versioning for the objects in the
+ * bucket. All objects added to the bucket receive the version ID null.</p>
  *
- *          <p>If the versioning state has never been set on a bucket, it has no versioning state; a
- *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html">GetBucketVersioning</a> request does not return a versioning state value.</p>
+ * <p>If the versioning state has never been set on a bucket, it has no versioning state; a
+ *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html">GetBucketVersioning</a> request does not return a versioning state value.</p>
  *
- *          <p>If the bucket owner enables MFA Delete in the bucket versioning configuration, the
- *          bucket owner must include the <code>x-amz-mfa request</code> header and the
- *             <code>Status</code> and the <code>MfaDelete</code> request elements in a request to set
- *          the versioning state of the bucket.</p>
+ * <p>If the bucket owner enables MFA Delete in the bucket versioning configuration, the
+ * bucket owner must include the <code>x-amz-mfa request</code> header and the
+ *    <code>Status</code> and the <code>MfaDelete</code> request elements in a request to set
+ * the versioning state of the bucket.</p>
  *
- *          <important>
- *             <p>If you have an object expiration lifecycle policy in your non-versioned bucket and
- *             you want to maintain the same permanent delete behavior when you enable versioning, you
- *             must add a noncurrent expiration policy. The noncurrent expiration lifecycle policy will
- *             manage the deletes of the noncurrent object versions in the version-enabled bucket. (A
- *             version-enabled bucket maintains one current and zero or more noncurrent object
- *             versions.) For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html#lifecycle-and-other-bucket-config">Lifecycle and Versioning</a>.</p>
- *          </important>
+ * <important>
+ *    <p>If you have an object expiration lifecycle policy in your non-versioned bucket and
+ *    you want to maintain the same permanent delete behavior when you enable versioning, you
+ *    must add a noncurrent expiration policy. The noncurrent expiration lifecycle policy will
+ *    manage the deletes of the noncurrent object versions in the version-enabled bucket. (A
+ *    version-enabled bucket maintains one current and zero or more noncurrent object
+ *    versions.) For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html#lifecycle-and-other-bucket-config">Lifecycle and Versioning</a>.</p>
+ * </important>
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html">GetBucketVersioning</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html">CreateBucket</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucket.html">DeleteBucket</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html">GetBucketVersioning</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutBucketWebsiteCommand.ts
+++ b/clients/client-s3/src/commands/PutBucketWebsiteCommand.ts
@@ -24,131 +24,131 @@ export interface PutBucketWebsiteCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>Sets the configuration of the website that is specified in the <code>website</code>
- *          subresource. To configure a bucket as a website, you can add this subresource on the bucket
- *          with website configuration information such as the file name of the index document and any
- *          redirect rules. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html">Hosting Websites on Amazon S3</a>.</p>
+ * subresource. To configure a bucket as a website, you can add this subresource on the bucket
+ * with website configuration information such as the file name of the index document and any
+ * redirect rules. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html">Hosting Websites on Amazon S3</a>.</p>
  *
- *          <p>This PUT action requires the <code>S3:PutBucketWebsite</code> permission. By default,
- *          only the bucket owner can configure the website attached to a bucket; however, bucket
- *          owners can allow other users to set the website configuration by writing a bucket policy
- *          that grants them the <code>S3:PutBucketWebsite</code> permission.</p>
+ * <p>This PUT action requires the <code>S3:PutBucketWebsite</code> permission. By default,
+ * only the bucket owner can configure the website attached to a bucket; however, bucket
+ * owners can allow other users to set the website configuration by writing a bucket policy
+ * that grants them the <code>S3:PutBucketWebsite</code> permission.</p>
  *
- *          <p>To redirect all website requests sent to the bucket's website endpoint, you add a
- *          website configuration with the following elements. Because all requests are sent to another
- *          website, you don't need to provide index document name for the bucket.</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <code>WebsiteConfiguration</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>RedirectAllRequestsTo</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>HostName</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>Protocol</code>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>To redirect all website requests sent to the bucket's website endpoint, you add a
+ * website configuration with the following elements. Because all requests are sent to another
+ * website, you don't need to provide index document name for the bucket.</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <code>WebsiteConfiguration</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>RedirectAllRequestsTo</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>HostName</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>Protocol</code>
+ *       </p>
+ *    </li>
+ * </ul>
  *
- *          <p>If you want granular control over redirects, you can use the following elements to add
- *          routing rules that describe conditions for redirecting requests and information about the
- *          redirect destination. In this case, the website configuration must provide an index
- *          document for the bucket, because some requests might not be redirected. </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <code>WebsiteConfiguration</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>IndexDocument</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>Suffix</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>ErrorDocument</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>Key</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>RoutingRules</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>RoutingRule</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>Condition</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>HttpErrorCodeReturnedEquals</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>KeyPrefixEquals</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>Redirect</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>Protocol</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>HostName</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>ReplaceKeyPrefixWith</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>ReplaceKeyWith</code>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>HttpRedirectCode</code>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>If you want granular control over redirects, you can use the following elements to add
+ * routing rules that describe conditions for redirecting requests and information about the
+ * redirect destination. In this case, the website configuration must provide an index
+ * document for the bucket, because some requests might not be redirected. </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <code>WebsiteConfiguration</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>IndexDocument</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>Suffix</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>ErrorDocument</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>Key</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>RoutingRules</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>RoutingRule</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>Condition</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>HttpErrorCodeReturnedEquals</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>KeyPrefixEquals</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>Redirect</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>Protocol</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>HostName</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>ReplaceKeyPrefixWith</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>ReplaceKeyWith</code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>HttpRedirectCode</code>
+ *       </p>
+ *    </li>
+ * </ul>
  *
- *          <p>Amazon S3 has a limitation of 50 routing rules per website configuration. If you require more
- *          than 50 routing rules, you can use object redirect. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html">Configuring an
- *             Object Redirect</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * <p>Amazon S3 has a limitation of 50 routing rules per website configuration. If you require more
+ * than 50 routing rules, you can use object redirect. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html">Configuring an
+ *    Object Redirect</a> in the <i>Amazon S3 User Guide</i>.</p>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutObjectAclCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectAclCommand.ts
@@ -24,182 +24,182 @@ export interface PutObjectAclCommandOutput extends PutObjectAclOutput, __Metadat
 
 /**
  * <p>Uses the <code>acl</code> subresource to set the access control list (ACL) permissions
- *          for a new or existing object in an S3 bucket. You must have <code>WRITE_ACP</code>
- *          permission to set the ACL of an object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#permissions">What
- *             permissions can I grant?</a> in the <i>Amazon S3 User Guide</i>.</p>
- *          <p>This action is not supported by Amazon S3 on Outposts.</p>
- *          <p>Depending on your application needs, you can choose to set
- *          the ACL on an object using either the request body or the headers. For example, if you have
- *          an existing application that updates a bucket ACL using the request body, you can continue
- *          to use that approach. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL) Overview</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * for a new or existing object in an S3 bucket. You must have <code>WRITE_ACP</code>
+ * permission to set the ACL of an object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#permissions">What
+ *    permissions can I grant?</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * <p>This action is not supported by Amazon S3 on Outposts.</p>
+ * <p>Depending on your application needs, you can choose to set
+ * the ACL on an object using either the request body or the headers. For example, if you have
+ * an existing application that updates a bucket ACL using the request body, you can continue
+ * to use that approach. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL) Overview</a> in the <i>Amazon S3 User Guide</i>.</p>
  *
  *
  *
- *          <p>
- *             <b>Access Permissions</b>
- *          </p>
- *          <p>You can set access permissions using one of the following methods:</p>
- *          <ul>
- *             <li>
- *                <p>Specify a canned ACL with the <code>x-amz-acl</code> request header. Amazon S3 supports
- *                a set of predefined ACLs, known as canned ACLs. Each canned ACL has a predefined set
- *                of grantees and permissions. Specify the canned ACL name as the value of
- *                   <code>x-amz-ac</code>l. If you use this header, you cannot use other access
- *                control-specific headers in your request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
- *             </li>
- *             <li>
- *                <p>Specify access permissions explicitly with the <code>x-amz-grant-read</code>,
- *                   <code>x-amz-grant-read-acp</code>, <code>x-amz-grant-write-acp</code>, and
- *                   <code>x-amz-grant-full-control</code> headers. When using these headers, you
- *                specify explicit access permissions and grantees (Amazon Web Services accounts or Amazon S3 groups) who
- *                will receive the permission. If you use these ACL-specific headers, you cannot use
- *                   <code>x-amz-acl</code> header to set a canned ACL. These parameters map to the set
- *                of permissions that Amazon S3 supports in an ACL. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL)
- *                Overview</a>.</p>
+ * <p>
+ *    <b>Access Permissions</b>
+ * </p>
+ * <p>You can set access permissions using one of the following methods:</p>
+ * <ul>
+ *    <li>
+ *       <p>Specify a canned ACL with the <code>x-amz-acl</code> request header. Amazon S3 supports
+ *       a set of predefined ACLs, known as canned ACLs. Each canned ACL has a predefined set
+ *       of grantees and permissions. Specify the canned ACL name as the value of
+ *          <code>x-amz-ac</code>l. If you use this header, you cannot use other access
+ *       control-specific headers in your request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a>.</p>
+ *    </li>
+ *    <li>
+ *       <p>Specify access permissions explicitly with the <code>x-amz-grant-read</code>,
+ *          <code>x-amz-grant-read-acp</code>, <code>x-amz-grant-write-acp</code>, and
+ *          <code>x-amz-grant-full-control</code> headers. When using these headers, you
+ *       specify explicit access permissions and grantees (Amazon Web Services accounts or Amazon S3 groups) who
+ *       will receive the permission. If you use these ACL-specific headers, you cannot use
+ *          <code>x-amz-acl</code> header to set a canned ACL. These parameters map to the set
+ *       of permissions that Amazon S3 supports in an ACL. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List (ACL)
+ *       Overview</a>.</p>
  *
- *                <p>You specify each grantee as a type=value pair, where the type is one of the
- *                following:</p>
+ *       <p>You specify each grantee as a type=value pair, where the type is one of the
+ *       following:</p>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <code>id</code> – if the value specified is the canonical user ID of an Amazon Web Services account</p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <code>uri</code> – if you are granting permissions to a predefined
+ *             group</p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <code>emailAddress</code> – if the value specified is the email address of
+ *             an Amazon Web Services account</p>
+ *             <note>
+ *                <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
  *                <ul>
  *                   <li>
- *                      <p>
- *                         <code>id</code> – if the value specified is the canonical user ID of an Amazon Web Services account</p>
+ *                      <p>US East (N. Virginia)</p>
  *                   </li>
  *                   <li>
- *                      <p>
- *                         <code>uri</code> – if you are granting permissions to a predefined
- *                      group</p>
+ *                      <p>US West (N. California)</p>
  *                   </li>
  *                   <li>
- *                      <p>
- *                         <code>emailAddress</code> – if the value specified is the email address of
- *                      an Amazon Web Services account</p>
- *                      <note>
- *                         <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
- *                         <ul>
- *                            <li>
- *                               <p>US East (N. Virginia)</p>
- *                            </li>
- *                            <li>
- *                               <p>US West (N. California)</p>
- *                            </li>
- *                            <li>
- *                               <p> US West (Oregon)</p>
- *                            </li>
- *                            <li>
- *                               <p> Asia Pacific (Singapore)</p>
- *                            </li>
- *                            <li>
- *                               <p>Asia Pacific (Sydney)</p>
- *                            </li>
- *                            <li>
- *                               <p>Asia Pacific (Tokyo)</p>
- *                            </li>
- *                            <li>
- *                               <p>Europe (Ireland)</p>
- *                            </li>
- *                            <li>
- *                               <p>South America (São Paulo)</p>
- *                            </li>
- *                         </ul>
- *                         <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
- *                      </note>
+ *                      <p> US West (Oregon)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p> Asia Pacific (Singapore)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p>Asia Pacific (Sydney)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p>Asia Pacific (Tokyo)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p>Europe (Ireland)</p>
+ *                   </li>
+ *                   <li>
+ *                      <p>South America (São Paulo)</p>
  *                   </li>
  *                </ul>
- *                <p>For example, the following <code>x-amz-grant-read</code> header grants list
- *                objects permission to the two Amazon Web Services accounts identified by their email
- *                addresses.</p>
- *                <p>
- *                   <code>x-amz-grant-read: emailAddress="xyz@amazon.com",
- *                   emailAddress="abc@amazon.com" </code>
- *                </p>
+ *                <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
+ *             </note>
+ *          </li>
+ *       </ul>
+ *       <p>For example, the following <code>x-amz-grant-read</code> header grants list
+ *       objects permission to the two Amazon Web Services accounts identified by their email
+ *       addresses.</p>
+ *       <p>
+ *          <code>x-amz-grant-read: emailAddress="xyz@amazon.com",
+ *          emailAddress="abc@amazon.com" </code>
+ *       </p>
  *
- *             </li>
- *          </ul>
- *          <p>You can use either a canned ACL or specify access permissions explicitly. You cannot do
- *          both.</p>
- *          <p>
- *             <b>Grantee Values</b>
- *          </p>
- *          <p>You can specify the person (grantee) to whom you're assigning access rights (using
- *          request elements) in the following ways:</p>
+ *    </li>
+ * </ul>
+ * <p>You can use either a canned ACL or specify access permissions explicitly. You cannot do
+ * both.</p>
+ * <p>
+ *    <b>Grantee Values</b>
+ * </p>
+ * <p>You can specify the person (grantee) to whom you're assigning access rights (using
+ * request elements) in the following ways:</p>
+ * <ul>
+ *    <li>
+ *       <p>By the person's ID:</p>
+ *       <p>
+ *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ *          xsi:type="CanonicalUser"><ID><>ID<></ID><DisplayName><>GranteesEmail<></DisplayName>
+ *          </Grantee></code>
+ *       </p>
+ *       <p>DisplayName is optional and ignored in the request.</p>
+ *    </li>
+ *    <li>
+ *       <p>By URI:</p>
+ *       <p>
+ *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ *          xsi:type="Group"><URI><>http://acs.amazonaws.com/groups/global/AuthenticatedUsers<></URI></Grantee></code>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>By Email address:</p>
+ *       <p>
+ *          <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ *          xsi:type="AmazonCustomerByEmail"><EmailAddress><>Grantees@email.com<></EmailAddress>lt;/Grantee></code>
+ *       </p>
+ *       <p>The grantee is resolved to the CanonicalUser and, in a response to a GET Object
+ *       acl request, appears as the CanonicalUser.</p>
+ *       <note>
+ *          <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
  *          <ul>
  *             <li>
- *                <p>By the person's ID:</p>
- *                <p>
- *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- *                   xsi:type="CanonicalUser"><ID><>ID<></ID><DisplayName><>GranteesEmail<></DisplayName>
- *                   </Grantee></code>
- *                </p>
- *                <p>DisplayName is optional and ignored in the request.</p>
+ *                <p>US East (N. Virginia)</p>
  *             </li>
  *             <li>
- *                <p>By URI:</p>
- *                <p>
- *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- *                   xsi:type="Group"><URI><>http://acs.amazonaws.com/groups/global/AuthenticatedUsers<></URI></Grantee></code>
- *                </p>
+ *                <p>US West (N. California)</p>
  *             </li>
  *             <li>
- *                <p>By Email address:</p>
- *                <p>
- *                   <code><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- *                   xsi:type="AmazonCustomerByEmail"><EmailAddress><>Grantees@email.com<></EmailAddress>lt;/Grantee></code>
- *                </p>
- *                <p>The grantee is resolved to the CanonicalUser and, in a response to a GET Object
- *                acl request, appears as the CanonicalUser.</p>
- *                <note>
- *                   <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
- *                   <ul>
- *                      <li>
- *                         <p>US East (N. Virginia)</p>
- *                      </li>
- *                      <li>
- *                         <p>US West (N. California)</p>
- *                      </li>
- *                      <li>
- *                         <p> US West (Oregon)</p>
- *                      </li>
- *                      <li>
- *                         <p> Asia Pacific (Singapore)</p>
- *                      </li>
- *                      <li>
- *                         <p>Asia Pacific (Sydney)</p>
- *                      </li>
- *                      <li>
- *                         <p>Asia Pacific (Tokyo)</p>
- *                      </li>
- *                      <li>
- *                         <p>Europe (Ireland)</p>
- *                      </li>
- *                      <li>
- *                         <p>South America (São Paulo)</p>
- *                      </li>
- *                   </ul>
- *                   <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
- *                </note>
+ *                <p> US West (Oregon)</p>
+ *             </li>
+ *             <li>
+ *                <p> Asia Pacific (Singapore)</p>
+ *             </li>
+ *             <li>
+ *                <p>Asia Pacific (Sydney)</p>
+ *             </li>
+ *             <li>
+ *                <p>Asia Pacific (Tokyo)</p>
+ *             </li>
+ *             <li>
+ *                <p>Europe (Ireland)</p>
+ *             </li>
+ *             <li>
+ *                <p>South America (São Paulo)</p>
  *             </li>
  *          </ul>
- *          <p>
- *             <b>Versioning</b>
- *          </p>
- *          <p>The ACL of an object is set at the object version level. By default, PUT sets the ACL of
- *          the current version of an object. To set the ACL of a different version, use the
- *             <code>versionId</code> subresource.</p>
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html">CopyObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
- *                </p>
- *             </li>
- *          </ul>
+ *          <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
+ *       </note>
+ *    </li>
+ * </ul>
+ * <p>
+ *    <b>Versioning</b>
+ * </p>
+ * <p>The ACL of an object is set at the object version level. By default, PUT sets the ACL of
+ * the current version of an object. To set the ACL of a different version, use the
+ *    <code>versionId</code> subresource.</p>
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html">CopyObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutObjectCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectCommand.ts
@@ -30,100 +30,100 @@ export interface PutObjectCommandOutput extends PutObjectOutput, __MetadataBeare
 
 /**
  * <p>Adds an object to a bucket. You must have WRITE permissions on a bucket to add an object
- *          to it.</p>
+ * to it.</p>
  *
  *
- *          <p>Amazon S3 never adds partial objects; if you receive a success response, Amazon S3 added the
- *          entire object to the bucket.</p>
+ * <p>Amazon S3 never adds partial objects; if you receive a success response, Amazon S3 added the
+ * entire object to the bucket.</p>
  *
- *          <p>Amazon S3 is a distributed system. If it receives multiple write requests for the same object
- *          simultaneously, it overwrites all but the last object written. Amazon S3 does not provide object
- *          locking; if you need this, make sure to build it into your application layer or use
- *          versioning instead.</p>
+ * <p>Amazon S3 is a distributed system. If it receives multiple write requests for the same object
+ * simultaneously, it overwrites all but the last object written. Amazon S3 does not provide object
+ * locking; if you need this, make sure to build it into your application layer or use
+ * versioning instead.</p>
  *
- *          <p>To ensure that data is not corrupted traversing the network, use the
- *             <code>Content-MD5</code> header. When you use this header, Amazon S3 checks the object
- *          against the provided MD5 value and, if they do not match, returns an error. Additionally,
- *          you can calculate the MD5 while putting an object to Amazon S3 and compare the returned ETag to
- *          the calculated MD5 value.</p>
- *          <note>
- *             <ul>
- *                <li>
- *                   <p>To successfully complete the <code>PutObject</code> request, you must have the
- *                <code>s3:PutObject</code> in your IAM permissions.</p>
- *                </li>
- *                <li>
- *                   <p>To successfully change the objects acl of your <code>PutObject</code> request,
- *                you must have the <code>s3:PutObjectAcl</code> in your IAM permissions.</p>
- *                </li>
- *                <li>
- *                   <p> The <code>Content-MD5</code> header is required for any request to upload an object
- *                   with a retention period configured using Amazon S3 Object Lock. For more information about
- *                   Amazon S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html">Amazon S3 Object Lock Overview</a>
- *                   in the <i>Amazon S3 User Guide</i>. </p>
- *                </li>
- *             </ul>
- *          </note>
+ * <p>To ensure that data is not corrupted traversing the network, use the
+ *    <code>Content-MD5</code> header. When you use this header, Amazon S3 checks the object
+ * against the provided MD5 value and, if they do not match, returns an error. Additionally,
+ * you can calculate the MD5 while putting an object to Amazon S3 and compare the returned ETag to
+ * the calculated MD5 value.</p>
+ * <note>
+ *    <ul>
+ *       <li>
+ *          <p>To successfully complete the <code>PutObject</code> request, you must have the
+ *       <code>s3:PutObject</code> in your IAM permissions.</p>
+ *       </li>
+ *       <li>
+ *          <p>To successfully change the objects acl of your <code>PutObject</code> request,
+ *       you must have the <code>s3:PutObjectAcl</code> in your IAM permissions.</p>
+ *       </li>
+ *       <li>
+ *          <p> The <code>Content-MD5</code> header is required for any request to upload an object
+ *          with a retention period configured using Amazon S3 Object Lock. For more information about
+ *          Amazon S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html">Amazon S3 Object Lock Overview</a>
+ *          in the <i>Amazon S3 User Guide</i>. </p>
+ *       </li>
+ *    </ul>
+ * </note>
  *
- *          <p>
- *             <b>Server-side Encryption</b>
- *          </p>
- *          <p>You can optionally request server-side encryption. With server-side encryption, Amazon S3 encrypts
- *          your data as it writes it to disks in its data centers and decrypts the data
- *          when you access it. You have the option to provide your own encryption key or use Amazon Web Services
- *          managed encryption keys (SSE-S3 or SSE-KMS). For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html">Using Server-Side
- *             Encryption</a>.</p>
- *          <p>If you request server-side encryption using Amazon Web Services Key Management Service (SSE-KMS), you can enable
- *          an S3 Bucket Key at the object-level. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the
- *          <i>Amazon S3 User Guide</i>.</p>
- *          <p>
- *             <b>Access Control List (ACL)-Specific Request
- *          Headers</b>
- *          </p>
- *          <p>You can use headers to grant ACL- based permissions. By default, all objects are
- *          private. Only the owner has full access control. When adding a new object, you can grant
- *          permissions to individual Amazon Web Services accounts or to predefined groups defined by Amazon S3. These
- *          permissions are then added to the ACL on the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List
- *             (ACL) Overview</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-using-rest-api.html">Managing ACLs Using the REST
- *             API</a>. </p>
+ * <p>
+ *    <b>Server-side Encryption</b>
+ * </p>
+ * <p>You can optionally request server-side encryption. With server-side encryption, Amazon S3 encrypts
+ * your data as it writes it to disks in its data centers and decrypts the data
+ * when you access it. You have the option to provide your own encryption key or use Amazon Web Services
+ * managed encryption keys (SSE-S3 or SSE-KMS). For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html">Using Server-Side
+ *    Encryption</a>.</p>
+ * <p>If you request server-side encryption using Amazon Web Services Key Management Service (SSE-KMS), you can enable
+ * an S3 Bucket Key at the object-level. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the
+ * <i>Amazon S3 User Guide</i>.</p>
+ * <p>
+ *    <b>Access Control List (ACL)-Specific Request
+ * Headers</b>
+ * </p>
+ * <p>You can use headers to grant ACL- based permissions. By default, all objects are
+ * private. Only the owner has full access control. When adding a new object, you can grant
+ * permissions to individual Amazon Web Services accounts or to predefined groups defined by Amazon S3. These
+ * permissions are then added to the ACL on the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html">Access Control List
+ *    (ACL) Overview</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-using-rest-api.html">Managing ACLs Using the REST
+ *    API</a>. </p>
  *
- *          <p>
- *             <b>Storage Class Options</b>
- *          </p>
- *          <p>By default, Amazon S3 uses the STANDARD Storage Class to store newly created objects. The
- *          STANDARD storage class provides high durability and high availability. Depending on
- *          performance needs, you can specify a different Storage Class. Amazon S3 on Outposts only uses
- *          the OUTPOSTS Storage Class. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a> in the
- *          <i>Amazon S3 User Guide</i>.</p>
- *
- *
- *          <p>
- *             <b>Versioning</b>
- *          </p>
- *          <p>If you enable versioning for a bucket, Amazon S3 automatically generates a unique version ID
- *          for the object being stored. Amazon S3 returns this ID in the response. When you enable
- *          versioning for a bucket, if Amazon S3 receives multiple write requests for the same object
- *          simultaneously, it stores all of the objects.</p>
- *          <p>For more information about versioning, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/AddingObjectstoVersioningEnabledBuckets.html">Adding Objects to
- *             Versioning Enabled Buckets</a>. For information about returning the versioning state
- *          of a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html">GetBucketVersioning</a>. </p>
+ * <p>
+ *    <b>Storage Class Options</b>
+ * </p>
+ * <p>By default, Amazon S3 uses the STANDARD Storage Class to store newly created objects. The
+ * STANDARD storage class provides high durability and high availability. Depending on
+ * performance needs, you can specify a different Storage Class. Amazon S3 on Outposts only uses
+ * the OUTPOSTS Storage Class. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a> in the
+ * <i>Amazon S3 User Guide</i>.</p>
  *
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html">CopyObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>
+ *    <b>Versioning</b>
+ * </p>
+ * <p>If you enable versioning for a bucket, Amazon S3 automatically generates a unique version ID
+ * for the object being stored. Amazon S3 returns this ID in the response. When you enable
+ * versioning for a bucket, if Amazon S3 receives multiple write requests for the same object
+ * simultaneously, it stores all of the objects.</p>
+ * <p>For more information about versioning, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/AddingObjectstoVersioningEnabledBuckets.html">Adding Objects to
+ *    Versioning Enabled Buckets</a>. For information about returning the versioning state
+ * of a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html">GetBucketVersioning</a>. </p>
+ *
+ *
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html">CopyObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html">DeleteObject</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutObjectLegalHoldCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectLegalHoldCommand.ts
@@ -24,9 +24,9 @@ export interface PutObjectLegalHoldCommandOutput extends PutObjectLegalHoldOutpu
 
 /**
  * <p>Applies a Legal Hold configuration to the specified object. For more information, see
- *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking
- *             Objects</a>.</p>
- *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+ *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking
+ *    Objects</a>.</p>
+ * <p>This action is not supported by Amazon S3 on Outposts.</p>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutObjectLockConfigurationCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectLockConfigurationCommand.ts
@@ -24,26 +24,26 @@ export interface PutObjectLockConfigurationCommandOutput extends PutObjectLockCo
 
 /**
  * <p>Places an Object Lock configuration on the specified bucket. The rule specified in the
- *          Object Lock configuration will be applied by default to every new object placed in the
- *          specified bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking Objects</a>.
+ * Object Lock configuration will be applied by default to every new object placed in the
+ * specified bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking Objects</a>.
  *       </p>
- *          <note>
- *             <ul>
- *                <li>
- *                   <p>The <code>DefaultRetention</code> settings require both a mode and a
- *                period.</p>
- *                </li>
- *                <li>
- *                   <p>The <code>DefaultRetention</code> period can be either <code>Days</code>
- *                or <code>Years</code> but you must select one. You cannot specify <code>Days</code>
- *                and <code>Years</code> at the same time.</p>
- *                </li>
- *                <li>
- *                   <p>You can only enable Object Lock for new buckets. If you want to turn on
- *                Object Lock for an existing bucket, contact Amazon Web Services Support.</p>
- *                </li>
- *             </ul>
- *          </note>
+ * <note>
+ *    <ul>
+ *       <li>
+ *          <p>The <code>DefaultRetention</code> settings require both a mode and a
+ *       period.</p>
+ *       </li>
+ *       <li>
+ *          <p>The <code>DefaultRetention</code> period can be either <code>Days</code>
+ *       or <code>Years</code> but you must select one. You cannot specify <code>Days</code>
+ *       and <code>Years</code> at the same time.</p>
+ *       </li>
+ *       <li>
+ *          <p>You can only enable Object Lock for new buckets. If you want to turn on
+ *       Object Lock for an existing bucket, contact Amazon Web Services Support.</p>
+ *       </li>
+ *    </ul>
+ * </note>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutObjectRetentionCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectRetentionCommand.ts
@@ -24,18 +24,18 @@ export interface PutObjectRetentionCommandOutput extends PutObjectRetentionOutpu
 
 /**
  * <p>Places an Object Retention configuration on an object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Locking Objects</a>.
- *           Users or accounts require the <code>s3:PutObjectRetention</code> permission in order to place
- *           an Object Retention configuration on objects. Bypassing a Governance Retention configuration
- *           requires the <code>s3:BypassGovernanceRetention</code> permission.
- *          </p>
- *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+ *  Users or accounts require the <code>s3:PutObjectRetention</code> permission in order to place
+ *  an Object Retention configuration on objects. Bypassing a Governance Retention configuration
+ *  requires the <code>s3:BypassGovernanceRetention</code> permission.
+ * </p>
+ * <p>This action is not supported by Amazon S3 on Outposts.</p>
  *
- *          <p>
- *             <b>Permissions</b>
- *          </p>
- *          <p>When the Object Lock retention mode is set to compliance, you need <code>s3:PutObjectRetention</code> and
- *          <code>s3:BypassGovernanceRetention</code> permissions. For other requests to <code>PutObjectRetention</code>,
- *          only <code>s3:PutObjectRetention</code> permissions are required.</p>
+ * <p>
+ *    <b>Permissions</b>
+ * </p>
+ * <p>When the Object Lock retention mode is set to compliance, you need <code>s3:PutObjectRetention</code> and
+ * <code>s3:BypassGovernanceRetention</code> permissions. For other requests to <code>PutObjectRetention</code>,
+ * only <code>s3:PutObjectRetention</code> permissions are required.</p>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutObjectTaggingCommand.ts
+++ b/clients/client-s3/src/commands/PutObjectTaggingCommand.ts
@@ -24,109 +24,109 @@ export interface PutObjectTaggingCommandOutput extends PutObjectTaggingOutput, _
 
 /**
  * <p>Sets the supplied tag-set to an object that already exists in a bucket.</p>
- *          <p>A tag is a key-value pair. You can associate tags with an object by sending a PUT
- *          request against the tagging subresource that is associated with the object. You can
- *          retrieve tags by sending a GET request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a>.</p>
+ * <p>A tag is a key-value pair. You can associate tags with an object by sending a PUT
+ * request against the tagging subresource that is associated with the object. You can
+ * retrieve tags by sending a GET request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a>.</p>
  *
- *          <p>For tagging-related restrictions related to characters and encodings, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html">Tag
- *             Restrictions</a>. Note that Amazon S3 limits the maximum number of tags to 10 tags per
- *          object.</p>
+ * <p>For tagging-related restrictions related to characters and encodings, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html">Tag
+ *    Restrictions</a>. Note that Amazon S3 limits the maximum number of tags to 10 tags per
+ * object.</p>
  *
- *          <p>To use this operation, you must have permission to perform the
- *             <code>s3:PutObjectTagging</code> action. By default, the bucket owner has this
- *          permission and can grant this permission to others.</p>
+ * <p>To use this operation, you must have permission to perform the
+ *    <code>s3:PutObjectTagging</code> action. By default, the bucket owner has this
+ * permission and can grant this permission to others.</p>
  *
- *          <p>To put tags of any other version, use the <code>versionId</code> query parameter. You
- *          also need permission for the <code>s3:PutObjectVersionTagging</code> action.</p>
+ * <p>To put tags of any other version, use the <code>versionId</code> query parameter. You
+ * also need permission for the <code>s3:PutObjectVersionTagging</code> action.</p>
  *
- *          <p>For information about the Amazon S3 object tagging feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html">Object Tagging</a>.</p>
- *
- *
- *          <p class="title">
- *             <b>Special Errors</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code: InvalidTagError </i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause: The tag provided was not a valid tag. This error can occur
- *                         if the tag did not pass input validation. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html">Object Tagging</a>.</i>
- *                      </p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code: MalformedXMLError </i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause: The XML provided does not match the schema.</i>
- *                      </p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code: OperationAbortedError </i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause: A conflicting conditional action is currently in
- *                         progress against this resource. Please try again.</i>
- *                      </p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code: InternalError</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause: The service was unable to apply the provided tag to the
- *                         object.</i>
- *                      </p>
- *                   </li>
- *                </ul>
- *             </li>
- *          </ul>
+ * <p>For information about the Amazon S3 object tagging feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html">Object Tagging</a>.</p>
  *
  *
+ * <p class="title">
+ *    <b>Special Errors</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code: InvalidTagError </i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause: The tag provided was not a valid tag. This error can occur
+ *                if the tag did not pass input validation. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html">Object Tagging</a>.</i>
+ *             </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code: MalformedXMLError </i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause: The XML provided does not match the schema.</i>
+ *             </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code: OperationAbortedError </i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause: A conflicting conditional action is currently in
+ *                progress against this resource. Please try again.</i>
+ *             </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code: InternalError</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause: The service was unable to apply the provided tag to the
+ *                object.</i>
+ *             </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ * </ul>
  *
  *
  *
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectTagging.html">DeleteObjectTagging</a>
- *                </p>
- *             </li>
- *          </ul>
+ *
+ *
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html">GetObjectTagging</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjectTagging.html">DeleteObjectTagging</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/PutPublicAccessBlockCommand.ts
+++ b/clients/client-s3/src/commands/PutPublicAccessBlockCommand.ts
@@ -24,50 +24,50 @@ export interface PutPublicAccessBlockCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>Creates or modifies the <code>PublicAccessBlock</code> configuration for an Amazon S3 bucket.
- *          To use this operation, you must have the <code>s3:PutBucketPublicAccessBlock</code>
- *          permission. For more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a
- *          Policy</a>.</p>
+ * To use this operation, you must have the <code>s3:PutBucketPublicAccessBlock</code>
+ * permission. For more information about Amazon S3 permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a
+ * Policy</a>.</p>
  *
- *          <important>
- *             <p>When Amazon S3 evaluates the <code>PublicAccessBlock</code> configuration for a bucket or
- *             an object, it checks the <code>PublicAccessBlock</code> configuration for both the
- *             bucket (or the bucket that contains the object) and the bucket owner's account. If the
- *                <code>PublicAccessBlock</code> configurations are different between the bucket and
- *             the account, Amazon S3 uses the most restrictive combination of the bucket-level and
- *             account-level settings.</p>
- *          </important>
- *
- *
- *          <p>For more information about when Amazon S3 considers a bucket or an object public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a>.</p>
+ * <important>
+ *    <p>When Amazon S3 evaluates the <code>PublicAccessBlock</code> configuration for a bucket or
+ *    an object, it checks the <code>PublicAccessBlock</code> configuration for both the
+ *    bucket (or the bucket that contains the object) and the bucket owner's account. If the
+ *       <code>PublicAccessBlock</code> configurations are different between the bucket and
+ *    the account, Amazon S3 uses the most restrictive combination of the bucket-level and
+ *    account-level settings.</p>
+ * </important>
  *
  *
+ * <p>For more information about when Amazon S3 considers a bucket or an object public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a>.</p>
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletePublicAccessBlock.html">DeletePublicAccessBlock</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicyStatus.html">GetBucketPolicyStatus</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
- *                   Public Access</a>
- *                </p>
- *             </li>
- *          </ul>
+ *
+ *
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetPublicAccessBlock.html">GetPublicAccessBlock</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeletePublicAccessBlock.html">DeletePublicAccessBlock</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicyStatus.html">GetBucketPolicyStatus</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html">Using Amazon S3 Block
+ *          Public Access</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/RestoreObjectCommand.ts
+++ b/clients/client-s3/src/commands/RestoreObjectCommand.ts
@@ -24,297 +24,297 @@ export interface RestoreObjectCommandOutput extends RestoreObjectOutput, __Metad
 
 /**
  * <p>Restores an archived copy of an object back into Amazon S3</p>
- *          <p>This action is not supported by Amazon S3 on Outposts.</p>
- *          <p>This action performs the following types of requests: </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <code>select</code> - Perform a select query on an archived object</p>
- *             </li>
- *             <li>
- *                <p>
- *                   <code>restore an archive</code> - Restore an archived object</p>
- *             </li>
- *          </ul>
- *          <p>To use this operation, you must have permissions to perform the
- *             <code>s3:RestoreObject</code> action. The bucket owner has this permission by default
- *          and can grant this permission to others. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
- *             Resources</a> in the <i>Amazon S3 User Guide</i>.</p>
- *          <p>
- *             <b>Querying Archives with Select Requests</b>
- *          </p>
- *          <p>You use a select type of request to perform SQL queries on archived objects. The
- *          archived objects that are being queried by the select request must be formatted as
- *          uncompressed comma-separated values (CSV) files. You can run queries and custom analytics
- *          on your archived data without having to restore your data to a hotter Amazon S3 tier. For an
- *          overview about select requests, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/querying-glacier-archives.html">Querying Archived Objects</a> in the <i>Amazon S3 User Guide</i>.</p>
- *          <p>When making a select request, do the following:</p>
- *          <ul>
- *             <li>
- *                <p>Define an output location for the select query's output. This must be an Amazon S3
- *                bucket in the same Amazon Web Services Region as the bucket that contains the archive object that is
- *                being queried. The Amazon Web Services account that initiates the job must have permissions to write
- *                to the S3 bucket. You can specify the storage class and encryption for the output
- *                objects stored in the bucket. For more information about output, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/querying-glacier-archives.html">Querying Archived Objects</a>
- *                in the <i>Amazon S3 User Guide</i>.</p>
- *                <p>For more information about the <code>S3</code> structure in the request body, see
- *                the following:</p>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Managing Access with
- *                         ACLs</a> in the <i>Amazon S3 User Guide</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Protecting Data Using
- *                         Server-Side Encryption</a> in the
- *                      <i>Amazon S3 User Guide</i>
- *                      </p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <p>Define the SQL expression for the <code>SELECT</code> type of restoration for your
- *                query in the request body's <code>SelectParameters</code> structure. You can use
- *                expressions like the following examples.</p>
- *                <ul>
- *                   <li>
- *                      <p>The following expression returns all records from the specified
- *                      object.</p>
- *                      <p>
- *                         <code>SELECT * FROM Object</code>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>Assuming that you are not using any headers for data stored in the object,
- *                      you can specify columns with positional headers.</p>
- *                      <p>
- *                         <code>SELECT s._1, s._2 FROM Object s WHERE s._3 > 100</code>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>If you have headers and you set the <code>fileHeaderInfo</code> in the
- *                         <code>CSV</code> structure in the request body to <code>USE</code>, you can
- *                      specify headers in the query. (If you set the <code>fileHeaderInfo</code> field
- *                      to <code>IGNORE</code>, the first row is skipped for the query.) You cannot mix
- *                      ordinal positions with header column names. </p>
- *                      <p>
- *                         <code>SELECT s.Id, s.FirstName, s.SSN FROM S3Object s</code>
- *                      </p>
- *                   </li>
- *                </ul>
- *             </li>
- *          </ul>
- *          <p>For more information about using SQL with S3 Glacier Select restore, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference.html">SQL Reference for Amazon S3 Select and
- *             S3 Glacier Select</a> in the <i>Amazon S3 User Guide</i>. </p>
- *          <p>When making a select request, you can also do the following:</p>
- *          <ul>
- *             <li>
- *                <p>To expedite your queries, specify the <code>Expedited</code> tier. For more
- *                information about tiers, see "Restoring Archives," later in this topic.</p>
- *             </li>
- *             <li>
- *                <p>Specify details about the data serialization format of both the input object that
- *                is being queried and the serialization of the CSV-encoded query results.</p>
- *             </li>
- *          </ul>
- *          <p>The following are additional important facts about the select feature:</p>
- *          <ul>
- *             <li>
- *                <p>The output results are new Amazon S3 objects. Unlike archive retrievals, they are
- *                stored until explicitly deleted-manually or through a lifecycle policy.</p>
- *             </li>
- *             <li>
- *                <p>You can issue more than one select request on the same Amazon S3 object. Amazon S3 doesn't
- *                deduplicate requests, so avoid issuing duplicate requests.</p>
- *             </li>
- *             <li>
- *                <p> Amazon S3 accepts a select request even if the object has already been restored. A
- *                select request doesn’t return error response <code>409</code>.</p>
- *             </li>
- *          </ul>
- *          <p>
- *             <b>Restoring objects</b>
- *          </p>
- *          <p>Objects that you archive to the S3 Glacier or
- *          S3 Glacier Deep Archive storage class, and S3 Intelligent-Tiering Archive or
- *          S3 Intelligent-Tiering Deep Archive tiers are not accessible in real time. For objects in
- *          Archive Access or Deep Archive Access tiers you must first initiate a restore request, and
- *          then wait until the object is moved into the Frequent Access tier. For objects in
- *          S3 Glacier or S3 Glacier Deep Archive storage classes you must
- *          first initiate a restore request, and then wait until a temporary copy of the object is
- *          available. To access an archived object, you must restore the object for the duration
- *          (number of days) that you specify.</p>
- *          <p>To restore a specific object version, you can provide a version ID. If you don't provide
- *          a version ID, Amazon S3 restores the current version.</p>
- *          <p>When restoring an archived object (or using a select request), you can specify one of
- *          the following data access tier options in the <code>Tier</code> element of the request
- *          body: </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <b>
- *                      <code>Expedited</code>
- *                   </b> - Expedited retrievals
- *                allow you to quickly access your data stored in the S3 Glacier
- *                storage class or S3 Intelligent-Tiering Archive tier when occasional urgent requests for a
- *                subset of archives are required. For all but the largest archived objects (250 MB+),
- *                data accessed using Expedited retrievals is typically made available within 1–5
- *                minutes. Provisioned capacity ensures that retrieval capacity for Expedited
- *                retrievals is available when you need it. Expedited retrievals and provisioned
- *                capacity are not available for objects stored in the S3 Glacier Deep Archive
- *                storage class or S3 Intelligent-Tiering Deep Archive tier.</p>
- *             </li>
- *             <li>
- *                <p>
- *                   <b>
- *                      <code>Standard</code>
- *                   </b> - Standard retrievals allow
- *                you to access any of your archived objects within several hours. This is the default
- *                option for retrieval requests that do not specify the retrieval option. Standard
- *                retrievals typically finish within 3–5 hours for objects stored in the
- *                S3 Glacier storage class or S3 Intelligent-Tiering Archive tier. They
- *                typically finish within 12 hours for objects stored in the
- *                S3 Glacier Deep Archive storage class or S3 Intelligent-Tiering Deep Archive tier.
- *                Standard retrievals are free for objects stored in S3 Intelligent-Tiering.</p>
- *             </li>
- *             <li>
- *                <p>
- *                   <b>
- *                      <code>Bulk</code>
- *                   </b> - Bulk retrievals are the
- *                lowest-cost retrieval option in S3 Glacier, enabling you to retrieve large amounts,
- *                even petabytes, of data inexpensively. Bulk retrievals typically finish within 5–12
- *                hours for objects stored in the S3 Glacier storage class or
- *                S3 Intelligent-Tiering Archive tier. They typically finish within 48 hours for objects stored
- *                in the S3 Glacier Deep Archive storage class or S3 Intelligent-Tiering Deep Archive tier.
- *                Bulk retrievals are free for objects stored in S3 Intelligent-Tiering.</p>
- *             </li>
- *          </ul>
- *          <p>For more information about archive retrieval options and provisioned capacity for
- *             <code>Expedited</code> data access, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html">Restoring Archived Objects</a> in the <i>Amazon S3 User Guide</i>. </p>
- *          <p>You can use Amazon S3 restore speed upgrade to change the restore speed to a faster speed
- *          while it is in progress. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html#restoring-objects-upgrade-tier.title.html">
- *             Upgrading the speed of an in-progress restore</a> in the
- *             <i>Amazon S3 User Guide</i>. </p>
- *          <p>To get the status of object restoration, you can send a <code>HEAD</code> request.
- *          Operations return the <code>x-amz-restore</code> header, which provides information about
- *          the restoration status, in the response. You can use Amazon S3 event notifications to notify you
- *          when a restore is initiated or completed. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Amazon S3 Event Notifications</a> in
- *          the <i>Amazon S3 User Guide</i>.</p>
- *          <p>After restoring an archived object, you can update the restoration period by reissuing
- *          the request with a new period. Amazon S3 updates the restoration period relative to the current
- *          time and charges only for the request-there are no data transfer charges. You cannot
- *          update the restoration period when Amazon S3 is actively processing your current restore request
- *          for the object.</p>
- *          <p>If your bucket has a lifecycle configuration with a rule that includes an expiration
- *          action, the object expiration overrides the life span that you specify in a restore
- *          request. For example, if you restore an object copy for 10 days, but the object is
- *          scheduled to expire in 3 days, Amazon S3 deletes the object in 3 days. For more information
- *          about lifecycle configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Object Lifecycle Management</a> in
- *             <i>Amazon S3 User Guide</i>.</p>
- *          <p>
- *             <b>Responses</b>
- *          </p>
- *          <p>A successful action returns either the <code>200 OK</code> or <code>202
- *             Accepted</code> status code. </p>
- *          <ul>
- *             <li>
- *                <p>If the object is not previously restored, then Amazon S3 returns <code>202
- *                   Accepted</code> in the response. </p>
- *             </li>
- *             <li>
- *                <p>If the object is previously restored, Amazon S3 returns <code>200 OK</code> in the
- *                response. </p>
- *             </li>
- *          </ul>
- *          <p class="title">
- *             <b>Special Errors</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code: RestoreAlreadyInProgress</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause: Object restore is already in progress. (This error does not
- *                         apply to SELECT type requests.)</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>HTTP Status Code: 409 Conflict</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>SOAP Fault Code Prefix: Client</i>
- *                      </p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code: GlacierExpeditedRetrievalNotAvailable</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause: expedited retrievals are currently not available. Try again
- *                         later. (Returned if there is insufficient capacity to process the Expedited
- *                         request. This error applies only to Expedited retrievals and not to
- *                         S3 Standard or Bulk retrievals.)</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>HTTP Status Code: 503</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>SOAP Fault Code Prefix: N/A</i>
- *                      </p>
- *                   </li>
- *                </ul>
- *             </li>
- *          </ul>
+ * <p>This action is not supported by Amazon S3 on Outposts.</p>
+ * <p>This action performs the following types of requests: </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <code>select</code> - Perform a select query on an archived object</p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <code>restore an archive</code> - Restore an archived object</p>
+ *    </li>
+ * </ul>
+ * <p>To use this operation, you must have permissions to perform the
+ *    <code>s3:RestoreObject</code> action. The bucket owner has this permission by default
+ * and can grant this permission to others. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-with-s3-actions.html#using-with-s3-actions-related-to-bucket-subresources">Permissions Related to Bucket Subresource Operations</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-access-control.html">Managing Access Permissions to Your Amazon S3
+ *    Resources</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * <p>
+ *    <b>Querying Archives with Select Requests</b>
+ * </p>
+ * <p>You use a select type of request to perform SQL queries on archived objects. The
+ * archived objects that are being queried by the select request must be formatted as
+ * uncompressed comma-separated values (CSV) files. You can run queries and custom analytics
+ * on your archived data without having to restore your data to a hotter Amazon S3 tier. For an
+ * overview about select requests, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/querying-glacier-archives.html">Querying Archived Objects</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * <p>When making a select request, do the following:</p>
+ * <ul>
+ *    <li>
+ *       <p>Define an output location for the select query's output. This must be an Amazon S3
+ *       bucket in the same Amazon Web Services Region as the bucket that contains the archive object that is
+ *       being queried. The Amazon Web Services account that initiates the job must have permissions to write
+ *       to the S3 bucket. You can specify the storage class and encryption for the output
+ *       objects stored in the bucket. For more information about output, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/querying-glacier-archives.html">Querying Archived Objects</a>
+ *       in the <i>Amazon S3 User Guide</i>.</p>
+ *       <p>For more information about the <code>S3</code> structure in the request body, see
+ *       the following:</p>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html">PutObject</a>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html">Managing Access with
+ *                ACLs</a> in the <i>Amazon S3 User Guide</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Protecting Data Using
+ *                Server-Side Encryption</a> in the
+ *             <i>Amazon S3 User Guide</i>
+ *             </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <p>Define the SQL expression for the <code>SELECT</code> type of restoration for your
+ *       query in the request body's <code>SelectParameters</code> structure. You can use
+ *       expressions like the following examples.</p>
+ *       <ul>
+ *          <li>
+ *             <p>The following expression returns all records from the specified
+ *             object.</p>
+ *             <p>
+ *                <code>SELECT * FROM Object</code>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>Assuming that you are not using any headers for data stored in the object,
+ *             you can specify columns with positional headers.</p>
+ *             <p>
+ *                <code>SELECT s._1, s._2 FROM Object s WHERE s._3 > 100</code>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>If you have headers and you set the <code>fileHeaderInfo</code> in the
+ *                <code>CSV</code> structure in the request body to <code>USE</code>, you can
+ *             specify headers in the query. (If you set the <code>fileHeaderInfo</code> field
+ *             to <code>IGNORE</code>, the first row is skipped for the query.) You cannot mix
+ *             ordinal positions with header column names. </p>
+ *             <p>
+ *                <code>SELECT s.Id, s.FirstName, s.SSN FROM S3Object s</code>
+ *             </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ * </ul>
+ * <p>For more information about using SQL with S3 Glacier Select restore, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference.html">SQL Reference for Amazon S3 Select and
+ *    S3 Glacier Select</a> in the <i>Amazon S3 User Guide</i>. </p>
+ * <p>When making a select request, you can also do the following:</p>
+ * <ul>
+ *    <li>
+ *       <p>To expedite your queries, specify the <code>Expedited</code> tier. For more
+ *       information about tiers, see "Restoring Archives," later in this topic.</p>
+ *    </li>
+ *    <li>
+ *       <p>Specify details about the data serialization format of both the input object that
+ *       is being queried and the serialization of the CSV-encoded query results.</p>
+ *    </li>
+ * </ul>
+ * <p>The following are additional important facts about the select feature:</p>
+ * <ul>
+ *    <li>
+ *       <p>The output results are new Amazon S3 objects. Unlike archive retrievals, they are
+ *       stored until explicitly deleted-manually or through a lifecycle policy.</p>
+ *    </li>
+ *    <li>
+ *       <p>You can issue more than one select request on the same Amazon S3 object. Amazon S3 doesn't
+ *       deduplicate requests, so avoid issuing duplicate requests.</p>
+ *    </li>
+ *    <li>
+ *       <p> Amazon S3 accepts a select request even if the object has already been restored. A
+ *       select request doesn’t return error response <code>409</code>.</p>
+ *    </li>
+ * </ul>
+ * <p>
+ *    <b>Restoring objects</b>
+ * </p>
+ * <p>Objects that you archive to the S3 Glacier or
+ * S3 Glacier Deep Archive storage class, and S3 Intelligent-Tiering Archive or
+ * S3 Intelligent-Tiering Deep Archive tiers are not accessible in real time. For objects in
+ * Archive Access or Deep Archive Access tiers you must first initiate a restore request, and
+ * then wait until the object is moved into the Frequent Access tier. For objects in
+ * S3 Glacier or S3 Glacier Deep Archive storage classes you must
+ * first initiate a restore request, and then wait until a temporary copy of the object is
+ * available. To access an archived object, you must restore the object for the duration
+ * (number of days) that you specify.</p>
+ * <p>To restore a specific object version, you can provide a version ID. If you don't provide
+ * a version ID, Amazon S3 restores the current version.</p>
+ * <p>When restoring an archived object (or using a select request), you can specify one of
+ * the following data access tier options in the <code>Tier</code> element of the request
+ * body: </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <b>
+ *             <code>Expedited</code>
+ *          </b> - Expedited retrievals
+ *       allow you to quickly access your data stored in the S3 Glacier
+ *       storage class or S3 Intelligent-Tiering Archive tier when occasional urgent requests for a
+ *       subset of archives are required. For all but the largest archived objects (250 MB+),
+ *       data accessed using Expedited retrievals is typically made available within 1–5
+ *       minutes. Provisioned capacity ensures that retrieval capacity for Expedited
+ *       retrievals is available when you need it. Expedited retrievals and provisioned
+ *       capacity are not available for objects stored in the S3 Glacier Deep Archive
+ *       storage class or S3 Intelligent-Tiering Deep Archive tier.</p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <b>
+ *             <code>Standard</code>
+ *          </b> - Standard retrievals allow
+ *       you to access any of your archived objects within several hours. This is the default
+ *       option for retrieval requests that do not specify the retrieval option. Standard
+ *       retrievals typically finish within 3–5 hours for objects stored in the
+ *       S3 Glacier storage class or S3 Intelligent-Tiering Archive tier. They
+ *       typically finish within 12 hours for objects stored in the
+ *       S3 Glacier Deep Archive storage class or S3 Intelligent-Tiering Deep Archive tier.
+ *       Standard retrievals are free for objects stored in S3 Intelligent-Tiering.</p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <b>
+ *             <code>Bulk</code>
+ *          </b> - Bulk retrievals are the
+ *       lowest-cost retrieval option in S3 Glacier, enabling you to retrieve large amounts,
+ *       even petabytes, of data inexpensively. Bulk retrievals typically finish within 5–12
+ *       hours for objects stored in the S3 Glacier storage class or
+ *       S3 Intelligent-Tiering Archive tier. They typically finish within 48 hours for objects stored
+ *       in the S3 Glacier Deep Archive storage class or S3 Intelligent-Tiering Deep Archive tier.
+ *       Bulk retrievals are free for objects stored in S3 Intelligent-Tiering.</p>
+ *    </li>
+ * </ul>
+ * <p>For more information about archive retrieval options and provisioned capacity for
+ *    <code>Expedited</code> data access, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html">Restoring Archived Objects</a> in the <i>Amazon S3 User Guide</i>. </p>
+ * <p>You can use Amazon S3 restore speed upgrade to change the restore speed to a faster speed
+ * while it is in progress. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html#restoring-objects-upgrade-tier.title.html">
+ *    Upgrading the speed of an in-progress restore</a> in the
+ *    <i>Amazon S3 User Guide</i>. </p>
+ * <p>To get the status of object restoration, you can send a <code>HEAD</code> request.
+ * Operations return the <code>x-amz-restore</code> header, which provides information about
+ * the restoration status, in the response. You can use Amazon S3 event notifications to notify you
+ * when a restore is initiated or completed. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Amazon S3 Event Notifications</a> in
+ * the <i>Amazon S3 User Guide</i>.</p>
+ * <p>After restoring an archived object, you can update the restoration period by reissuing
+ * the request with a new period. Amazon S3 updates the restoration period relative to the current
+ * time and charges only for the request-there are no data transfer charges. You cannot
+ * update the restoration period when Amazon S3 is actively processing your current restore request
+ * for the object.</p>
+ * <p>If your bucket has a lifecycle configuration with a rule that includes an expiration
+ * action, the object expiration overrides the life span that you specify in a restore
+ * request. For example, if you restore an object copy for 10 days, but the object is
+ * scheduled to expire in 3 days, Amazon S3 deletes the object in 3 days. For more information
+ * about lifecycle configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Object Lifecycle Management</a> in
+ *    <i>Amazon S3 User Guide</i>.</p>
+ * <p>
+ *    <b>Responses</b>
+ * </p>
+ * <p>A successful action returns either the <code>200 OK</code> or <code>202
+ *    Accepted</code> status code. </p>
+ * <ul>
+ *    <li>
+ *       <p>If the object is not previously restored, then Amazon S3 returns <code>202
+ *          Accepted</code> in the response. </p>
+ *    </li>
+ *    <li>
+ *       <p>If the object is previously restored, Amazon S3 returns <code>200 OK</code> in the
+ *       response. </p>
+ *    </li>
+ * </ul>
+ * <p class="title">
+ *    <b>Special Errors</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code: RestoreAlreadyInProgress</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause: Object restore is already in progress. (This error does not
+ *                apply to SELECT type requests.)</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>HTTP Status Code: 409 Conflict</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>SOAP Fault Code Prefix: Client</i>
+ *             </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code: GlacierExpeditedRetrievalNotAvailable</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause: expedited retrievals are currently not available. Try again
+ *                later. (Returned if there is insufficient capacity to process the Expedited
+ *                request. This error applies only to Expedited retrievals and not to
+ *                S3 Standard or Bulk retrievals.)</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>HTTP Status Code: 503</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>SOAP Fault Code Prefix: N/A</i>
+ *             </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ * </ul>
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketNotificationConfiguration.html">GetBucketNotificationConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference.html">SQL Reference for
- *                   Amazon S3 Select and S3 Glacier Select </a> in the
- *                   <i>Amazon S3 User Guide</i>
- *                </p>
- *             </li>
- *          </ul>
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketNotificationConfiguration.html">GetBucketNotificationConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference.html">SQL Reference for
+ *          Amazon S3 Select and S3 Glacier Select </a> in the
+ *          <i>Amazon S3 User Guide</i>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/SelectObjectContentCommand.ts
+++ b/clients/client-s3/src/commands/SelectObjectContentCommand.ts
@@ -25,122 +25,122 @@ export interface SelectObjectContentCommandOutput extends SelectObjectContentOut
 
 /**
  * <p>This action filters the contents of an Amazon S3 object based on a simple structured query
- *          language (SQL) statement. In the request, along with the SQL expression, you must also
- *          specify a data serialization format (JSON, CSV, or Apache Parquet) of the object. Amazon S3 uses
- *          this format to parse object data into records, and returns only records that match the
- *          specified SQL expression. You must also specify the data serialization format for the
- *          response.</p>
- *          <p>This action is not supported by Amazon S3 on Outposts.</p>
- *          <p>For more information about Amazon S3 Select,
- *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/selecting-content-from-objects.html">Selecting Content from
- *             Objects</a> in the <i>Amazon S3 User Guide</i>.</p>
- *          <p>For more information about using SQL with Amazon S3 Select, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference.html"> SQL Reference for Amazon S3 Select
- *             and S3 Glacier Select</a> in the <i>Amazon S3 User Guide</i>.</p>
- *          <p></p>
- *          <p>
- *             <b>Permissions</b>
- *          </p>
- *          <p>You must have <code>s3:GetObject</code> permission for this operation. Amazon S3 Select does
- *          not support anonymous access. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a Policy</a>
- *          in the <i>Amazon S3 User Guide</i>.</p>
- *          <p></p>
- *          <p>
- *             <i>Object Data Formats</i>
- *          </p>
- *          <p>You can use Amazon S3 Select to query objects that have the following format
- *          properties:</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <i>CSV, JSON, and Parquet</i> - Objects must be in CSV, JSON, or
- *                Parquet format.</p>
- *             </li>
- *             <li>
- *                <p>
- *                   <i>UTF-8</i> - UTF-8 is the only encoding type Amazon S3 Select
- *                supports.</p>
- *             </li>
- *             <li>
- *                <p>
- *                   <i>GZIP or BZIP2</i> - CSV and JSON files can be compressed using
- *                GZIP or BZIP2. GZIP and BZIP2 are the only compression formats that Amazon S3 Select
- *                supports for CSV and JSON files. Amazon S3 Select supports columnar compression for
- *                Parquet using GZIP or Snappy. Amazon S3 Select does not support whole-object compression
- *                for Parquet objects.</p>
- *             </li>
- *             <li>
- *                <p>
- *                   <i>Server-side encryption</i> - Amazon S3 Select supports querying
- *                objects that are protected with server-side encryption.</p>
- *                <p>For objects that are encrypted with customer-provided encryption keys (SSE-C), you
- *                must use HTTPS, and you must use the headers that are documented in the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>. For more information about SSE-C, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html">Server-Side Encryption
- *                   (Using Customer-Provided Encryption Keys)</a> in the
- *                   <i>Amazon S3 User Guide</i>.</p>
- *                <p>For objects that are encrypted with Amazon S3 managed encryption keys (SSE-S3) and
- *                customer master keys (CMKs) stored in Amazon Web Services Key Management Service (SSE-KMS),
- *                server-side encryption is handled transparently, so you don't need to specify
- *                anything. For more information about server-side encryption, including SSE-S3 and
- *                SSE-KMS, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Protecting Data Using
- *                   Server-Side Encryption</a> in the <i>Amazon S3 User Guide</i>.</p>
- *             </li>
- *          </ul>
+ * language (SQL) statement. In the request, along with the SQL expression, you must also
+ * specify a data serialization format (JSON, CSV, or Apache Parquet) of the object. Amazon S3 uses
+ * this format to parse object data into records, and returns only records that match the
+ * specified SQL expression. You must also specify the data serialization format for the
+ * response.</p>
+ * <p>This action is not supported by Amazon S3 on Outposts.</p>
+ * <p>For more information about Amazon S3 Select,
+ * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/selecting-content-from-objects.html">Selecting Content from
+ *    Objects</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * <p>For more information about using SQL with Amazon S3 Select, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-glacier-select-sql-reference.html"> SQL Reference for Amazon S3 Select
+ *    and S3 Glacier Select</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * <p></p>
+ * <p>
+ *    <b>Permissions</b>
+ * </p>
+ * <p>You must have <code>s3:GetObject</code> permission for this operation. Amazon S3 Select does
+ * not support anonymous access. For more information about permissions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html">Specifying Permissions in a Policy</a>
+ * in the <i>Amazon S3 User Guide</i>.</p>
+ * <p></p>
+ * <p>
+ *    <i>Object Data Formats</i>
+ * </p>
+ * <p>You can use Amazon S3 Select to query objects that have the following format
+ * properties:</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <i>CSV, JSON, and Parquet</i> - Objects must be in CSV, JSON, or
+ *       Parquet format.</p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <i>UTF-8</i> - UTF-8 is the only encoding type Amazon S3 Select
+ *       supports.</p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <i>GZIP or BZIP2</i> - CSV and JSON files can be compressed using
+ *       GZIP or BZIP2. GZIP and BZIP2 are the only compression formats that Amazon S3 Select
+ *       supports for CSV and JSON files. Amazon S3 Select supports columnar compression for
+ *       Parquet using GZIP or Snappy. Amazon S3 Select does not support whole-object compression
+ *       for Parquet objects.</p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <i>Server-side encryption</i> - Amazon S3 Select supports querying
+ *       objects that are protected with server-side encryption.</p>
+ *       <p>For objects that are encrypted with customer-provided encryption keys (SSE-C), you
+ *       must use HTTPS, and you must use the headers that are documented in the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>. For more information about SSE-C, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html">Server-Side Encryption
+ *          (Using Customer-Provided Encryption Keys)</a> in the
+ *          <i>Amazon S3 User Guide</i>.</p>
+ *       <p>For objects that are encrypted with Amazon S3 managed encryption keys (SSE-S3) and
+ *       customer master keys (CMKs) stored in Amazon Web Services Key Management Service (SSE-KMS),
+ *       server-side encryption is handled transparently, so you don't need to specify
+ *       anything. For more information about server-side encryption, including SSE-S3 and
+ *       SSE-KMS, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html">Protecting Data Using
+ *          Server-Side Encryption</a> in the <i>Amazon S3 User Guide</i>.</p>
+ *    </li>
+ * </ul>
  *
- *          <p>
- *             <b>Working with the Response Body</b>
- *          </p>
- *          <p>Given the response size is unknown, Amazon S3 Select streams the response as a series of
- *          messages and includes a <code>Transfer-Encoding</code> header with <code>chunked</code> as
- *          its value in the response. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html">Appendix: SelectObjectContent
- *             Response</a>.</p>
+ * <p>
+ *    <b>Working with the Response Body</b>
+ * </p>
+ * <p>Given the response size is unknown, Amazon S3 Select streams the response as a series of
+ * messages and includes a <code>Transfer-Encoding</code> header with <code>chunked</code> as
+ * its value in the response. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html">Appendix: SelectObjectContent
+ *    Response</a>.</p>
  *
- *          <p></p>
- *          <p>
- *             <b>GetObject Support</b>
- *          </p>
- *          <p>The <code>SelectObjectContent</code> action does not support the following
- *             <code>GetObject</code> functionality. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>.</p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <code>Range</code>: Although you can specify a scan range for an Amazon S3 Select request
- *                (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_SelectObjectContent.html#AmazonS3-SelectObjectContent-request-ScanRange">SelectObjectContentRequest - ScanRange</a> in the request parameters),
- *                you cannot specify the range of bytes of an object to return. </p>
- *             </li>
- *             <li>
- *                <p>GLACIER, DEEP_ARCHIVE and REDUCED_REDUNDANCY storage classes: You cannot specify
- *                the GLACIER, DEEP_ARCHIVE, or <code>REDUCED_REDUNDANCY</code> storage classes. For
- *                more information, about storage classes see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#storage-class-intro">Storage Classes</a>
- *                in the <i>Amazon S3 User Guide</i>.</p>
- *             </li>
- *          </ul>
- *          <p></p>
- *          <p>
- *             <b>Special Errors</b>
- *          </p>
+ * <p></p>
+ * <p>
+ *    <b>GetObject Support</b>
+ * </p>
+ * <p>The <code>SelectObjectContent</code> action does not support the following
+ *    <code>GetObject</code> functionality. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>.</p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <code>Range</code>: Although you can specify a scan range for an Amazon S3 Select request
+ *       (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_SelectObjectContent.html#AmazonS3-SelectObjectContent-request-ScanRange">SelectObjectContentRequest - ScanRange</a> in the request parameters),
+ *       you cannot specify the range of bytes of an object to return. </p>
+ *    </li>
+ *    <li>
+ *       <p>GLACIER, DEEP_ARCHIVE and REDUCED_REDUNDANCY storage classes: You cannot specify
+ *       the GLACIER, DEEP_ARCHIVE, or <code>REDUCED_REDUNDANCY</code> storage classes. For
+ *       more information, about storage classes see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#storage-class-intro">Storage Classes</a>
+ *       in the <i>Amazon S3 User Guide</i>.</p>
+ *    </li>
+ * </ul>
+ * <p></p>
+ * <p>
+ *    <b>Special Errors</b>
+ * </p>
  *
- *          <p>For a list of special errors for this operation, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#SelectObjectContentErrorCodeList">List of
- *             SELECT Object Content Error Codes</a>
- *          </p>
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html">GetBucketLifecycleConfiguration</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a>
- *                </p>
- *             </li>
- *          </ul>
+ * <p>For a list of special errors for this operation, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#SelectObjectContentErrorCodeList">List of
+ *    SELECT Object Content Error Codes</a>
+ * </p>
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html">GetBucketLifecycleConfiguration</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/UploadPartCommand.ts
+++ b/clients/client-s3/src/commands/UploadPartCommand.ts
@@ -33,143 +33,143 @@ export interface UploadPartCommandOutput extends UploadPartOutput, __MetadataBea
 
 /**
  * <p>Uploads a part in a multipart upload.</p>
- *          <note>
- *             <p>In this operation, you provide part data in your request. However, you have an option
- *             to specify your existing Amazon S3 object as a data source for the part you are uploading. To
- *             upload a part from an existing object, you use the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html">UploadPartCopy</a> operation.
- *          </p>
- *          </note>
+ * <note>
+ *    <p>In this operation, you provide part data in your request. However, you have an option
+ *    to specify your existing Amazon S3 object as a data source for the part you are uploading. To
+ *    upload a part from an existing object, you use the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html">UploadPartCopy</a> operation.
+ * </p>
+ * </note>
  *
- *          <p>You must initiate a multipart upload (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>)
- *          before you can upload any part. In response to your initiate request, Amazon S3 returns an
- *          upload ID, a unique identifier, that you must include in your upload part request.</p>
- *          <p>Part numbers can be any number from 1 to 10,000, inclusive. A part number uniquely
- *          identifies a part and also defines its position within the object being created. If you
- *          upload a new part using the same part number that was used with a previous part, the
- *          previously uploaded part is overwritten. Each part must be at least 5 MB in size, except
- *          the last part. There is no size limit on the last part of your multipart upload.</p>
- *          <p>To ensure that data is not corrupted when traversing the network, specify the
- *             <code>Content-MD5</code> header in the upload part request. Amazon S3 checks the part data
- *          against the provided MD5 value. If they do not match, Amazon S3 returns an error. </p>
+ * <p>You must initiate a multipart upload (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>)
+ * before you can upload any part. In response to your initiate request, Amazon S3 returns an
+ * upload ID, a unique identifier, that you must include in your upload part request.</p>
+ * <p>Part numbers can be any number from 1 to 10,000, inclusive. A part number uniquely
+ * identifies a part and also defines its position within the object being created. If you
+ * upload a new part using the same part number that was used with a previous part, the
+ * previously uploaded part is overwritten. Each part must be at least 5 MB in size, except
+ * the last part. There is no size limit on the last part of your multipart upload.</p>
+ * <p>To ensure that data is not corrupted when traversing the network, specify the
+ *    <code>Content-MD5</code> header in the upload part request. Amazon S3 checks the part data
+ * against the provided MD5 value. If they do not match, Amazon S3 returns an error. </p>
  *
- *          <p>If the upload request is signed with Signature Version 4, then Amazon Web Services S3 uses the
- *             <code>x-amz-content-sha256</code> header as a checksum instead of
- *             <code>Content-MD5</code>. For more information see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html">Authenticating Requests: Using the Authorization Header (Amazon Web Services Signature Version
- *             4)</a>. </p>
- *
- *
- *
- *          <p>
- *             <b>Note:</b> After you initiate multipart upload and upload
- *          one or more parts, you must either complete or abort multipart upload in order to stop
- *          getting charged for storage of the uploaded parts. Only after you either complete or abort
- *          multipart upload, Amazon S3 frees up the parts storage and stops charging you for the parts
- *          storage.</p>
- *
- *          <p>For more information on multipart uploads, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html">Multipart Upload Overview</a> in the
- *             <i>Amazon S3 User Guide </i>.</p>
- *          <p>For information on the permissions required to use the multipart upload API, go to
- *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
- *             Permissions</a> in the <i>Amazon S3 User Guide</i>.</p>
- *
- *          <p>You can optionally request server-side encryption where Amazon S3 encrypts your data as it
- *          writes it to disks in its data centers and decrypts it for you when you access it. You have
- *          the option of providing your own encryption key, or you can use the Amazon Web Services managed encryption
- *          keys. If you choose to provide your own encryption key, the request headers you provide in
- *          the request must match the headers you used in the request to initiate the upload by using
- *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>. For more information, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html">Using Server-Side Encryption</a> in
- *          the <i>Amazon S3 User Guide</i>.</p>
- *
- *          <p>Server-side encryption is supported by the S3 Multipart Upload actions. Unless you are
- *          using a customer-provided encryption key, you don't need to specify the encryption
- *          parameters in each UploadPart request. Instead, you only need to specify the server-side
- *          encryption parameters in the initial Initiate Multipart request. For more information, see
- *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>.</p>
- *
- *          <p>If you requested server-side encryption using a customer-provided encryption key in your
- *          initiate multipart upload request, you must provide identical encryption information in
- *          each part upload using the following headers.</p>
+ * <p>If the upload request is signed with Signature Version 4, then Amazon Web Services S3 uses the
+ *    <code>x-amz-content-sha256</code> header as a checksum instead of
+ *    <code>Content-MD5</code>. For more information see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html">Authenticating Requests: Using the Authorization Header (Amazon Web Services Signature Version
+ *    4)</a>. </p>
  *
  *
- *          <ul>
- *             <li>
- *                <p>x-amz-server-side-encryption-customer-algorithm</p>
- *             </li>
- *             <li>
- *                <p>x-amz-server-side-encryption-customer-key</p>
- *             </li>
- *             <li>
- *                <p>x-amz-server-side-encryption-customer-key-MD5</p>
- *             </li>
- *          </ul>
  *
- *          <p class="title">
- *             <b>Special Errors</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code: NoSuchUpload</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause: The specified multipart upload does not exist. The upload
- *                         ID might be invalid, or the multipart upload might have been aborted or
- *                         completed.</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i> HTTP Status Code: 404 Not Found </i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>SOAP Fault Code Prefix: Client</i>
- *                      </p>
- *                   </li>
- *                </ul>
- *             </li>
- *          </ul>
+ * <p>
+ *    <b>Note:</b> After you initiate multipart upload and upload
+ * one or more parts, you must either complete or abort multipart upload in order to stop
+ * getting charged for storage of the uploaded parts. Only after you either complete or abort
+ * multipart upload, Amazon S3 frees up the parts storage and stops charging you for the parts
+ * storage.</p>
+ *
+ * <p>For more information on multipart uploads, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html">Multipart Upload Overview</a> in the
+ *    <i>Amazon S3 User Guide </i>.</p>
+ * <p>For information on the permissions required to use the multipart upload API, go to
+ *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload and
+ *    Permissions</a> in the <i>Amazon S3 User Guide</i>.</p>
+ *
+ * <p>You can optionally request server-side encryption where Amazon S3 encrypts your data as it
+ * writes it to disks in its data centers and decrypts it for you when you access it. You have
+ * the option of providing your own encryption key, or you can use the Amazon Web Services managed encryption
+ * keys. If you choose to provide your own encryption key, the request headers you provide in
+ * the request must match the headers you used in the request to initiate the upload by using
+ *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>. For more information, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html">Using Server-Side Encryption</a> in
+ * the <i>Amazon S3 User Guide</i>.</p>
+ *
+ * <p>Server-side encryption is supported by the S3 Multipart Upload actions. Unless you are
+ * using a customer-provided encryption key, you don't need to specify the encryption
+ * parameters in each UploadPart request. Instead, you only need to specify the server-side
+ * encryption parameters in the initial Initiate Multipart request. For more information, see
+ *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>.</p>
+ *
+ * <p>If you requested server-side encryption using a customer-provided encryption key in your
+ * initiate multipart upload request, you must provide identical encryption information in
+ * each part upload using the following headers.</p>
  *
  *
+ * <ul>
+ *    <li>
+ *       <p>x-amz-server-side-encryption-customer-algorithm</p>
+ *    </li>
+ *    <li>
+ *       <p>x-amz-server-side-encryption-customer-key</p>
+ *    </li>
+ *    <li>
+ *       <p>x-amz-server-side-encryption-customer-key-MD5</p>
+ *    </li>
+ * </ul>
+ *
+ * <p class="title">
+ *    <b>Special Errors</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code: NoSuchUpload</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause: The specified multipart upload does not exist. The upload
+ *                ID might be invalid, or the multipart upload might have been aborted or
+ *                completed.</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i> HTTP Status Code: 404 Not Found </i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>SOAP Fault Code Prefix: Client</i>
+ *             </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ * </ul>
  *
  *
  *
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
- *                </p>
- *             </li>
- *          </ul>
+ *
+ *
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/UploadPartCopyCommand.ts
+++ b/clients/client-s3/src/commands/UploadPartCopyCommand.ts
@@ -25,184 +25,184 @@ export interface UploadPartCopyCommandOutput extends UploadPartCopyOutput, __Met
 
 /**
  * <p>Uploads a part by copying data from an existing object as data source. You specify the
- *          data source by adding the request header <code>x-amz-copy-source</code> in your request and
- *          a byte range by adding the request header <code>x-amz-copy-source-range</code> in your
- *          request. </p>
- *          <p>The minimum allowable part size for a multipart upload is 5 MB. For more information
- *          about multipart upload limits, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html">Quick
- *             Facts</a> in the <i>Amazon S3 User Guide</i>. </p>
- *          <note>
- *             <p>Instead of using an existing object as part data, you might use the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
- *             action and provide data in your request.</p>
- *          </note>
+ * data source by adding the request header <code>x-amz-copy-source</code> in your request and
+ * a byte range by adding the request header <code>x-amz-copy-source-range</code> in your
+ * request. </p>
+ * <p>The minimum allowable part size for a multipart upload is 5 MB. For more information
+ * about multipart upload limits, go to <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html">Quick
+ *    Facts</a> in the <i>Amazon S3 User Guide</i>. </p>
+ * <note>
+ *    <p>Instead of using an existing object as part data, you might use the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+ *    action and provide data in your request.</p>
+ * </note>
  *
- *          <p>You must initiate a multipart upload before you can upload any part. In response to your
- *          initiate request. Amazon S3 returns a unique identifier, the upload ID, that you must include in
- *          your upload part request.</p>
- *          <p>For more information about using the <code>UploadPartCopy</code> operation, see the
- *          following:</p>
+ * <p>You must initiate a multipart upload before you can upload any part. In response to your
+ * initiate request. Amazon S3 returns a unique identifier, the upload ID, that you must include in
+ * your upload part request.</p>
+ * <p>For more information about using the <code>UploadPartCopy</code> operation, see the
+ * following:</p>
  *
- *          <ul>
- *             <li>
- *                <p>For conceptual information about multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
- *                   Upload</a> in the <i>Amazon S3 User Guide</i>.</p>
- *             </li>
- *             <li>
- *                <p>For information about permissions required to use the multipart upload API, see
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload  and
- *                   Permissions</a> in the <i>Amazon S3 User Guide</i>.</p>
- *             </li>
- *             <li>
- *                <p>For information about copying objects using a single atomic action vs. the
- *                multipart upload, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectOperations.html">Operations on
- *                   Objects</a> in the <i>Amazon S3 User Guide</i>.</p>
- *             </li>
- *             <li>
- *                <p>For information about using server-side encryption with customer-provided
- *                encryption keys with the UploadPartCopy operation, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html">CopyObject</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>.</p>
- *             </li>
- *          </ul>
- *          <p>Note the following additional considerations about the request headers
- *             <code>x-amz-copy-source-if-match</code>, <code>x-amz-copy-source-if-none-match</code>,
- *             <code>x-amz-copy-source-if-unmodified-since</code>, and
- *             <code>x-amz-copy-source-if-modified-since</code>:</p>
- *          <p> </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <b>Consideration 1</b> - If both of the
- *                   <code>x-amz-copy-source-if-match</code> and
- *                   <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the
- *                request as follows:</p>
- *                <p>
- *                   <code>x-amz-copy-source-if-match</code> condition evaluates to <code>true</code>,
- *                and;</p>
- *                <p>
- *                   <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to
- *                   <code>false</code>;</p>
- *                <p>Amazon S3 returns <code>200 OK</code> and copies the data.
- *                </p>
+ * <ul>
+ *    <li>
+ *       <p>For conceptual information about multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/uploadobjusingmpu.html">Uploading Objects Using Multipart
+ *          Upload</a> in the <i>Amazon S3 User Guide</i>.</p>
+ *    </li>
+ *    <li>
+ *       <p>For information about permissions required to use the multipart upload API, see
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuAndPermissions.html">Multipart Upload  and
+ *          Permissions</a> in the <i>Amazon S3 User Guide</i>.</p>
+ *    </li>
+ *    <li>
+ *       <p>For information about copying objects using a single atomic action vs. the
+ *       multipart upload, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectOperations.html">Operations on
+ *          Objects</a> in the <i>Amazon S3 User Guide</i>.</p>
+ *    </li>
+ *    <li>
+ *       <p>For information about using server-side encryption with customer-provided
+ *       encryption keys with the UploadPartCopy operation, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html">CopyObject</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>.</p>
+ *    </li>
+ * </ul>
+ * <p>Note the following additional considerations about the request headers
+ *    <code>x-amz-copy-source-if-match</code>, <code>x-amz-copy-source-if-none-match</code>,
+ *    <code>x-amz-copy-source-if-unmodified-since</code>, and
+ *    <code>x-amz-copy-source-if-modified-since</code>:</p>
+ * <p> </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <b>Consideration 1</b> - If both of the
+ *          <code>x-amz-copy-source-if-match</code> and
+ *          <code>x-amz-copy-source-if-unmodified-since</code> headers are present in the
+ *       request as follows:</p>
+ *       <p>
+ *          <code>x-amz-copy-source-if-match</code> condition evaluates to <code>true</code>,
+ *       and;</p>
+ *       <p>
+ *          <code>x-amz-copy-source-if-unmodified-since</code> condition evaluates to
+ *          <code>false</code>;</p>
+ *       <p>Amazon S3 returns <code>200 OK</code> and copies the data.
+ *       </p>
  *
- *             </li>
- *             <li>
- *                <p>
- *                   <b>Consideration 2</b> - If both of the
- *                   <code>x-amz-copy-source-if-none-match</code> and
- *                   <code>x-amz-copy-source-if-modified-since</code> headers are present in the
- *                request as follows:</p>
- *                <p>
- *                   <code>x-amz-copy-source-if-none-match</code> condition evaluates to
- *                   <code>false</code>, and;</p>
- *                <p>
- *                   <code>x-amz-copy-source-if-modified-since</code> condition evaluates to
- *                   <code>true</code>;</p>
- *                <p>Amazon S3 returns <code>412 Precondition Failed</code> response code.
- *                </p>
- *             </li>
- *          </ul>
- *          <p>
- *             <b>Versioning</b>
- *          </p>
- *          <p>If your bucket has versioning enabled, you could have multiple versions of the same
- *          object. By default, <code>x-amz-copy-source</code> identifies the current version of the
- *          object to copy. If the current version is a delete marker and you don't specify a versionId
- *          in the <code>x-amz-copy-source</code>, Amazon S3 returns a 404 error, because the object does
- *          not exist. If you specify versionId in the <code>x-amz-copy-source</code> and the versionId
- *          is a delete marker, Amazon S3 returns an HTTP 400 error, because you are not allowed to specify
- *          a delete marker as a version for the <code>x-amz-copy-source</code>. </p>
- *          <p>You can optionally specify a specific version of the source object to copy by adding the
- *             <code>versionId</code> subresource as shown in the following example:</p>
- *          <p>
- *             <code>x-amz-copy-source: /bucket/object?versionId=version id</code>
- *          </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <b>Consideration 2</b> - If both of the
+ *          <code>x-amz-copy-source-if-none-match</code> and
+ *          <code>x-amz-copy-source-if-modified-since</code> headers are present in the
+ *       request as follows:</p>
+ *       <p>
+ *          <code>x-amz-copy-source-if-none-match</code> condition evaluates to
+ *          <code>false</code>, and;</p>
+ *       <p>
+ *          <code>x-amz-copy-source-if-modified-since</code> condition evaluates to
+ *          <code>true</code>;</p>
+ *       <p>Amazon S3 returns <code>412 Precondition Failed</code> response code.
+ *       </p>
+ *    </li>
+ * </ul>
+ * <p>
+ *    <b>Versioning</b>
+ * </p>
+ * <p>If your bucket has versioning enabled, you could have multiple versions of the same
+ * object. By default, <code>x-amz-copy-source</code> identifies the current version of the
+ * object to copy. If the current version is a delete marker and you don't specify a versionId
+ * in the <code>x-amz-copy-source</code>, Amazon S3 returns a 404 error, because the object does
+ * not exist. If you specify versionId in the <code>x-amz-copy-source</code> and the versionId
+ * is a delete marker, Amazon S3 returns an HTTP 400 error, because you are not allowed to specify
+ * a delete marker as a version for the <code>x-amz-copy-source</code>. </p>
+ * <p>You can optionally specify a specific version of the source object to copy by adding the
+ *    <code>versionId</code> subresource as shown in the following example:</p>
+ * <p>
+ *    <code>x-amz-copy-source: /bucket/object?versionId=version id</code>
+ * </p>
  *
- *          <p class="title">
- *             <b>Special Errors</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code: NoSuchUpload</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause: The specified multipart upload does not exist. The upload
- *                         ID might be invalid, or the multipart upload might have been aborted or
- *                         completed.</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>HTTP Status Code: 404 Not Found</i>
- *                      </p>
- *                   </li>
- *                </ul>
- *             </li>
- *             <li>
- *                <ul>
- *                   <li>
- *                      <p>
- *                         <i>Code: InvalidRequest</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>Cause: The specified copy source is not supported as a byte-range
- *                         copy source.</i>
- *                      </p>
- *                   </li>
- *                   <li>
- *                      <p>
- *                         <i>HTTP Status Code: 400 Bad Request</i>
- *                      </p>
- *                   </li>
- *                </ul>
- *             </li>
- *          </ul>
- *
- *
+ * <p class="title">
+ *    <b>Special Errors</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code: NoSuchUpload</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause: The specified multipart upload does not exist. The upload
+ *                ID might be invalid, or the multipart upload might have been aborted or
+ *                completed.</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>HTTP Status Code: 404 Not Found</i>
+ *             </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ *    <li>
+ *       <ul>
+ *          <li>
+ *             <p>
+ *                <i>Code: InvalidRequest</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>Cause: The specified copy source is not supported as a byte-range
+ *                copy source.</i>
+ *             </p>
+ *          </li>
+ *          <li>
+ *             <p>
+ *                <i>HTTP Status Code: 400 Bad Request</i>
+ *             </p>
+ *          </li>
+ *       </ul>
+ *    </li>
+ * </ul>
  *
  *
  *
  *
- *          <p class="title">
- *             <b>Related Resources</b>
- *          </p>
- *          <ul>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
- *                </p>
- *             </li>
- *             <li>
- *                <p>
- *                   <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
- *                </p>
- *             </li>
- *          </ul>
+ *
+ *
+ * <p class="title">
+ *    <b>Related Resources</b>
+ * </p>
+ * <ul>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html">CreateMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html">UploadPart</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html">CompleteMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html">AbortMultipartUpload</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListParts.html">ListParts</a>
+ *       </p>
+ *    </li>
+ *    <li>
+ *       <p>
+ *          <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html">ListMultipartUploads</a>
+ *       </p>
+ *    </li>
+ * </ul>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/commands/WriteGetObjectResponseCommand.ts
+++ b/clients/client-s3/src/commands/WriteGetObjectResponseCommand.ts
@@ -32,28 +32,28 @@ export interface WriteGetObjectResponseCommandOutput extends __MetadataBearer {}
 
 /**
  * <p>Passes transformed
- *          objects to a <code>GetObject</code> operation when using Object Lambda Access Points. For information about
- *          Object Lambda Access Points, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/transforming-objects.html">Transforming objects with
- *             Object Lambda Access Points</a> in the <i>Amazon S3 User Guide</i>.</p>
- *          <p>This operation supports metadata that can be returned by <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>, in addition to
- *            <code>RequestRoute</code>, <code>RequestToken</code>, <code>StatusCode</code>,
- *            <code>ErrorCode</code>, and <code>ErrorMessage</code>. The <code>GetObject</code>
+ * objects to a <code>GetObject</code> operation when using Object Lambda Access Points. For information about
+ * Object Lambda Access Points, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/transforming-objects.html">Transforming objects with
+ *    Object Lambda Access Points</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * <p>This operation supports metadata that can be returned by <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html">GetObject</a>, in addition to
+ *   <code>RequestRoute</code>, <code>RequestToken</code>, <code>StatusCode</code>,
+ *   <code>ErrorCode</code>, and <code>ErrorMessage</code>. The <code>GetObject</code>
  *         response metadata is supported so that the <code>WriteGetObjectResponse</code> caller,
  *         typically an Lambda function, can provide the same metadata when it internally invokes
- *            <code>GetObject</code>. When <code>WriteGetObjectResponse</code> is called by a
+ *   <code>GetObject</code>. When <code>WriteGetObjectResponse</code> is called by a
  *         customer-owned Lambda function, the metadata returned to the end user
- *            <code>GetObject</code> call might differ from what Amazon S3 would normally return.</p>
- *          <p>You can include any number of metadata headers. When including a metadata header, it should be
- *          prefaced with <code>x-amz-meta</code>. For example, <code>x-amz-meta-my-custom-header: MyCustomValue</code>.
- *          The primary use case for this is to forward <code>GetObject</code> metadata.</p>
- *          <p>Amazon Web Services provides some prebuilt Lambda functions that you can use with S3 Object Lambda to detect and redact
- *          personally identifiable information (PII) and decompress S3 objects. These Lambda functions
- *          are available in the Amazon Web Services Serverless Application Repository, and can be selected through the Amazon Web Services Management Console when you create your
- *          Object Lambda Access Point.</p>
- *          <p>Example 1: PII Access Control - This Lambda function uses Amazon Comprehend, a natural language processing (NLP) service using machine learning to find insights and relationships in text. It automatically detects personally identifiable information (PII) such as names, addresses, dates, credit card numbers, and social security numbers from documents in your Amazon S3 bucket. </p>
- *          <p>Example 2: PII Redaction - This Lambda function uses Amazon Comprehend, a natural language processing (NLP) service using machine learning to find insights and relationships in text. It automatically redacts personally identifiable information (PII) such as names, addresses, dates, credit card numbers, and social security numbers from documents in your Amazon S3 bucket. </p>
- *          <p>Example 3: Decompression - The Lambda function S3ObjectLambdaDecompression, is equipped to decompress objects stored in S3 in one of six compressed file formats including bzip2, gzip, snappy, zlib, zstandard and ZIP. </p>
- *          <p>For information on how to view and use these functions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/olap-examples.html">Using Amazon Web Services built Lambda functions</a> in the <i>Amazon S3 User Guide</i>.</p>
+ *   <code>GetObject</code> call might differ from what Amazon S3 would normally return.</p>
+ * <p>You can include any number of metadata headers. When including a metadata header, it should be
+ * prefaced with <code>x-amz-meta</code>. For example, <code>x-amz-meta-my-custom-header: MyCustomValue</code>.
+ * The primary use case for this is to forward <code>GetObject</code> metadata.</p>
+ * <p>Amazon Web Services provides some prebuilt Lambda functions that you can use with S3 Object Lambda to detect and redact
+ * personally identifiable information (PII) and decompress S3 objects. These Lambda functions
+ * are available in the Amazon Web Services Serverless Application Repository, and can be selected through the Amazon Web Services Management Console when you create your
+ * Object Lambda Access Point.</p>
+ * <p>Example 1: PII Access Control - This Lambda function uses Amazon Comprehend, a natural language processing (NLP) service using machine learning to find insights and relationships in text. It automatically detects personally identifiable information (PII) such as names, addresses, dates, credit card numbers, and social security numbers from documents in your Amazon S3 bucket. </p>
+ * <p>Example 2: PII Redaction - This Lambda function uses Amazon Comprehend, a natural language processing (NLP) service using machine learning to find insights and relationships in text. It automatically redacts personally identifiable information (PII) such as names, addresses, dates, credit card numbers, and social security numbers from documents in your Amazon S3 bucket. </p>
+ * <p>Example 3: Decompression - The Lambda function S3ObjectLambdaDecompression, is equipped to decompress objects stored in S3 in one of six compressed file formats including bzip2, gzip, snappy, zlib, zstandard and ZIP. </p>
+ * <p>For information on how to view and use these functions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/olap-examples.html">Using Amazon Web Services built Lambda functions</a> in the <i>Amazon S3 User Guide</i>.</p>
  * @example
  * Use a bare-bones client and the command you need to make an API call.
  * ```javascript

--- a/clients/client-s3/src/models/models_0.ts
+++ b/clients/client-s3/src/models/models_0.ts
@@ -4,14 +4,14 @@ import { Readable } from "stream";
 
 /**
  * <p>Specifies the days since the initiation of an incomplete multipart upload that Amazon S3 will
- *          wait before permanently removing all parts of the upload. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config">
- *             Aborting Incomplete Multipart Uploads Using a Bucket Lifecycle Policy</a> in the
- *             <i>Amazon S3 User Guide</i>.</p>
+ * wait before permanently removing all parts of the upload. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config">
+ *    Aborting Incomplete Multipart Uploads Using a Bucket Lifecycle Policy</a> in the
+ *    <i>Amazon S3 User Guide</i>.</p>
  */
 export interface AbortIncompleteMultipartUpload {
   /**
    * <p>Specifies the number of days after which Amazon S3 aborts an incomplete multipart
-   *          upload.</p>
+   * upload.</p>
    */
   DaysAfterInitiation?: number;
 }
@@ -30,7 +30,7 @@ export type RequestCharged = "requester";
 export interface AbortMultipartUploadOutput {
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -49,8 +49,8 @@ export type RequestPayer = "requester";
 export interface AbortMultipartUploadRequest {
   /**
    * <p>The bucket name to which the upload was taking place. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -66,9 +66,9 @@ export interface AbortMultipartUploadRequest {
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -108,8 +108,8 @@ export type BucketAccelerateStatus = "Enabled" | "Suspended";
 
 /**
  * <p>Configures the transfer acceleration state for an Amazon S3 bucket. For more information, see
- *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html">Amazon S3
- *             Transfer Acceleration</a> in the <i>Amazon S3 User Guide</i>.</p>
+ *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html">Amazon S3
+ *    Transfer Acceleration</a> in the <i>Amazon S3 User Guide</i>.</p>
  */
 export interface AccelerateConfiguration {
   /**
@@ -140,36 +140,36 @@ export interface Grantee {
 
   /**
    * <p>Email address of the grantee.</p>
-   *          <note>
-   *             <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
-   *             <ul>
-   *                <li>
-   *                   <p>US East (N. Virginia)</p>
-   *                </li>
-   *                <li>
-   *                   <p>US West (N. California)</p>
-   *                </li>
-   *                <li>
-   *                   <p> US West (Oregon)</p>
-   *                </li>
-   *                <li>
-   *                   <p> Asia Pacific (Singapore)</p>
-   *                </li>
-   *                <li>
-   *                   <p>Asia Pacific (Sydney)</p>
-   *                </li>
-   *                <li>
-   *                   <p>Asia Pacific (Tokyo)</p>
-   *                </li>
-   *                <li>
-   *                   <p>Europe (Ireland)</p>
-   *                </li>
-   *                <li>
-   *                   <p>South America (São Paulo)</p>
-   *                </li>
-   *             </ul>
-   *             <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
-   *          </note>
+   * <note>
+   *    <p>Using email addresses to specify a grantee is only supported in the following Amazon Web Services Regions: </p>
+   *    <ul>
+   *       <li>
+   *          <p>US East (N. Virginia)</p>
+   *       </li>
+   *       <li>
+   *          <p>US West (N. California)</p>
+   *       </li>
+   *       <li>
+   *          <p> US West (Oregon)</p>
+   *       </li>
+   *       <li>
+   *          <p> Asia Pacific (Singapore)</p>
+   *       </li>
+   *       <li>
+   *          <p>Asia Pacific (Sydney)</p>
+   *       </li>
+   *       <li>
+   *          <p>Asia Pacific (Tokyo)</p>
+   *       </li>
+   *       <li>
+   *          <p>Europe (Ireland)</p>
+   *       </li>
+   *       <li>
+   *          <p>South America (São Paulo)</p>
+   *       </li>
+   *    </ul>
+   *    <p>For a list of all the Amazon S3 supported Regions and endpoints, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a> in the Amazon Web Services General Reference.</p>
+   * </note>
    */
   EmailAddress?: string;
 
@@ -280,7 +280,7 @@ export type OwnerOverride = "Destination";
 export interface AccessControlTranslation {
   /**
    * <p>Specifies the replica ownership. For default and valid values, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTreplication.html">PUT bucket
-   *             replication</a> in the <i>Amazon S3 API Reference</i>.</p>
+   *    replication</a> in the <i>Amazon S3 API Reference</i>.</p>
    */
   Owner: OwnerOverride | string | undefined;
 }
@@ -304,8 +304,8 @@ export interface CompleteMultipartUploadOutput {
 
   /**
    * <p>The name of the bucket that contains the newly created object. Does not return the access point ARN or access point alias if used.</p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket?: string;
 
@@ -316,36 +316,36 @@ export interface CompleteMultipartUploadOutput {
 
   /**
    * <p>If the object expiration is configured, this will contain the expiration date
-   *          (expiry-date) and rule ID (rule-id). The value of rule-id is URL encoded.</p>
+   * (expiry-date) and rule ID (rule-id). The value of rule-id is URL encoded.</p>
    */
   Expiration?: string;
 
   /**
    * <p>Entity tag that identifies the newly created object's data. Objects with different
-   *          object data will have different entity tags. The entity tag is an opaque string. The entity
-   *          tag may or may not be an MD5 digest of the object data. If the entity tag is not an MD5
-   *          digest of the object data, it will contain one or more nonhexadecimal characters and/or
-   *          will consist of less than 32 or more than 32 hexadecimal digits.</p>
+   * object data will have different entity tags. The entity tag is an opaque string. The entity
+   * tag may or may not be an MD5 digest of the object data. If the entity tag is not an MD5
+   * digest of the object data, it will contain one or more nonhexadecimal characters and/or
+   * will consist of less than 32 or more than 32 hexadecimal digits.</p>
    */
   ETag?: string;
 
   /**
    * <p>If you specified server-side encryption either with an Amazon S3-managed encryption key or an
-   *          Amazon Web Services KMS customer master key (CMK) in your initiate multipart upload request, the response
-   *          includes this header. It confirms the encryption algorithm that Amazon S3 used to encrypt the
-   *          object.</p>
+   * Amazon Web Services KMS customer master key (CMK) in your initiate multipart upload request, the response
+   * includes this header. It confirms the encryption algorithm that Amazon S3 used to encrypt the
+   * object.</p>
    */
   ServerSideEncryption?: ServerSideEncryption | string;
 
   /**
    * <p>Version ID of the newly created object, in case the bucket has versioning turned
-   *          on.</p>
+   * on.</p>
    */
   VersionId?: string;
 
   /**
    * <p>If present, specifies the ID of the Amazon Web Services Key Management Service (Amazon Web Services KMS) symmetric
-   *          customer managed customer master key (CMK) that was used for the object.</p>
+   * customer managed customer master key (CMK) that was used for the object.</p>
    */
   SSEKMSKeyId?: string;
 
@@ -356,7 +356,7 @@ export interface CompleteMultipartUploadOutput {
 
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -382,7 +382,7 @@ export interface CompletedPart {
 
   /**
    * <p>Part number that identifies the part. This is a positive integer between 1 and
-   *          10,000.</p>
+   * 10,000.</p>
    */
   PartNumber?: number;
 }
@@ -418,8 +418,8 @@ export namespace CompletedMultipartUpload {
 export interface CompleteMultipartUploadRequest {
   /**
    * <p>Name of the bucket to which the multipart upload was initiated.</p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -440,9 +440,9 @@ export interface CompleteMultipartUploadRequest {
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -508,33 +508,33 @@ export interface CopyObjectOutput {
 
   /**
    * <p>The server-side encryption algorithm used when storing this object in Amazon S3 (for example,
-   *          AES256, aws:kms).</p>
+   * AES256, aws:kms).</p>
    */
   ServerSideEncryption?: ServerSideEncryption | string;
 
   /**
    * <p>If server-side encryption with a customer-provided encryption key was requested, the
-   *          response will include this header confirming the encryption algorithm used.</p>
+   * response will include this header confirming the encryption algorithm used.</p>
    */
   SSECustomerAlgorithm?: string;
 
   /**
    * <p>If server-side encryption with a customer-provided encryption key was requested, the
-   *          response will include this header to provide round-trip message integrity verification of
-   *          the customer-provided encryption key.</p>
+   * response will include this header to provide round-trip message integrity verification of
+   * the customer-provided encryption key.</p>
    */
   SSECustomerKeyMD5?: string;
 
   /**
    * <p>If present, specifies the ID of the Amazon Web Services Key Management Service (Amazon Web Services KMS) symmetric
-   *          customer managed customer master key (CMK) that was used for the object.</p>
+   * customer managed customer master key (CMK) that was used for the object.</p>
    */
   SSEKMSKeyId?: string;
 
   /**
    * <p>If present, specifies the Amazon Web Services KMS Encryption Context to use for object encryption. The
-   *          value of this header is a base64-encoded UTF-8 string holding JSON with the encryption
-   *          context key-value pairs.</p>
+   * value of this header is a base64-encoded UTF-8 string holding JSON with the encryption
+   * context key-value pairs.</p>
    */
   SSEKMSEncryptionContext?: string;
 
@@ -545,7 +545,7 @@ export interface CopyObjectOutput {
 
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -591,14 +591,14 @@ export type TaggingDirective = "COPY" | "REPLACE";
 export interface CopyObjectRequest {
   /**
    * <p>The canned ACL to apply to the object.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   ACL?: ObjectCannedACL | string;
 
   /**
    * <p>The name of the destination bucket.</p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -614,8 +614,8 @@ export interface CopyObjectRequest {
 
   /**
    * <p>Specifies what content encodings have been applied to the object and thus what decoding
-   *          mechanisms must be applied to obtain the media-type referenced by the Content-Type header
-   *          field.</p>
+   * mechanisms must be applied to obtain the media-type referenced by the Content-Type header
+   * field.</p>
    */
   ContentEncoding?: string;
 
@@ -631,29 +631,29 @@ export interface CopyObjectRequest {
 
   /**
    * <p>Specifies the source object for the copy operation. You specify the value in one of two
-   *          formats, depending on whether you want to access the source object through an <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points.html">access point</a>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>For objects not accessed through an access point, specify the name of the source
-   *                bucket and the key of the source object, separated by a slash (/). For example, to
-   *                copy the object <code>reports/january.pdf</code> from the bucket
-   *                   <code>awsexamplebucket</code>, use
-   *                   <code>awsexamplebucket/reports/january.pdf</code>. The value must be URL
-   *                encoded.</p>
-   *             </li>
-   *             <li>
-   *                <p>For objects accessed through access points, specify the Amazon Resource Name (ARN) of the object as accessed through the access point, in the format <code>arn:aws:s3:<Region>:<account-id>:accesspoint/<access-point-name>/object/<key></code>. For example, to copy the object <code>reports/january.pdf</code> through access point <code>my-access-point</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3:us-west-2:123456789012:accesspoint/my-access-point/object/reports/january.pdf</code>. The value must be URL encoded.</p>
-   *                <note>
-   *                   <p>Amazon S3 supports copy operations using access points only when the source and destination buckets are in the same Amazon Web Services Region.</p>
-   *                </note>
-   *                <p>Alternatively, for objects accessed through Amazon S3 on Outposts, specify the ARN of the object as accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/object/<key></code>. For example, to copy the object <code>reports/january.pdf</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/object/reports/january.pdf</code>. The value must be URL encoded.  </p>
-   *             </li>
-   *          </ul>
-   *          <p>To copy a specific version of an object, append <code>?versionId=<version-id></code>
-   *          to the value (for example,
-   *             <code>awsexamplebucket/reports/january.pdf?versionId=QUpfdndhfd8438MNFDN93jdnJFkdmqnh893</code>).
-   *          If you don't specify a version ID, Amazon S3 copies the latest version of the source
-   *          object.</p>
+   * formats, depending on whether you want to access the source object through an <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points.html">access point</a>:</p>
+   * <ul>
+   *    <li>
+   *       <p>For objects not accessed through an access point, specify the name of the source
+   *       bucket and the key of the source object, separated by a slash (/). For example, to
+   *       copy the object <code>reports/january.pdf</code> from the bucket
+   *          <code>awsexamplebucket</code>, use
+   *          <code>awsexamplebucket/reports/january.pdf</code>. The value must be URL
+   *       encoded.</p>
+   *    </li>
+   *    <li>
+   *       <p>For objects accessed through access points, specify the Amazon Resource Name (ARN) of the object as accessed through the access point, in the format <code>arn:aws:s3:<Region>:<account-id>:accesspoint/<access-point-name>/object/<key></code>. For example, to copy the object <code>reports/january.pdf</code> through access point <code>my-access-point</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3:us-west-2:123456789012:accesspoint/my-access-point/object/reports/january.pdf</code>. The value must be URL encoded.</p>
+   *       <note>
+   *          <p>Amazon S3 supports copy operations using access points only when the source and destination buckets are in the same Amazon Web Services Region.</p>
+   *       </note>
+   *       <p>Alternatively, for objects accessed through Amazon S3 on Outposts, specify the ARN of the object as accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/object/<key></code>. For example, to copy the object <code>reports/january.pdf</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/object/reports/january.pdf</code>. The value must be URL encoded.  </p>
+   *    </li>
+   * </ul>
+   * <p>To copy a specific version of an object, append <code>?versionId=<version-id></code>
+   * to the value (for example,
+   *    <code>awsexamplebucket/reports/january.pdf?versionId=QUpfdndhfd8438MNFDN93jdnJFkdmqnh893</code>).
+   * If you don't specify a version ID, Amazon S3 copies the latest version of the source
+   * object.</p>
    */
   CopySource: string | undefined;
 
@@ -685,27 +685,27 @@ export interface CopyObjectRequest {
   /**
    * <p>Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the
    *       object.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantFullControl?: string;
 
   /**
    * <p>Allows grantee to read the object data and its
    *       metadata.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantRead?: string;
 
   /**
    * <p>Allows grantee to read the object ACL.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantReadACP?: string;
 
   /**
    * <p>Allows grantee to write the ACL for the applicable
    *       object.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantWriteACP?: string;
 
@@ -721,113 +721,113 @@ export interface CopyObjectRequest {
 
   /**
    * <p>Specifies whether the metadata is copied from the source object or replaced with
-   *          metadata provided in the request.</p>
+   * metadata provided in the request.</p>
    */
   MetadataDirective?: MetadataDirective | string;
 
   /**
    * <p>Specifies whether the object tag-set are copied from the source object or replaced with
-   *          tag-set provided in the request.</p>
+   * tag-set provided in the request.</p>
    */
   TaggingDirective?: TaggingDirective | string;
 
   /**
    * <p>The server-side encryption algorithm used when storing this object in Amazon S3 (for example,
-   *          AES256, aws:kms).</p>
+   * AES256, aws:kms).</p>
    */
   ServerSideEncryption?: ServerSideEncryption | string;
 
   /**
    * <p>By default, Amazon S3 uses the STANDARD Storage Class to store newly created objects. The
-   *          STANDARD storage class provides high durability and high availability. Depending on
-   *          performance needs, you can specify a different Storage Class. Amazon S3 on Outposts only uses
-   *          the OUTPOSTS Storage Class. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a> in the
-   *          <i>Amazon S3 User Guide</i>.</p>
+   * STANDARD storage class provides high durability and high availability. Depending on
+   * performance needs, you can specify a different Storage Class. Amazon S3 on Outposts only uses
+   * the OUTPOSTS Storage Class. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a> in the
+   * <i>Amazon S3 User Guide</i>.</p>
    */
   StorageClass?: StorageClass | string;
 
   /**
    * <p>If the bucket is configured as a website, redirects requests for this object to another
-   *          object in the same bucket or to an external URL. Amazon S3 stores the value of this header in
-   *          the object metadata.</p>
+   * object in the same bucket or to an external URL. Amazon S3 stores the value of this header in
+   * the object metadata.</p>
    */
   WebsiteRedirectLocation?: string;
 
   /**
    * <p>Specifies the algorithm to use to when encrypting the object (for example,
-   *          AES256).</p>
+   * AES256).</p>
    */
   SSECustomerAlgorithm?: string;
 
   /**
    * <p>Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This
-   *          value is used to store the object and then it is discarded; Amazon S3 does not store the
-   *          encryption key. The key must be appropriate for use with the algorithm specified in the
-   *             <code>x-amz-server-side-encryption-customer-algorithm</code> header.</p>
+   * value is used to store the object and then it is discarded; Amazon S3 does not store the
+   * encryption key. The key must be appropriate for use with the algorithm specified in the
+   *    <code>x-amz-server-side-encryption-customer-algorithm</code> header.</p>
    */
   SSECustomerKey?: string;
 
   /**
    * <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses
-   *          this header for a message integrity check to ensure that the encryption key was transmitted
-   *          without error.</p>
+   * this header for a message integrity check to ensure that the encryption key was transmitted
+   * without error.</p>
    */
   SSECustomerKeyMD5?: string;
 
   /**
    * <p>Specifies the Amazon Web Services KMS key ID to use for object encryption. All GET and PUT requests for
-   *          an object protected by Amazon Web Services KMS will fail if not made via SSL or using SigV4. For
-   *          information about configuring using any of the officially supported Amazon Web Services SDKs and Amazon Web Services CLI,
-   *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version">Specifying the
-   *             Signature Version in Request Authentication</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * an object protected by Amazon Web Services KMS will fail if not made via SSL or using SigV4. For
+   * information about configuring using any of the officially supported Amazon Web Services SDKs and Amazon Web Services CLI,
+   * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version">Specifying the
+   *    Signature Version in Request Authentication</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   SSEKMSKeyId?: string;
 
   /**
    * <p>Specifies the Amazon Web Services KMS Encryption Context to use for object encryption. The value of this
-   *          header is a base64-encoded UTF-8 string holding JSON with the encryption context key-value
-   *          pairs.</p>
+   * header is a base64-encoded UTF-8 string holding JSON with the encryption context key-value
+   * pairs.</p>
    */
   SSEKMSEncryptionContext?: string;
 
   /**
    * <p>Specifies whether Amazon S3 should use an S3 Bucket Key for object encryption with server-side encryption using AWS KMS (SSE-KMS). Setting this header to <code>true</code> causes Amazon S3 to use an S3 Bucket Key for object encryption with SSE-KMS. </p>
-   *          <p>Specifying this header with a COPY action doesn’t affect bucket-level settings for S3 Bucket Key.</p>
+   * <p>Specifying this header with a COPY action doesn’t affect bucket-level settings for S3 Bucket Key.</p>
    */
   BucketKeyEnabled?: boolean;
 
   /**
    * <p>Specifies the algorithm to use when decrypting the source object (for example,
-   *          AES256).</p>
+   * AES256).</p>
    */
   CopySourceSSECustomerAlgorithm?: string;
 
   /**
    * <p>Specifies the customer-provided encryption key for Amazon S3 to use to decrypt the source
-   *          object. The encryption key provided in this header must be one that was used when the
-   *          source object was created.</p>
+   * object. The encryption key provided in this header must be one that was used when the
+   * source object was created.</p>
    */
   CopySourceSSECustomerKey?: string;
 
   /**
    * <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses
-   *          this header for a message integrity check to ensure that the encryption key was transmitted
-   *          without error.</p>
+   * this header for a message integrity check to ensure that the encryption key was transmitted
+   * without error.</p>
    */
   CopySourceSSECustomerKeyMD5?: string;
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
   /**
    * <p>The tag-set for the object destination object this value must be used in conjunction
-   *          with the <code>TaggingDirective</code>. The tag-set must be encoded as URL Query
-   *          parameters.</p>
+   * with the <code>TaggingDirective</code>. The tag-set must be encoded as URL Query
+   * parameters.</p>
    */
   Tagging?: string;
 
@@ -872,7 +872,7 @@ export namespace CopyObjectRequest {
 
 /**
  * <p>The source object of the COPY action is not in the active tier and is only stored in
- *          Amazon S3 Glacier.</p>
+ * Amazon S3 Glacier.</p>
  */
 export interface ObjectNotInActiveTierError extends __SmithyException, $MetadataBearer {
   name: "ObjectNotInActiveTierError";
@@ -890,7 +890,7 @@ export namespace ObjectNotInActiveTierError {
 
 /**
  * <p>The requested bucket name is not available. The bucket namespace is shared by all users
- *          of the system. Select a different name and try again.</p>
+ * of the system. Select a different name and try again.</p>
  */
 export interface BucketAlreadyExists extends __SmithyException, $MetadataBearer {
   name: "BucketAlreadyExists";
@@ -908,9 +908,9 @@ export namespace BucketAlreadyExists {
 
 /**
  * <p>The bucket you tried to create already exists, and you own it. Amazon S3 returns this error
- *          in all Amazon Web Services Regions except in the North Virginia Region. For legacy compatibility, if you
- *          re-create an existing bucket that you already own in the North Virginia Region, Amazon S3
- *          returns 200 OK and resets the bucket access control lists (ACLs).</p>
+ * in all Amazon Web Services Regions except in the North Virginia Region. For legacy compatibility, if you
+ * re-create an existing bucket that you already own in the North Virginia Region, Amazon S3
+ * returns 200 OK and resets the bucket access control lists (ACLs).</p>
  */
 export interface BucketAlreadyOwnedByYou extends __SmithyException, $MetadataBearer {
   name: "BucketAlreadyOwnedByYou";
@@ -929,8 +929,8 @@ export namespace BucketAlreadyOwnedByYou {
 export interface CreateBucketOutput {
   /**
    * <p>Specifies the Region where the bucket will be created. If you are creating a bucket on
-   *          the US East (N. Virginia) Region (us-east-1), you do not need to specify the
-   *          location.</p>
+   * the US East (N. Virginia) Region (us-east-1), you do not need to specify the
+   * location.</p>
    */
   Location?: string;
 }
@@ -979,7 +979,7 @@ export type BucketLocationConstraint =
 export interface CreateBucketConfiguration {
   /**
    * <p>Specifies the Region where the bucket will be created. If you don't specify a Region,
-   *          the bucket is created in the US East (N. Virginia) Region (us-east-1).</p>
+   * the bucket is created in the US East (N. Virginia) Region (us-east-1).</p>
    */
   LocationConstraint?: BucketLocationConstraint | string;
 }
@@ -1006,7 +1006,7 @@ export interface CreateBucketRequest {
 
   /**
    * <p>Allows grantee the read, write, read ACP, and write ACP permissions on the
-   *          bucket.</p>
+   * bucket.</p>
    */
   GrantFullControl?: string;
 
@@ -1022,7 +1022,7 @@ export interface CreateBucketRequest {
 
   /**
    * <p>Allows grantee to create new objects in the bucket.</p>
-   *          <p>For the bucket and object owners of existing objects, also allows deletions and overwrites of those objects.</p>
+   * <p>For the bucket and object owners of existing objects, also allows deletions and overwrites of those objects.</p>
    */
   GrantWrite?: string;
 
@@ -1054,27 +1054,27 @@ export namespace CreateBucketRequest {
 export interface CreateMultipartUploadOutput {
   /**
    * <p>If the bucket has a lifecycle rule configured with an action to abort incomplete
-   *          multipart uploads and the prefix in the lifecycle rule matches the object name in the
-   *          request, the response includes this header. The header indicates when the initiated
-   *          multipart upload becomes eligible for an abort operation. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config">
-   *             Aborting Incomplete Multipart Uploads Using a Bucket Lifecycle Policy</a>.</p>
+   * multipart uploads and the prefix in the lifecycle rule matches the object name in the
+   * request, the response includes this header. The header indicates when the initiated
+   * multipart upload becomes eligible for an abort operation. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config">
+   *    Aborting Incomplete Multipart Uploads Using a Bucket Lifecycle Policy</a>.</p>
    *
-   *          <p>The response also includes the <code>x-amz-abort-rule-id</code> header that provides the
-   *          ID of the lifecycle configuration rule that defines this action.</p>
+   * <p>The response also includes the <code>x-amz-abort-rule-id</code> header that provides the
+   * ID of the lifecycle configuration rule that defines this action.</p>
    */
   AbortDate?: Date;
 
   /**
    * <p>This header is returned along with the <code>x-amz-abort-date</code> header. It
-   *          identifies the applicable lifecycle configuration rule that defines the action to abort
-   *          incomplete multipart uploads.</p>
+   * identifies the applicable lifecycle configuration rule that defines the action to abort
+   * incomplete multipart uploads.</p>
    */
   AbortRuleId?: string;
 
   /**
    * <p>The name of the bucket to which the multipart upload was initiated. Does not return the access point ARN or access point alias if used.</p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket?: string;
 
@@ -1090,33 +1090,33 @@ export interface CreateMultipartUploadOutput {
 
   /**
    * <p>The server-side encryption algorithm used when storing this object in Amazon S3 (for example,
-   *          AES256, aws:kms).</p>
+   * AES256, aws:kms).</p>
    */
   ServerSideEncryption?: ServerSideEncryption | string;
 
   /**
    * <p>If server-side encryption with a customer-provided encryption key was requested, the
-   *          response will include this header confirming the encryption algorithm used.</p>
+   * response will include this header confirming the encryption algorithm used.</p>
    */
   SSECustomerAlgorithm?: string;
 
   /**
    * <p>If server-side encryption with a customer-provided encryption key was requested, the
-   *          response will include this header to provide round-trip message integrity verification of
-   *          the customer-provided encryption key.</p>
+   * response will include this header to provide round-trip message integrity verification of
+   * the customer-provided encryption key.</p>
    */
   SSECustomerKeyMD5?: string;
 
   /**
    * <p>If present, specifies the ID of the Amazon Web Services Key Management Service (Amazon Web Services KMS) symmetric
-   *          customer managed customer master key (CMK) that was used for the object.</p>
+   * customer managed customer master key (CMK) that was used for the object.</p>
    */
   SSEKMSKeyId?: string;
 
   /**
    * <p>If present, specifies the Amazon Web Services KMS Encryption Context to use for object encryption. The
-   *          value of this header is a base64-encoded UTF-8 string holding JSON with the encryption
-   *          context key-value pairs.</p>
+   * value of this header is a base64-encoded UTF-8 string holding JSON with the encryption
+   * context key-value pairs.</p>
    */
   SSEKMSEncryptionContext?: string;
 
@@ -1127,7 +1127,7 @@ export interface CreateMultipartUploadOutput {
 
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -1146,14 +1146,14 @@ export namespace CreateMultipartUploadOutput {
 export interface CreateMultipartUploadRequest {
   /**
    * <p>The canned ACL to apply to the object.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   ACL?: ObjectCannedACL | string;
 
   /**
    * <p>The name of the bucket to which to initiate the upload</p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -1169,8 +1169,8 @@ export interface CreateMultipartUploadRequest {
 
   /**
    * <p>Specifies what content encodings have been applied to the object and thus what decoding
-   *          mechanisms must be applied to obtain the media-type referenced by the Content-Type header
-   *          field.</p>
+   * mechanisms must be applied to obtain the media-type referenced by the Content-Type header
+   * field.</p>
    */
   ContentEncoding?: string;
 
@@ -1192,27 +1192,27 @@ export interface CreateMultipartUploadRequest {
   /**
    * <p>Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the
    *       object.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantFullControl?: string;
 
   /**
    * <p>Allows grantee to read the object data and its
    *       metadata.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantRead?: string;
 
   /**
    * <p>Allows grantee to read the object ACL.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantReadACP?: string;
 
   /**
    * <p>Allows grantee to write the ACL for the applicable
    *       object.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantWriteACP?: string;
 
@@ -1228,74 +1228,74 @@ export interface CreateMultipartUploadRequest {
 
   /**
    * <p>The server-side encryption algorithm used when storing this object in Amazon S3 (for example,
-   *          AES256, aws:kms).</p>
+   * AES256, aws:kms).</p>
    */
   ServerSideEncryption?: ServerSideEncryption | string;
 
   /**
    * <p>By default, Amazon S3 uses the STANDARD Storage Class to store newly created objects. The
-   *          STANDARD storage class provides high durability and high availability. Depending on
-   *          performance needs, you can specify a different Storage Class. Amazon S3 on Outposts only uses
-   *          the OUTPOSTS Storage Class. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a> in the
-   *          <i>Amazon S3 User Guide</i>.</p>
+   * STANDARD storage class provides high durability and high availability. Depending on
+   * performance needs, you can specify a different Storage Class. Amazon S3 on Outposts only uses
+   * the OUTPOSTS Storage Class. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a> in the
+   * <i>Amazon S3 User Guide</i>.</p>
    */
   StorageClass?: StorageClass | string;
 
   /**
    * <p>If the bucket is configured as a website, redirects requests for this object to another
-   *          object in the same bucket or to an external URL. Amazon S3 stores the value of this header in
-   *          the object metadata.</p>
+   * object in the same bucket or to an external URL. Amazon S3 stores the value of this header in
+   * the object metadata.</p>
    */
   WebsiteRedirectLocation?: string;
 
   /**
    * <p>Specifies the algorithm to use to when encrypting the object (for example,
-   *          AES256).</p>
+   * AES256).</p>
    */
   SSECustomerAlgorithm?: string;
 
   /**
    * <p>Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This
-   *          value is used to store the object and then it is discarded; Amazon S3 does not store the
-   *          encryption key. The key must be appropriate for use with the algorithm specified in the
-   *             <code>x-amz-server-side-encryption-customer-algorithm</code> header.</p>
+   * value is used to store the object and then it is discarded; Amazon S3 does not store the
+   * encryption key. The key must be appropriate for use with the algorithm specified in the
+   *    <code>x-amz-server-side-encryption-customer-algorithm</code> header.</p>
    */
   SSECustomerKey?: string;
 
   /**
    * <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses
-   *          this header for a message integrity check to ensure that the encryption key was transmitted
-   *          without error.</p>
+   * this header for a message integrity check to ensure that the encryption key was transmitted
+   * without error.</p>
    */
   SSECustomerKeyMD5?: string;
 
   /**
    * <p>Specifies the ID of the symmetric customer managed Amazon Web Services KMS CMK to use for object
-   *          encryption. All GET and PUT requests for an object protected by Amazon Web Services KMS will fail if not
-   *          made via SSL or using SigV4. For information about configuring using any of the officially
-   *          supported Amazon Web Services SDKs and Amazon Web Services CLI, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version">Specifying the Signature Version in Request Authentication</a>
-   *          in the <i>Amazon S3 User Guide</i>.</p>
+   * encryption. All GET and PUT requests for an object protected by Amazon Web Services KMS will fail if not
+   * made via SSL or using SigV4. For information about configuring using any of the officially
+   * supported Amazon Web Services SDKs and Amazon Web Services CLI, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version">Specifying the Signature Version in Request Authentication</a>
+   * in the <i>Amazon S3 User Guide</i>.</p>
    */
   SSEKMSKeyId?: string;
 
   /**
    * <p>Specifies the Amazon Web Services KMS Encryption Context to use for object encryption. The value of this
-   *          header is a base64-encoded UTF-8 string holding JSON with the encryption context key-value
-   *          pairs.</p>
+   * header is a base64-encoded UTF-8 string holding JSON with the encryption context key-value
+   * pairs.</p>
    */
   SSEKMSEncryptionContext?: string;
 
   /**
    * <p>Specifies whether Amazon S3 should use an S3 Bucket Key for object encryption with server-side encryption using AWS KMS (SSE-KMS). Setting this header to <code>true</code> causes Amazon S3 to use an S3 Bucket Key for object encryption with SSE-KMS.</p>
-   *          <p>Specifying this header with an object action doesn’t affect bucket-level settings for S3 Bucket Key.</p>
+   * <p>Specifying this header with an object action doesn’t affect bucket-level settings for S3 Bucket Key.</p>
    */
   BucketKeyEnabled?: boolean;
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -1408,7 +1408,7 @@ export namespace DeleteBucketCorsRequest {
 export interface DeleteBucketEncryptionRequest {
   /**
    * <p>The name of the bucket containing the server-side encryption configuration to
-   *          delete.</p>
+   * delete.</p>
    */
   Bucket: string | undefined;
 
@@ -1629,19 +1629,19 @@ export namespace DeleteBucketWebsiteRequest {
 export interface DeleteObjectOutput {
   /**
    * <p>Specifies whether the versioned object that was permanently deleted was (true) or was
-   *          not (false) a delete marker.</p>
+   * not (false) a delete marker.</p>
    */
   DeleteMarker?: boolean;
 
   /**
    * <p>Returns the version ID of the delete marker created as a result of the DELETE
-   *          operation.</p>
+   * operation.</p>
    */
   VersionId?: string;
 
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -1658,8 +1658,8 @@ export namespace DeleteObjectOutput {
 export interface DeleteObjectRequest {
   /**
    * <p>The bucket name of the bucket containing the object. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -1670,8 +1670,8 @@ export interface DeleteObjectRequest {
 
   /**
    * <p>The concatenation of the authentication device's serial number, a space, and the value
-   *          that is displayed on your authentication device. Required to permanently delete a versioned
-   *          object if versioning is configured with MFA delete enabled.</p>
+   * that is displayed on your authentication device. Required to permanently delete a versioned
+   * object if versioning is configured with MFA delete enabled.</p>
    */
   MFA?: string;
 
@@ -1682,16 +1682,16 @@ export interface DeleteObjectRequest {
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
   /**
    * <p>Indicates whether S3 Object Lock should bypass Governance-mode restrictions to process
-   *          this operation. To use this header, you must have the <code>s3:PutBucketPublicAccessBlock</code>
-   *          permission.</p>
+   * this operation. To use this header, you must have the <code>s3:PutBucketPublicAccessBlock</code>
+   * permission.</p>
    */
   BypassGovernanceRetention?: boolean;
 
@@ -1726,15 +1726,15 @@ export interface DeletedObject {
 
   /**
    * <p>Specifies whether the versioned object that was permanently deleted was (true) or was
-   *          not (false) a delete marker. In a simple DELETE, this header indicates whether (true) or
-   *          not (false) a delete marker was created.</p>
+   * not (false) a delete marker. In a simple DELETE, this header indicates whether (true) or
+   * not (false) a delete marker was created.</p>
    */
   DeleteMarker?: boolean;
 
   /**
    * <p>The version ID of the delete marker created as a result of the DELETE operation. If you
-   *          delete a specific object version, the value returned by this header is the version ID of
-   *          the object version deleted.</p>
+   * delete a specific object version, the value returned by this header is the version ID of
+   * the object version deleted.</p>
    */
   DeleteMarkerVersionId?: string;
 }
@@ -1764,1878 +1764,1878 @@ export interface _Error {
 
   /**
    * <p>The error code is a string that uniquely identifies an error condition. It is meant to
-   *          be read and understood by programs that detect and handle errors by type. </p>
-   *          <p class="title">
-   *             <b>Amazon S3 error codes</b>
+   * be read and understood by programs that detect and handle errors by type. </p>
+   * <p class="title">
+   *    <b>Amazon S3 error codes</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> AccessDenied </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Access Denied</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 403 Forbidden</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> AccountProblem</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> There is a problem with your Amazon Web Services account
+   *             that prevents the action from completing successfully. Contact Amazon Web Services Support
+   *             for further assistance.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 403 Forbidden</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> AllAccessDisabled</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> All access to this Amazon S3 resource has been
+   *             disabled. Contact Amazon Web Services Support for further assistance.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 403 Forbidden</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> AmbiguousGrantByEmailAddress</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The email address you provided is
+   *             associated with more than one account.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> AuthorizationHeaderMalformed</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The authorization header you provided is
+   *             invalid.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> N/A</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> BadDigest</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The Content-MD5 you specified did not
+   *             match what we received.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> BucketAlreadyExists</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The requested bucket name is not
+   *             available. The bucket namespace is shared by all users of the system. Please
+   *             select a different name and try again.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 409 Conflict</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> BucketAlreadyOwnedByYou</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The bucket you tried to create already
+   *             exists, and you own it. Amazon S3 returns this error in all Amazon Web Services Regions except in
+   *             the North Virginia Region. For legacy compatibility, if you re-create an
+   *             existing bucket that you already own in the North Virginia Region, Amazon S3 returns
+   *             200 OK and resets the bucket access control lists (ACLs).</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> 409 Conflict (in all Regions except the North
+   *             Virginia Region) </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> BucketNotEmpty</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The bucket you tried to delete is not
+   *             empty.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 409 Conflict</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> CredentialsNotSupported</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> This request does not support
+   *             credentials.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> CrossLocationLoggingProhibited</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Cross-location logging not allowed.
+   *             Buckets in one geographic location cannot log information to a bucket in
+   *             another location.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 403 Forbidden</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> EntityTooSmall</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Your proposed upload is smaller than the
+   *             minimum allowed object size.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> EntityTooLarge</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Your proposed upload exceeds the maximum
+   *             allowed object size.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> ExpiredToken</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The provided token has expired.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> IllegalVersioningConfigurationException </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Indicates that the versioning
+   *             configuration specified in the request is invalid.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> IncompleteBody</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> You did not provide the number of bytes
+   *             specified by the Content-Length HTTP header</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> IncorrectNumberOfFilesInPostRequest</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> POST requires exactly one file upload per
+   *             request.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InlineDataTooLarge</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Inline data exceeds the maximum allowed
+   *             size.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InternalError</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> We encountered an internal error. Please
+   *             try again.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 500 Internal Server Error</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Server</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidAccessKeyId</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The Amazon Web Services access key ID you provided does
+   *             not exist in our records.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 403 Forbidden</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidAddressingHeader</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> You must specify the Anonymous
+   *             role.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> N/A</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidArgument</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Invalid Argument</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidBucketName</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The specified bucket is not valid.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidBucketState</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The request is not valid with the current
+   *             state of the bucket.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 409 Conflict</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidDigest</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The Content-MD5 you specified is not
+   *             valid.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidEncryptionAlgorithmError</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The encryption request you specified is
+   *             not valid. The valid value is AES256.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidLocationConstraint</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The specified location constraint is not
+   *             valid. For more information about Regions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro">How to Select a
+   *                Region for Your Buckets</a>. </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidObjectState</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The action is not valid for the current
+   *             state of the object.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 403 Forbidden</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidPart</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> One or more of the specified parts could
+   *             not be found. The part might not have been uploaded, or the specified entity
+   *             tag might not have matched the part's entity tag.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidPartOrder</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The list of parts was not in ascending
+   *             order. Parts list must be specified in order by part number.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidPayer</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> All access to this object has been
+   *             disabled. Please contact Amazon Web Services Support for further assistance.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 403 Forbidden</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidPolicyDocument</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The content of the form does not meet the
+   *             conditions specified in the policy document.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidRange</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The requested range cannot be
+   *             satisfied.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 416 Requested Range Not
+   *             Satisfiable</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidRequest</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Please use <code>AWS4-HMAC-SHA256</code>.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> N/A</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidRequest</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> SOAP requests must be made over an HTTPS
+   *             connection.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidRequest</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Amazon S3 Transfer Acceleration is not
+   *             supported for buckets with non-DNS compliant names.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> N/A</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidRequest</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Amazon S3 Transfer Acceleration is not
+   *             supported for buckets with periods (.) in their names.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> N/A</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidRequest</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Amazon S3 Transfer Accelerate endpoint only
+   *             supports virtual style requests.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> N/A</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidRequest</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Amazon S3 Transfer Accelerate is not configured
+   *             on this bucket.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> N/A</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidRequest</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Amazon S3 Transfer Accelerate is disabled on
+   *             this bucket.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> N/A</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidRequest</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Amazon S3 Transfer Acceleration is not
+   *             supported on this bucket. Contact Amazon Web Services Support for more information.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> N/A</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidRequest</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Amazon S3 Transfer Acceleration cannot be
+   *             enabled on this bucket. Contact Amazon Web Services Support for more information.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> N/A</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidSecurity</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The provided security credentials are not
+   *             valid.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 403 Forbidden</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidSOAPRequest</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The SOAP request body is invalid.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidStorageClass</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The storage class you specified is not
+   *             valid.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidTargetBucketForLogging</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The target bucket for logging does not
+   *             exist, is not owned by you, or does not have the appropriate grants for the
+   *             log-delivery group. </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidToken</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The provided token is malformed or
+   *             otherwise invalid.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> InvalidURI</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Couldn't parse the specified URI.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> KeyTooLongError</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Your key is too long.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> MalformedACLError</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The XML you provided was not well-formed
+   *             or did not validate against our published schema.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> MalformedPOSTRequest </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The body of your POST request is not
+   *             well-formed multipart/form-data.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> MalformedXML</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> This happens when the user sends malformed
+   *             XML (XML that doesn't conform to the published XSD) for the configuration. The
+   *             error message is, "The XML you provided was not well-formed or did not validate
+   *             against our published schema." </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> MaxMessageLengthExceeded</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Your request was too big.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> MaxPostPreDataLengthExceededError</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Your POST request fields preceding the
+   *             upload file were too large.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> MetadataTooLarge</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Your metadata headers exceed the maximum
+   *             allowed metadata size.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> MethodNotAllowed</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The specified method is not allowed
+   *             against this resource.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 405 Method Not Allowed</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> MissingAttachment</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> A SOAP attachment was expected, but none
+   *             were found.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> N/A</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> MissingContentLength</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> You must provide the Content-Length HTTP
+   *             header.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 411 Length Required</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> MissingRequestBodyError</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> This happens when the user sends an empty
+   *             XML document as a request. The error message is, "Request body is empty."
    *          </p>
-   *          <ul>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> AccessDenied </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Access Denied</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 403 Forbidden</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> AccountProblem</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> There is a problem with your Amazon Web Services account
-   *                      that prevents the action from completing successfully. Contact Amazon Web Services Support
-   *                      for further assistance.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 403 Forbidden</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> AllAccessDisabled</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> All access to this Amazon S3 resource has been
-   *                      disabled. Contact Amazon Web Services Support for further assistance.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 403 Forbidden</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> AmbiguousGrantByEmailAddress</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The email address you provided is
-   *                      associated with more than one account.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> AuthorizationHeaderMalformed</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The authorization header you provided is
-   *                      invalid.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> N/A</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> BadDigest</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The Content-MD5 you specified did not
-   *                      match what we received.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> BucketAlreadyExists</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The requested bucket name is not
-   *                      available. The bucket namespace is shared by all users of the system. Please
-   *                      select a different name and try again.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 409 Conflict</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> BucketAlreadyOwnedByYou</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The bucket you tried to create already
-   *                      exists, and you own it. Amazon S3 returns this error in all Amazon Web Services Regions except in
-   *                      the North Virginia Region. For legacy compatibility, if you re-create an
-   *                      existing bucket that you already own in the North Virginia Region, Amazon S3 returns
-   *                      200 OK and resets the bucket access control lists (ACLs).</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> 409 Conflict (in all Regions except the North
-   *                      Virginia Region) </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> BucketNotEmpty</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The bucket you tried to delete is not
-   *                      empty.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 409 Conflict</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> CredentialsNotSupported</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> This request does not support
-   *                      credentials.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> CrossLocationLoggingProhibited</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Cross-location logging not allowed.
-   *                      Buckets in one geographic location cannot log information to a bucket in
-   *                      another location.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 403 Forbidden</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> EntityTooSmall</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Your proposed upload is smaller than the
-   *                      minimum allowed object size.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> EntityTooLarge</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Your proposed upload exceeds the maximum
-   *                      allowed object size.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> ExpiredToken</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The provided token has expired.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> IllegalVersioningConfigurationException </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Indicates that the versioning
-   *                      configuration specified in the request is invalid.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> IncompleteBody</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> You did not provide the number of bytes
-   *                      specified by the Content-Length HTTP header</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> IncorrectNumberOfFilesInPostRequest</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> POST requires exactly one file upload per
-   *                      request.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InlineDataTooLarge</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Inline data exceeds the maximum allowed
-   *                      size.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InternalError</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> We encountered an internal error. Please
-   *                      try again.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 500 Internal Server Error</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Server</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidAccessKeyId</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The Amazon Web Services access key ID you provided does
-   *                      not exist in our records.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 403 Forbidden</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidAddressingHeader</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> You must specify the Anonymous
-   *                      role.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> N/A</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidArgument</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Invalid Argument</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidBucketName</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The specified bucket is not valid.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidBucketState</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The request is not valid with the current
-   *                      state of the bucket.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 409 Conflict</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidDigest</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The Content-MD5 you specified is not
-   *                      valid.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidEncryptionAlgorithmError</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The encryption request you specified is
-   *                      not valid. The valid value is AES256.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidLocationConstraint</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The specified location constraint is not
-   *                      valid. For more information about Regions, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro">How to Select a
-   *                         Region for Your Buckets</a>. </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidObjectState</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The action is not valid for the current
-   *                      state of the object.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 403 Forbidden</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidPart</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> One or more of the specified parts could
-   *                      not be found. The part might not have been uploaded, or the specified entity
-   *                      tag might not have matched the part's entity tag.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidPartOrder</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The list of parts was not in ascending
-   *                      order. Parts list must be specified in order by part number.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidPayer</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> All access to this object has been
-   *                      disabled. Please contact Amazon Web Services Support for further assistance.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 403 Forbidden</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidPolicyDocument</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The content of the form does not meet the
-   *                      conditions specified in the policy document.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidRange</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The requested range cannot be
-   *                      satisfied.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 416 Requested Range Not
-   *                      Satisfiable</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidRequest</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Please use <code>AWS4-HMAC-SHA256</code>.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> N/A</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidRequest</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> SOAP requests must be made over an HTTPS
-   *                      connection.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidRequest</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Amazon S3 Transfer Acceleration is not
-   *                      supported for buckets with non-DNS compliant names.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> N/A</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidRequest</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Amazon S3 Transfer Acceleration is not
-   *                      supported for buckets with periods (.) in their names.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> N/A</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidRequest</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Amazon S3 Transfer Accelerate endpoint only
-   *                      supports virtual style requests.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> N/A</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidRequest</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Amazon S3 Transfer Accelerate is not configured
-   *                      on this bucket.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> N/A</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidRequest</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Amazon S3 Transfer Accelerate is disabled on
-   *                      this bucket.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> N/A</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidRequest</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Amazon S3 Transfer Acceleration is not
-   *                      supported on this bucket. Contact Amazon Web Services Support for more information.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> N/A</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidRequest</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Amazon S3 Transfer Acceleration cannot be
-   *                      enabled on this bucket. Contact Amazon Web Services Support for more information.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> N/A</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidSecurity</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The provided security credentials are not
-   *                      valid.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 403 Forbidden</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidSOAPRequest</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The SOAP request body is invalid.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidStorageClass</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The storage class you specified is not
-   *                      valid.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidTargetBucketForLogging</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The target bucket for logging does not
-   *                      exist, is not owned by you, or does not have the appropriate grants for the
-   *                      log-delivery group. </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidToken</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The provided token is malformed or
-   *                      otherwise invalid.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> InvalidURI</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Couldn't parse the specified URI.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> KeyTooLongError</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Your key is too long.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> MalformedACLError</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The XML you provided was not well-formed
-   *                      or did not validate against our published schema.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> MalformedPOSTRequest </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The body of your POST request is not
-   *                      well-formed multipart/form-data.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> MalformedXML</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> This happens when the user sends malformed
-   *                      XML (XML that doesn't conform to the published XSD) for the configuration. The
-   *                      error message is, "The XML you provided was not well-formed or did not validate
-   *                      against our published schema." </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> MaxMessageLengthExceeded</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Your request was too big.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> MaxPostPreDataLengthExceededError</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Your POST request fields preceding the
-   *                      upload file were too large.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> MetadataTooLarge</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Your metadata headers exceed the maximum
-   *                      allowed metadata size.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> MethodNotAllowed</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The specified method is not allowed
-   *                      against this resource.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 405 Method Not Allowed</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> MissingAttachment</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> A SOAP attachment was expected, but none
-   *                      were found.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> N/A</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> MissingContentLength</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> You must provide the Content-Length HTTP
-   *                      header.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 411 Length Required</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> MissingRequestBodyError</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> This happens when the user sends an empty
-   *                      XML document as a request. The error message is, "Request body is empty."
-   *                   </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> MissingSecurityElement</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The SOAP 1.1 request is missing a security
-   *                      element.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> MissingSecurityHeader</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Your request is missing a required
-   *                      header.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> NoLoggingStatusForKey</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> There is no such thing as a logging status
-   *                      subresource for a key.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> NoSuchBucket</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The specified bucket does not
-   *                      exist.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 404 Not Found</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> NoSuchBucketPolicy</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The specified bucket does not have a
-   *                      bucket policy.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 404 Not Found</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> NoSuchKey</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The specified key does not exist.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 404 Not Found</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> NoSuchLifecycleConfiguration</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The lifecycle configuration does not
-   *                      exist. </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 404 Not Found</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> NoSuchUpload</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The specified multipart upload does not
-   *                      exist. The upload ID might be invalid, or the multipart upload might have been
-   *                      aborted or completed.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 404 Not Found</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> NoSuchVersion </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Indicates that the version ID specified in
-   *                      the request does not match an existing version.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 404 Not Found</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> NotImplemented</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> A header you provided implies
-   *                      functionality that is not implemented.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 501 Not Implemented</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Server</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> NotSignedUp</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Your account is not signed up for the Amazon S3
-   *                      service. You must sign up before you can use Amazon S3. You can sign up at the
-   *                      following URL: <a href="http://aws.amazon.com/s3">Amazon S3</a>
-   *                      </p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 403 Forbidden</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> OperationAborted</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> A conflicting conditional action is
-   *                      currently in progress against this resource. Try again.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 409 Conflict</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> PermanentRedirect</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The bucket you are attempting to access
-   *                      must be addressed using the specified endpoint. Send all future requests to
-   *                      this endpoint.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 301 Moved Permanently</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> PreconditionFailed</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> At least one of the preconditions you
-   *                      specified did not hold.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 412 Precondition Failed</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> Redirect</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Temporary redirect.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 307 Moved Temporarily</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> RestoreAlreadyInProgress</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Object restore is already in
-   *                      progress.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 409 Conflict</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> RequestIsNotMultiPartContent</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Bucket POST must be of the enclosure-type
-   *                      multipart/form-data.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> RequestTimeout</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Your socket connection to the server was
-   *                      not read from or written to within the timeout period.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> RequestTimeTooSkewed</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The difference between the request time
-   *                      and the server's time is too large.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 403 Forbidden</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> RequestTorrentOfBucketError</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Requesting the torrent file of a bucket is
-   *                      not permitted.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> SignatureDoesNotMatch</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The request signature we calculated does
-   *                      not match the signature you provided. Check your Amazon Web Services secret access key and
-   *                      signing method. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html">REST Authentication</a> and
-   *                         <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/SOAPAuthentication.html">SOAP Authentication</a>
-   *                      for details.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 403 Forbidden</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> ServiceUnavailable</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Reduce your request rate.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 503 Service Unavailable</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Server</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> SlowDown</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> Reduce your request rate.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 503 Slow Down</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Server</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> TemporaryRedirect</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> You are being redirected to the bucket
-   *                      while DNS updates.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 307 Moved Temporarily</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> TokenRefreshRequired</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The provided token must be
-   *                      refreshed.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> TooManyBuckets</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> You have attempted to create more buckets
-   *                      than allowed.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> UnexpectedContent</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> This request does not support
-   *                      content.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> UnresolvableGrantByEmailAddress</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The email address you provided does not
-   *                      match any account on record.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *             <li>
-   *                <ul>
-   *                   <li>
-   *                      <p>
-   *                         <i>Code:</i> UserKeyMustBeSpecified</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>Description:</i> The bucket POST must contain the specified
-   *                      field name. If it is specified, check the order of the fields.</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>HTTP Status Code:</i> 400 Bad Request</p>
-   *                   </li>
-   *                   <li>
-   *                      <p>
-   *                         <i>SOAP Fault Code Prefix:</i> Client</p>
-   *                   </li>
-   *                </ul>
-   *             </li>
-   *          </ul>
-   *          <p></p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> MissingSecurityElement</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The SOAP 1.1 request is missing a security
+   *             element.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> MissingSecurityHeader</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Your request is missing a required
+   *             header.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> NoLoggingStatusForKey</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> There is no such thing as a logging status
+   *             subresource for a key.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> NoSuchBucket</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The specified bucket does not
+   *             exist.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 404 Not Found</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> NoSuchBucketPolicy</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The specified bucket does not have a
+   *             bucket policy.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 404 Not Found</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> NoSuchKey</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The specified key does not exist.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 404 Not Found</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> NoSuchLifecycleConfiguration</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The lifecycle configuration does not
+   *             exist. </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 404 Not Found</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> NoSuchUpload</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The specified multipart upload does not
+   *             exist. The upload ID might be invalid, or the multipart upload might have been
+   *             aborted or completed.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 404 Not Found</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> NoSuchVersion </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Indicates that the version ID specified in
+   *             the request does not match an existing version.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 404 Not Found</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> NotImplemented</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> A header you provided implies
+   *             functionality that is not implemented.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 501 Not Implemented</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Server</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> NotSignedUp</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Your account is not signed up for the Amazon S3
+   *             service. You must sign up before you can use Amazon S3. You can sign up at the
+   *             following URL: <a href="http://aws.amazon.com/s3">Amazon S3</a>
+   *             </p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 403 Forbidden</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> OperationAborted</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> A conflicting conditional action is
+   *             currently in progress against this resource. Try again.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 409 Conflict</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> PermanentRedirect</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The bucket you are attempting to access
+   *             must be addressed using the specified endpoint. Send all future requests to
+   *             this endpoint.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 301 Moved Permanently</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> PreconditionFailed</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> At least one of the preconditions you
+   *             specified did not hold.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 412 Precondition Failed</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> Redirect</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Temporary redirect.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 307 Moved Temporarily</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> RestoreAlreadyInProgress</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Object restore is already in
+   *             progress.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 409 Conflict</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> RequestIsNotMultiPartContent</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Bucket POST must be of the enclosure-type
+   *             multipart/form-data.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> RequestTimeout</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Your socket connection to the server was
+   *             not read from or written to within the timeout period.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> RequestTimeTooSkewed</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The difference between the request time
+   *             and the server's time is too large.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 403 Forbidden</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> RequestTorrentOfBucketError</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Requesting the torrent file of a bucket is
+   *             not permitted.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> SignatureDoesNotMatch</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The request signature we calculated does
+   *             not match the signature you provided. Check your Amazon Web Services secret access key and
+   *             signing method. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html">REST Authentication</a> and
+   *                <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/SOAPAuthentication.html">SOAP Authentication</a>
+   *             for details.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 403 Forbidden</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> ServiceUnavailable</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Reduce your request rate.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 503 Service Unavailable</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Server</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> SlowDown</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> Reduce your request rate.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 503 Slow Down</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Server</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> TemporaryRedirect</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> You are being redirected to the bucket
+   *             while DNS updates.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 307 Moved Temporarily</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> TokenRefreshRequired</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The provided token must be
+   *             refreshed.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> TooManyBuckets</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> You have attempted to create more buckets
+   *             than allowed.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> UnexpectedContent</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> This request does not support
+   *             content.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> UnresolvableGrantByEmailAddress</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The email address you provided does not
+   *             match any account on record.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   *    <li>
+   *       <ul>
+   *          <li>
+   *             <p>
+   *                <i>Code:</i> UserKeyMustBeSpecified</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>Description:</i> The bucket POST must contain the specified
+   *             field name. If it is specified, check the order of the fields.</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>HTTP Status Code:</i> 400 Bad Request</p>
+   *          </li>
+   *          <li>
+   *             <p>
+   *                <i>SOAP Fault Code Prefix:</i> Client</p>
+   *          </li>
+   *       </ul>
+   *    </li>
+   * </ul>
+   * <p></p>
    */
   Code?: string;
 
   /**
    * <p>The error message contains a generic description of the error condition in English. It
-   *          is intended for a human audience. Simple programs display the message directly to the end
-   *          user if they encounter an error condition they don't know how or don't care to handle.
-   *          Sophisticated programs with more exhaustive error handling and proper internationalization
-   *          are more likely to ignore the error message.</p>
+   * is intended for a human audience. Simple programs display the message directly to the end
+   * user if they encounter an error condition they don't know how or don't care to handle.
+   * Sophisticated programs with more exhaustive error handling and proper internationalization
+   * are more likely to ignore the error message.</p>
    */
   Message?: string;
 }
@@ -3652,19 +3652,19 @@ export namespace _Error {
 export interface DeleteObjectsOutput {
   /**
    * <p>Container element for a successful delete. It identifies the object that was
-   *          successfully deleted.</p>
+   * successfully deleted.</p>
    */
   Deleted?: DeletedObject[];
 
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 
   /**
    * <p>Container for a failed delete action that describes the object that Amazon S3 attempted to
-   *          delete and the error it encountered.</p>
+   * delete and the error it encountered.</p>
    */
   Errors?: _Error[];
 }
@@ -3684,11 +3684,11 @@ export namespace DeleteObjectsOutput {
 export interface ObjectIdentifier {
   /**
    * <p>Key name of the object.</p>
-   *          <important>
-   *             <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
-   *          XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
-   *             XML related object key constraints</a>.</p>
-   *          </important>
+   * <important>
+   *    <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
+   * XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
+   *    XML related object key constraints</a>.</p>
+   * </important>
    */
   Key: string | undefined;
 
@@ -3718,7 +3718,7 @@ export interface Delete {
 
   /**
    * <p>Element to enable quiet mode for the request. When you add this element, you must set
-   *          its value to true.</p>
+   * its value to true.</p>
    */
   Quiet?: boolean;
 }
@@ -3735,30 +3735,30 @@ export namespace Delete {
 export interface DeleteObjectsRequest {
   /**
    * <p>The bucket name containing the objects to delete. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
   /**
    * <p>The concatenation of the authentication device's serial number, a space, and the value
-   *          that is displayed on your authentication device. Required to permanently delete a versioned
-   *          object if versioning is configured with MFA delete enabled.</p>
+   * that is displayed on your authentication device. Required to permanently delete a versioned
+   * object if versioning is configured with MFA delete enabled.</p>
    */
   MFA?: string;
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
   /**
    * <p>Specifies whether you want to delete this object even if it has a Governance-type Object
-   *          Lock in place. To use this header, you must have the <code>s3:PutBucketPublicAccessBlock</code>
-   *          permission.</p>
+   * Lock in place. To use this header, you must have the <code>s3:PutBucketPublicAccessBlock</code>
+   * permission.</p>
    */
   BypassGovernanceRetention?: boolean;
 
@@ -3801,8 +3801,8 @@ export namespace DeleteObjectTaggingOutput {
 export interface DeleteObjectTaggingRequest {
   /**
    * <p>The bucket name containing the objects from which to remove the tags. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -3958,13 +3958,13 @@ export namespace Tag {
 
 /**
  * <p>A conjunction (logical AND) of predicates, which is used in evaluating a metrics filter.
- *          The operator must have at least two predicates in any combination, and an object must match
- *          all of the predicates for the filter to apply.</p>
+ * The operator must have at least two predicates in any combination, and an object must match
+ * all of the predicates for the filter to apply.</p>
  */
 export interface AnalyticsAndOperator {
   /**
    * <p>The prefix to use when evaluating an AND predicate: The prefix that an object must have
-   *          to be included in the metrics results.</p>
+   * to be included in the metrics results.</p>
    */
   Prefix?: string;
 
@@ -3985,8 +3985,8 @@ export namespace AnalyticsAndOperator {
 
 /**
  * <p>The filter used to describe a set of objects for analyses. A filter must have exactly
- *          one prefix, one tag, or one conjunction (AnalyticsAndOperator). If no filter is provided,
- *          all objects will be considered in any analysis.</p>
+ * one prefix, one tag, or one conjunction (AnalyticsAndOperator). If no filter is provided,
+ * all objects will be considered in any analysis.</p>
  */
 export type AnalyticsFilter =
   | AnalyticsFilter.AndMember
@@ -4017,7 +4017,7 @@ export namespace AnalyticsFilter {
 
   /**
    * <p>A conjunction (logical AND) of predicates, which is used in evaluating an analytics
-   *          filter. The operator must have at least two predicates.</p>
+   * filter. The operator must have at least two predicates.</p>
    */
   export interface AndMember {
     Prefix?: never;
@@ -4071,11 +4071,11 @@ export interface AnalyticsS3BucketDestination {
 
   /**
    * <p>The account ID that owns the destination S3 bucket. If no account ID is provided, the
-   *          owner is not validated before exporting data.</p>
-   *          <note>
-   *             <p> Although this value is optional, we strongly recommend that you set it to help
-   *             prevent problems if the destination bucket ownership changes. </p>
-   *          </note>
+   * owner is not validated before exporting data.</p>
+   * <note>
+   *    <p> Although this value is optional, we strongly recommend that you set it to help
+   *    prevent problems if the destination bucket ownership changes. </p>
+   * </note>
    */
   BucketAccountId?: string;
 
@@ -4122,12 +4122,12 @@ export type StorageClassAnalysisSchemaVersion = "V_1";
 
 /**
  * <p>Container for data related to the storage class analysis for an Amazon S3 bucket for
- *          export.</p>
+ * export.</p>
  */
 export interface StorageClassAnalysisDataExport {
   /**
    * <p>The version of the output schema to use when exporting data. Must be
-   *          <code>V_1</code>.</p>
+   * <code>V_1</code>.</p>
    */
   OutputSchemaVersion: StorageClassAnalysisSchemaVersion | string | undefined;
 
@@ -4148,12 +4148,12 @@ export namespace StorageClassAnalysisDataExport {
 
 /**
  * <p>Specifies data related to access patterns to be collected and made available to analyze
- *          the tradeoffs between different storage classes for an Amazon S3 bucket.</p>
+ * the tradeoffs between different storage classes for an Amazon S3 bucket.</p>
  */
 export interface StorageClassAnalysis {
   /**
    * <p>Specifies how data related to the storage class analysis for an Amazon S3 bucket should be
-   *          exported.</p>
+   * exported.</p>
    */
   DataExport?: StorageClassAnalysisDataExport;
 }
@@ -4178,14 +4178,14 @@ export interface AnalyticsConfiguration {
 
   /**
    * <p>The filter used to describe a set of objects for analyses. A filter must have exactly
-   *          one prefix, one tag, or one conjunction (AnalyticsAndOperator). If no filter is provided,
-   *          all objects will be considered in any analysis.</p>
+   * one prefix, one tag, or one conjunction (AnalyticsAndOperator). If no filter is provided,
+   * all objects will be considered in any analysis.</p>
    */
   Filter?: AnalyticsFilter;
 
   /**
    * <p> Contains data related to access patterns to be collected and made available to analyze
-   *          the tradeoffs between different storage classes. </p>
+   * the tradeoffs between different storage classes. </p>
    */
   StorageClassAnalysis: StorageClassAnalysis | undefined;
 }
@@ -4256,14 +4256,14 @@ export interface CORSRule {
 
   /**
    * <p>Headers that are specified in the <code>Access-Control-Request-Headers</code> header.
-   *          These headers are allowed in a preflight OPTIONS request. In response to any preflight
-   *          OPTIONS request, Amazon S3 returns any requested headers that are allowed.</p>
+   * These headers are allowed in a preflight OPTIONS request. In response to any preflight
+   * OPTIONS request, Amazon S3 returns any requested headers that are allowed.</p>
    */
   AllowedHeaders?: string[];
 
   /**
    * <p>An HTTP method that you allow the origin to execute. Valid values are <code>GET</code>,
-   *             <code>PUT</code>, <code>HEAD</code>, <code>POST</code>, and <code>DELETE</code>.</p>
+   *    <code>PUT</code>, <code>HEAD</code>, <code>POST</code>, and <code>DELETE</code>.</p>
    */
   AllowedMethods: string[] | undefined;
 
@@ -4274,14 +4274,14 @@ export interface CORSRule {
 
   /**
    * <p>One or more headers in the response that you want customers to be able to access from
-   *          their applications (for example, from a JavaScript <code>XMLHttpRequest</code>
-   *          object).</p>
+   * their applications (for example, from a JavaScript <code>XMLHttpRequest</code>
+   * object).</p>
    */
   ExposeHeaders?: string[];
 
   /**
    * <p>The time in seconds that your browser is to cache the preflight response for the
-   *          specified resource.</p>
+   * specified resource.</p>
    */
   MaxAgeSeconds?: number;
 }
@@ -4298,7 +4298,7 @@ export namespace CORSRule {
 export interface GetBucketCorsOutput {
   /**
    * <p>A set of origins and methods (cross-origin access that you want to allow). You can add
-   *          up to 100 rules to the configuration.</p>
+   * up to 100 rules to the configuration.</p>
    */
   CORSRules?: CORSRule[];
 }
@@ -4335,9 +4335,9 @@ export namespace GetBucketCorsRequest {
 
 /**
  * <p>Describes the default server-side encryption to apply to new objects in the bucket. If a
- *          PUT Object request doesn't specify any server-side encryption, this default encryption will
- *          be applied. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTencryption.html">PUT Bucket encryption</a> in
- *          the <i>Amazon S3 API Reference</i>.</p>
+ * PUT Object request doesn't specify any server-side encryption, this default encryption will
+ * be applied. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTencryption.html">PUT Bucket encryption</a> in
+ * the <i>Amazon S3 API Reference</i>.</p>
  */
 export interface ServerSideEncryptionByDefault {
   /**
@@ -4349,28 +4349,28 @@ export interface ServerSideEncryptionByDefault {
    * <p>Amazon Web Services Key Management Service (KMS) customer Amazon Web Services KMS key ID to use for the default
    *         encryption. This parameter is allowed if and only if <code>SSEAlgorithm</code> is set to
    *         <code>aws:kms</code>.</p>
-   *          <p>You can specify the key ID or the Amazon Resource Name (ARN) of the KMS key. However, if you
+   * <p>You can specify the key ID or the Amazon Resource Name (ARN) of the KMS key. However, if you
    *         are using encryption with cross-account operations, you must use a fully qualified KMS key ARN.
    *         For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html#bucket-encryption-update-bucket-policy">Using encryption for cross-account operations</a>. </p>
-   *          <p>
-   *             <b>For example:</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>
-   *                </p>
-   *             </li>
-   *             <li>
-   *                <p>Key ARN:
-   *                   <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>
-   *                </p>
-   *             </li>
-   *          </ul>
-   *          <important>
-   *             <p>Amazon S3 only supports symmetric KMS keys and not asymmetric KMS keys. For more information, see
-   *            <a href="https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html">Using symmetric and
-   *            asymmetric keys</a> in the <i>Amazon Web Services Key Management Service Developer Guide</i>.</p>
-   *          </important>
+   * <p>
+   *    <b>For example:</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *       <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>
+   *       </p>
+   *    </li>
+   *    <li>
+   *       <p>Key ARN:
+   *          <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>
+   *       </p>
+   *    </li>
+   * </ul>
+   * <important>
+   *    <p>Amazon S3 only supports symmetric KMS keys and not asymmetric KMS keys. For more information, see
+   *   <a href="https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html">Using symmetric and
+   *   asymmetric keys</a> in the <i>Amazon Web Services Key Management Service Developer Guide</i>.</p>
+   * </important>
    */
   KMSMasterKeyID?: string;
 }
@@ -4391,14 +4391,14 @@ export namespace ServerSideEncryptionByDefault {
 export interface ServerSideEncryptionRule {
   /**
    * <p>Specifies the default server-side encryption to apply to new objects in the bucket. If a
-   *          PUT Object request doesn't specify any server-side encryption, this default encryption will
-   *          be applied.</p>
+   * PUT Object request doesn't specify any server-side encryption, this default encryption will
+   * be applied.</p>
    */
   ApplyServerSideEncryptionByDefault?: ServerSideEncryptionByDefault;
 
   /**
    * <p>Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket. Existing objects are not affected. Setting the <code>BucketKeyEnabled</code> element to <code>true</code> causes Amazon S3 to use an S3 Bucket Key. By default, S3 Bucket Key is not enabled.</p>
-   *          <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html">Amazon S3 Bucket Keys</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   BucketKeyEnabled?: boolean;
 }
@@ -4423,7 +4423,7 @@ export namespace ServerSideEncryptionRule {
 export interface ServerSideEncryptionConfiguration {
   /**
    * <p>Container for information about a particular server-side encryption configuration
-   *          rule.</p>
+   * rule.</p>
    */
   Rules: ServerSideEncryptionRule[] | undefined;
 }
@@ -4462,7 +4462,7 @@ export namespace GetBucketEncryptionOutput {
 export interface GetBucketEncryptionRequest {
   /**
    * <p>The name of the bucket from which the server-side encryption configuration is
-   *          retrieved.</p>
+   * retrieved.</p>
    */
   Bucket: string | undefined;
 
@@ -4483,18 +4483,18 @@ export namespace GetBucketEncryptionRequest {
 
 /**
  * <p>A container for specifying S3 Intelligent-Tiering filters. The filters determine the
- *          subset of objects to which the rule applies.</p>
+ * subset of objects to which the rule applies.</p>
  */
 export interface IntelligentTieringAndOperator {
   /**
    * <p>An object key name prefix that identifies the subset of objects to which the
-   *          configuration applies.</p>
+   * configuration applies.</p>
    */
   Prefix?: string;
 
   /**
    * <p>All of these tags must exist in the object's tag set in order for the configuration to
-   *          apply.</p>
+   * apply.</p>
    */
   Tags?: Tag[];
 }
@@ -4510,17 +4510,17 @@ export namespace IntelligentTieringAndOperator {
 
 /**
  * <p>The <code>Filter</code> is used to identify objects that the S3 Intelligent-Tiering
- *          configuration applies to.</p>
+ * configuration applies to.</p>
  */
 export interface IntelligentTieringFilter {
   /**
    * <p>An object key name prefix that identifies the subset of objects to which the rule
-   *          applies.</p>
-   *          <important>
-   *             <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
-   *          XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
-   *             XML related object key constraints</a>.</p>
-   *          </important>
+   * applies.</p>
+   * <important>
+   *    <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
+   * XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
+   *    XML related object key constraints</a>.</p>
+   * </important>
    */
   Prefix?: string;
 
@@ -4531,8 +4531,8 @@ export interface IntelligentTieringFilter {
 
   /**
    * <p>A conjunction (logical AND) of predicates, which is used in evaluating a metrics filter.
-   *          The operator must have at least two predicates, and an object must match all of the
-   *          predicates in order for the filter to apply.</p>
+   * The operator must have at least two predicates, and an object must match all of the
+   * predicates in order for the filter to apply.</p>
    */
   And?: IntelligentTieringAndOperator;
 }
@@ -4552,22 +4552,22 @@ export type IntelligentTieringAccessTier = "ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCE
 
 /**
  * <p>The S3 Intelligent-Tiering storage class is designed to optimize storage costs by
- *          automatically moving data to the most cost-effective storage access tier, without
- *          additional operational overhead.</p>
+ * automatically moving data to the most cost-effective storage access tier, without
+ * additional operational overhead.</p>
  */
 export interface Tiering {
   /**
    * <p>The number of consecutive days of no access after which an object will be eligible to be
-   *          transitioned to the corresponding tier. The minimum number of days specified for
-   *          Archive Access tier must be at least 90 days and Deep Archive Access tier must be at least
-   *          180 days. The maximum can be up to 2 years (730 days).</p>
+   * transitioned to the corresponding tier. The minimum number of days specified for
+   * Archive Access tier must be at least 90 days and Deep Archive Access tier must be at least
+   * 180 days. The maximum can be up to 2 years (730 days).</p>
    */
   Days: number | undefined;
 
   /**
    * <p>S3 Intelligent-Tiering access tier. See <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for
-   *             automatically optimizing frequently and infrequently accessed objects</a> for a list
-   *          of access tiers in the S3 Intelligent-Tiering storage class.</p>
+   *    automatically optimizing frequently and infrequently accessed objects</a> for a list
+   * of access tiers in the S3 Intelligent-Tiering storage class.</p>
    */
   AccessTier: IntelligentTieringAccessTier | string | undefined;
 }
@@ -4583,8 +4583,8 @@ export namespace Tiering {
 
 /**
  * <p>Specifies the S3 Intelligent-Tiering configuration for an Amazon S3 bucket.</p>
- *          <p>For information about the S3 Intelligent-Tiering storage class, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for
- *             automatically optimizing frequently and infrequently accessed objects</a>.</p>
+ * <p>For information about the S3 Intelligent-Tiering storage class, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access">Storage class for
+ *    automatically optimizing frequently and infrequently accessed objects</a>.</p>
  */
 export interface IntelligentTieringConfiguration {
   /**
@@ -4594,7 +4594,7 @@ export interface IntelligentTieringConfiguration {
 
   /**
    * <p>Specifies a bucket filter. The configuration only includes objects that meet the
-   *          filter's criteria.</p>
+   * filter's criteria.</p>
    */
   Filter?: IntelligentTieringFilter;
 
@@ -4661,7 +4661,7 @@ export namespace GetBucketIntelligentTieringConfigurationRequest {
 export interface SSEKMS {
   /**
    * <p>Specifies the ID of the Amazon Web Services Key Management Service (Amazon Web Services KMS) symmetric customer managed
-   *          customer master key (CMK) to use for encrypting inventory reports.</p>
+   * customer master key (CMK) to use for encrypting inventory reports.</p>
    */
   KeyId: string | undefined;
 }
@@ -4692,7 +4692,7 @@ export namespace SSES3 {
 
 /**
  * <p>Contains the type of server-side encryption used to encrypt the inventory
- *          results.</p>
+ * results.</p>
  */
 export interface InventoryEncryption {
   /**
@@ -4720,22 +4720,22 @@ export type InventoryFormat = "CSV" | "ORC" | "Parquet";
 
 /**
  * <p>Contains the bucket name, file format, bucket owner (optional), and prefix (optional)
- *          where inventory results are published.</p>
+ * where inventory results are published.</p>
  */
 export interface InventoryS3BucketDestination {
   /**
    * <p>The account ID that owns the destination S3 bucket. If no account ID is provided, the
-   *          owner is not validated before exporting data. </p>
-   *          <note>
-   *             <p> Although this value is optional, we strongly recommend that you set it to help
-   *             prevent problems if the destination bucket ownership changes. </p>
-   *          </note>
+   * owner is not validated before exporting data. </p>
+   * <note>
+   *    <p> Although this value is optional, we strongly recommend that you set it to help
+   *    prevent problems if the destination bucket ownership changes. </p>
+   * </note>
    */
   AccountId?: string;
 
   /**
    * <p>The Amazon Resource Name (ARN) of the bucket where inventory results will be
-   *          published.</p>
+   * published.</p>
    */
   Bucket: string | undefined;
 
@@ -4751,7 +4751,7 @@ export interface InventoryS3BucketDestination {
 
   /**
    * <p>Contains the type of server-side encryption used to encrypt the inventory
-   *          results.</p>
+   * results.</p>
    */
   Encryption?: InventoryEncryption;
 }
@@ -4772,7 +4772,7 @@ export namespace InventoryS3BucketDestination {
 export interface InventoryDestination {
   /**
    * <p>Contains the bucket name, file format, bucket owner (optional), and prefix (optional)
-   *          where inventory results are published.</p>
+   * where inventory results are published.</p>
    */
   S3BucketDestination: InventoryS3BucketDestination | undefined;
 }
@@ -4791,7 +4791,7 @@ export namespace InventoryDestination {
 
 /**
  * <p>Specifies an inventory filter. The inventory only includes objects that meet the
- *          filter's criteria.</p>
+ * filter's criteria.</p>
  */
 export interface InventoryFilter {
   /**
@@ -4848,7 +4848,7 @@ export namespace InventorySchedule {
 
 /**
  * <p>Specifies the inventory configuration for an Amazon S3 bucket. For more information, see
- *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETInventoryConfig.html">GET Bucket inventory</a> in the <i>Amazon S3 API Reference</i>.
+ *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETInventoryConfig.html">GET Bucket inventory</a> in the <i>Amazon S3 API Reference</i>.
  *       </p>
  */
 export interface InventoryConfiguration {
@@ -4859,14 +4859,14 @@ export interface InventoryConfiguration {
 
   /**
    * <p>Specifies whether the inventory is enabled or disabled. If set to <code>True</code>, an
-   *          inventory list is generated. If set to <code>False</code>, no inventory list is
-   *          generated.</p>
+   * inventory list is generated. If set to <code>False</code>, no inventory list is
+   * generated.</p>
    */
   IsEnabled: boolean | undefined;
 
   /**
    * <p>Specifies an inventory filter. The inventory only includes objects that meet the
-   *          filter's criteria.</p>
+   * filter's criteria.</p>
    */
   Filter?: InventoryFilter;
 
@@ -4877,10 +4877,10 @@ export interface InventoryConfiguration {
 
   /**
    * <p>Object versions to include in the inventory list. If set to <code>All</code>, the list
-   *          includes all the object versions, which adds the version-related fields
-   *             <code>VersionId</code>, <code>IsLatest</code>, and <code>DeleteMarker</code> to the
-   *          list. If set to <code>Current</code>, the list does not contain these version-related
-   *          fields.</p>
+   * includes all the object versions, which adds the version-related fields
+   *    <code>VersionId</code>, <code>IsLatest</code>, and <code>DeleteMarker</code> to the
+   * list. If set to <code>Current</code>, the list does not contain these version-related
+   * fields.</p>
    */
   IncludedObjectVersions: InventoryIncludedObjectVersions | string | undefined;
 
@@ -4956,20 +4956,20 @@ export namespace GetBucketInventoryConfigurationRequest {
 export interface LifecycleExpiration {
   /**
    * <p>Indicates at what date the object is to be moved or deleted. Should be in GMT ISO 8601
-   *          Format.</p>
+   * Format.</p>
    */
   Date?: Date;
 
   /**
    * <p>Indicates the lifetime, in days, of the objects that are subject to the rule. The value
-   *          must be a non-zero positive integer.</p>
+   * must be a non-zero positive integer.</p>
    */
   Days?: number;
 
   /**
    * <p>Indicates whether Amazon S3 will remove a delete marker with no noncurrent versions. If set
-   *          to true, the delete marker will be expired; if set to false the policy takes no action.
-   *          This cannot be specified with Days or Date in a Lifecycle Expiration Policy.</p>
+   * to true, the delete marker will be expired; if set to false the policy takes no action.
+   * This cannot be specified with Days or Date in a Lifecycle Expiration Policy.</p>
    */
   ExpiredObjectDeleteMarker?: boolean;
 }
@@ -4985,8 +4985,8 @@ export namespace LifecycleExpiration {
 
 /**
  * <p>This is used in a Lifecycle Rule Filter to apply a logical AND to two or more
- *          predicates. The Lifecycle Rule will apply to any object matching all of the predicates
- *          configured inside the And operator.</p>
+ * predicates. The Lifecycle Rule will apply to any object matching all of the predicates
+ * configured inside the And operator.</p>
  */
 export interface LifecycleRuleAndOperator {
   /**
@@ -4996,7 +4996,7 @@ export interface LifecycleRuleAndOperator {
 
   /**
    * <p>All of these tags must exist in the object's tag set in order for the rule to
-   *          apply.</p>
+   * apply.</p>
    */
   Tags?: Tag[];
 }
@@ -5012,8 +5012,8 @@ export namespace LifecycleRuleAndOperator {
 
 /**
  * <p>The <code>Filter</code> is used to identify objects that a Lifecycle Rule applies to. A
- *             <code>Filter</code> must have exactly one of <code>Prefix</code>, <code>Tag</code>, or
- *             <code>And</code> specified.</p>
+ *    <code>Filter</code> must have exactly one of <code>Prefix</code>, <code>Tag</code>, or
+ *    <code>And</code> specified.</p>
  */
 export type LifecycleRuleFilter =
   | LifecycleRuleFilter.AndMember
@@ -5024,11 +5024,11 @@ export type LifecycleRuleFilter =
 export namespace LifecycleRuleFilter {
   /**
    * <p>Prefix identifying one or more objects to which the rule applies.</p>
-   *          <important>
-   *             <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
-   *          XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
-   *             XML related object key constraints</a>.</p>
-   *          </important>
+   * <important>
+   *    <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
+   * XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
+   *    XML related object key constraints</a>.</p>
+   * </important>
    */
   export interface PrefixMember {
     Prefix: string;
@@ -5049,8 +5049,8 @@ export namespace LifecycleRuleFilter {
 
   /**
    * <p>This is used in a Lifecycle Rule Filter to apply a logical AND to two or more
-   *          predicates. The Lifecycle Rule will apply to any object matching all of the predicates
-   *          configured inside the And operator.</p>
+   * predicates. The Lifecycle Rule will apply to any object matching all of the predicates
+   * configured inside the And operator.</p>
    */
   export interface AndMember {
     Prefix?: never;
@@ -5093,15 +5093,15 @@ export namespace LifecycleRuleFilter {
 
 /**
  * <p>Specifies when noncurrent object versions expire. Upon expiration, Amazon S3 permanently
- *          deletes the noncurrent object versions. You set this lifecycle configuration action on a
- *          bucket that has versioning enabled (or suspended) to request that Amazon S3 delete noncurrent
- *          object versions at a specific period in the object's lifetime.</p>
+ * deletes the noncurrent object versions. You set this lifecycle configuration action on a
+ * bucket that has versioning enabled (or suspended) to request that Amazon S3 delete noncurrent
+ * object versions at a specific period in the object's lifetime.</p>
  */
 export interface NoncurrentVersionExpiration {
   /**
    * <p>Specifies the number of days an object is noncurrent before Amazon S3 can perform the
-   *          associated action. For information about the noncurrent days calculations, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#non-current-days-calculations">How
-   *             Amazon S3 Calculates When an Object Became Noncurrent</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * associated action. For information about the noncurrent days calculations, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#non-current-days-calculations">How
+   *    Amazon S3 Calculates When an Object Became Noncurrent</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   NoncurrentDays?: number;
 }
@@ -5119,20 +5119,20 @@ export type TransitionStorageClass = "DEEP_ARCHIVE" | "GLACIER" | "INTELLIGENT_T
 
 /**
  * <p>Container for the transition rule that describes when noncurrent objects transition to
- *          the <code>STANDARD_IA</code>, <code>ONEZONE_IA</code>, <code>INTELLIGENT_TIERING</code>,
- *             <code>GLACIER</code>, or <code>DEEP_ARCHIVE</code> storage class. If your bucket is
- *          versioning-enabled (or versioning is suspended), you can set this action to request that
- *          Amazon S3 transition noncurrent object versions to the <code>STANDARD_IA</code>,
- *             <code>ONEZONE_IA</code>, <code>INTELLIGENT_TIERING</code>, <code>GLACIER</code>, or
- *             <code>DEEP_ARCHIVE</code> storage class at a specific period in the object's
- *          lifetime.</p>
+ * the <code>STANDARD_IA</code>, <code>ONEZONE_IA</code>, <code>INTELLIGENT_TIERING</code>,
+ *    <code>GLACIER</code>, or <code>DEEP_ARCHIVE</code> storage class. If your bucket is
+ * versioning-enabled (or versioning is suspended), you can set this action to request that
+ * Amazon S3 transition noncurrent object versions to the <code>STANDARD_IA</code>,
+ *    <code>ONEZONE_IA</code>, <code>INTELLIGENT_TIERING</code>, <code>GLACIER</code>, or
+ *    <code>DEEP_ARCHIVE</code> storage class at a specific period in the object's
+ * lifetime.</p>
  */
 export interface NoncurrentVersionTransition {
   /**
    * <p>Specifies the number of days an object is noncurrent before Amazon S3 can perform the
-   *          associated action. For information about the noncurrent days calculations, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#non-current-days-calculations">How
-   *             Amazon S3 Calculates How Long an Object Has Been Noncurrent</a> in the
-   *             <i>Amazon S3 User Guide</i>.</p>
+   * associated action. For information about the noncurrent days calculations, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#non-current-days-calculations">How
+   *    Amazon S3 Calculates How Long an Object Has Been Noncurrent</a> in the
+   *    <i>Amazon S3 User Guide</i>.</p>
    */
   NoncurrentDays?: number;
 
@@ -5155,19 +5155,19 @@ export type ExpirationStatus = "Disabled" | "Enabled";
 
 /**
  * <p>Specifies when an object transitions to a specified storage class. For more information
- *          about Amazon S3 lifecycle configuration rules, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/lifecycle-transition-general-considerations.html">Transitioning
- *             Objects Using Amazon S3 Lifecycle</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * about Amazon S3 lifecycle configuration rules, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/lifecycle-transition-general-considerations.html">Transitioning
+ *    Objects Using Amazon S3 Lifecycle</a> in the <i>Amazon S3 User Guide</i>.</p>
  */
 export interface Transition {
   /**
    * <p>Indicates when objects are transitioned to the specified storage class. The date value
-   *          must be in ISO 8601 format. The time is always midnight UTC.</p>
+   * must be in ISO 8601 format. The time is always midnight UTC.</p>
    */
   Date?: Date;
 
   /**
    * <p>Indicates the number of days after creation when objects are transitioned to the
-   *          specified storage class. The value must be a positive integer.</p>
+   * specified storage class. The value must be a positive integer.</p>
    */
   Days?: number;
 
@@ -5192,7 +5192,7 @@ export namespace Transition {
 export interface LifecycleRule {
   /**
    * <p>Specifies the expiration for the lifecycle of the object in the form of date, days and,
-   *          whether the object has a delete marker.</p>
+   * whether the object has a delete marker.</p>
    */
   Expiration?: LifecycleExpiration;
 
@@ -5205,26 +5205,26 @@ export interface LifecycleRule {
    * @deprecated
    *
    * <p>Prefix identifying one or more objects to which the rule applies. This is
-   *          no longer used; use <code>Filter</code> instead.</p>
-   *          <important>
-   *             <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
-   *          XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
-   *             XML related object key constraints</a>.</p>
-   *          </important>
+   * no longer used; use <code>Filter</code> instead.</p>
+   * <important>
+   *    <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
+   * XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
+   *    XML related object key constraints</a>.</p>
+   * </important>
    */
   Prefix?: string;
 
   /**
    * <p>The <code>Filter</code> is used to identify objects that a Lifecycle Rule applies to. A
-   *          <code>Filter</code> must have exactly one of <code>Prefix</code>, <code>Tag</code>, or
-   *          <code>And</code> specified. <code>Filter</code> is required if the <code>LifecycleRule</code>
-   *          does not containt a <code>Prefix</code> element.</p>
+   * <code>Filter</code> must have exactly one of <code>Prefix</code>, <code>Tag</code>, or
+   * <code>And</code> specified. <code>Filter</code> is required if the <code>LifecycleRule</code>
+   * does not containt a <code>Prefix</code> element.</p>
    */
   Filter?: LifecycleRuleFilter;
 
   /**
    * <p>If 'Enabled', the rule is currently being applied. If 'Disabled', the rule is not
-   *          currently being applied.</p>
+   * currently being applied.</p>
    */
   Status: ExpirationStatus | string | undefined;
 
@@ -5235,26 +5235,26 @@ export interface LifecycleRule {
 
   /**
    * <p> Specifies the transition rule for the lifecycle rule that describes when noncurrent
-   *          objects transition to a specific storage class. If your bucket is versioning-enabled (or
-   *          versioning is suspended), you can set this action to request that Amazon S3 transition
-   *          noncurrent object versions to a specific storage class at a set period in the object's
-   *          lifetime. </p>
+   * objects transition to a specific storage class. If your bucket is versioning-enabled (or
+   * versioning is suspended), you can set this action to request that Amazon S3 transition
+   * noncurrent object versions to a specific storage class at a set period in the object's
+   * lifetime. </p>
    */
   NoncurrentVersionTransitions?: NoncurrentVersionTransition[];
 
   /**
    * <p>Specifies when noncurrent object versions expire. Upon expiration, Amazon S3 permanently
-   *          deletes the noncurrent object versions. You set this lifecycle configuration action on a
-   *          bucket that has versioning enabled (or suspended) to request that Amazon S3 delete noncurrent
-   *          object versions at a specific period in the object's lifetime.</p>
+   * deletes the noncurrent object versions. You set this lifecycle configuration action on a
+   * bucket that has versioning enabled (or suspended) to request that Amazon S3 delete noncurrent
+   * object versions at a specific period in the object's lifetime.</p>
    */
   NoncurrentVersionExpiration?: NoncurrentVersionExpiration;
 
   /**
    * <p>Specifies the days since the initiation of an incomplete multipart upload that Amazon S3 will
-   *          wait before permanently removing all parts of the upload. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config">
-   *             Aborting Incomplete Multipart Uploads Using a Bucket Lifecycle Policy</a> in the
-   *             <i>Amazon S3 User Guide</i>.</p>
+   * wait before permanently removing all parts of the upload. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config">
+   *    Aborting Incomplete Multipart Uploads Using a Bucket Lifecycle Policy</a> in the
+   *    <i>Amazon S3 User Guide</i>.</p>
    */
   AbortIncompleteMultipartUpload?: AbortIncompleteMultipartUpload;
 }
@@ -5310,9 +5310,9 @@ export namespace GetBucketLifecycleConfigurationRequest {
 export interface GetBucketLocationOutput {
   /**
    * <p>Specifies the Region where the bucket resides. For a list of all the Amazon S3 supported
-   *          location constraints by Region, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a>.
-   *          Buckets in Region <code>us-east-1</code> have a LocationConstraint of
-   *          <code>null</code>.</p>
+   * location constraints by Region, see <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region">Regions and Endpoints</a>.
+   * Buckets in Region <code>us-east-1</code> have a LocationConstraint of
+   * <code>null</code>.</p>
    */
   LocationConstraint?: BucketLocationConstraint | string;
 }
@@ -5375,16 +5375,16 @@ export namespace TargetGrant {
 
 /**
  * <p>Describes where logs are stored and the prefix that Amazon S3 assigns to all log object keys
- *          for a bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlogging.html">PUT Bucket logging</a> in the
- *             <i>Amazon S3 API Reference</i>.</p>
+ * for a bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlogging.html">PUT Bucket logging</a> in the
+ *    <i>Amazon S3 API Reference</i>.</p>
  */
 export interface LoggingEnabled {
   /**
    * <p>Specifies the bucket where you want Amazon S3 to store server access logs. You can have your
-   *          logs delivered to any bucket that you own, including the same bucket that is being logged.
-   *          You can also configure multiple buckets to deliver their logs to the same target bucket. In
-   *          this case, you should choose a different <code>TargetPrefix</code> for each source bucket
-   *          so that the delivered log files can be distinguished by key.</p>
+   * logs delivered to any bucket that you own, including the same bucket that is being logged.
+   * You can also configure multiple buckets to deliver their logs to the same target bucket. In
+   * this case, you should choose a different <code>TargetPrefix</code> for each source bucket
+   * so that the delivered log files can be distinguished by key.</p>
    */
   TargetBucket: string | undefined;
 
@@ -5395,8 +5395,8 @@ export interface LoggingEnabled {
 
   /**
    * <p>A prefix for all log object keys. If you store log files from multiple Amazon S3 buckets in a
-   *          single bucket, you can use a prefix to distinguish which log files came from which
-   *          bucket.</p>
+   * single bucket, you can use a prefix to distinguish which log files came from which
+   * bucket.</p>
    */
   TargetPrefix: string | undefined;
 }
@@ -5413,8 +5413,8 @@ export namespace LoggingEnabled {
 export interface GetBucketLoggingOutput {
   /**
    * <p>Describes where logs are stored and the prefix that Amazon S3 assigns to all log object keys
-   *          for a bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlogging.html">PUT Bucket logging</a> in the
-   *             <i>Amazon S3 API Reference</i>.</p>
+   * for a bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlogging.html">PUT Bucket logging</a> in the
+   *    <i>Amazon S3 API Reference</i>.</p>
    */
   LoggingEnabled?: LoggingEnabled;
 }
@@ -5451,8 +5451,8 @@ export namespace GetBucketLoggingRequest {
 
 /**
  * <p>A conjunction (logical AND) of predicates, which is used in evaluating a metrics filter.
- *          The operator must have at least two predicates, and an object must match all of the
- *          predicates in order for the filter to apply.</p>
+ * The operator must have at least two predicates, and an object must match all of the
+ * predicates in order for the filter to apply.</p>
  */
 export interface MetricsAndOperator {
   /**
@@ -5477,8 +5477,8 @@ export namespace MetricsAndOperator {
 
 /**
  * <p>Specifies a metrics configuration filter. The metrics configuration only includes
- *          objects that meet the filter's criteria. A filter must be a prefix, a tag, or a conjunction
- *          (MetricsAndOperator).</p>
+ * objects that meet the filter's criteria. A filter must be a prefix, a tag, or a conjunction
+ * (MetricsAndOperator).</p>
  */
 export type MetricsFilter =
   | MetricsFilter.AndMember
@@ -5509,8 +5509,8 @@ export namespace MetricsFilter {
 
   /**
    * <p>A conjunction (logical AND) of predicates, which is used in evaluating a metrics filter.
-   *          The operator must have at least two predicates, and an object must match all of the
-   *          predicates in order for the filter to apply.</p>
+   * The operator must have at least two predicates, and an object must match all of the
+   * predicates in order for the filter to apply.</p>
    */
   export interface AndMember {
     Prefix?: never;
@@ -5553,11 +5553,11 @@ export namespace MetricsFilter {
 
 /**
  * <p>Specifies a metrics configuration for the CloudWatch request metrics (specified by the
- *          metrics configuration ID) from an Amazon S3 bucket. If you're updating an existing metrics
- *          configuration, note that this is a full replacement of the existing metrics configuration.
- *          If you don't include the elements you want to keep, they are erased. For more information,
- *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTMetricConfiguration.html"> PUT Bucket
- *             metrics</a> in the <i>Amazon S3 API Reference</i>.</p>
+ * metrics configuration ID) from an Amazon S3 bucket. If you're updating an existing metrics
+ * configuration, note that this is a full replacement of the existing metrics configuration.
+ * If you don't include the elements you want to keep, they are erased. For more information,
+ * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTMetricConfiguration.html"> PUT Bucket
+ *    metrics</a> in the <i>Amazon S3 API Reference</i>.</p>
  */
 export interface MetricsConfiguration {
   /**
@@ -5567,8 +5567,8 @@ export interface MetricsConfiguration {
 
   /**
    * <p>Specifies a metrics configuration filter. The metrics configuration will only include
-   *          objects that meet the filter's criteria. A filter must be a prefix, a tag, or a conjunction
-   *          (MetricsAndOperator).</p>
+   * objects that meet the filter's criteria. A filter must be a prefix, a tag, or a conjunction
+   * (MetricsAndOperator).</p>
    */
   Filter?: MetricsFilter;
 }
@@ -5672,14 +5672,14 @@ export type FilterRuleName = "prefix" | "suffix";
 
 /**
  * <p>Specifies the Amazon S3 object key name to filter on and whether to filter on the suffix or
- *          prefix of the key name.</p>
+ * prefix of the key name.</p>
  */
 export interface FilterRule {
   /**
    * <p>The object key name prefix or suffix identifying one or more objects to which the
-   *          filtering rule applies. The maximum length is 1,024 characters. Overlapping prefixes and
-   *          suffixes are not supported. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Event Notifications</a>
-   *          in the <i>Amazon S3 User Guide</i>.</p>
+   * filtering rule applies. The maximum length is 1,024 characters. Overlapping prefixes and
+   * suffixes are not supported. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring Event Notifications</a>
+   * in the <i>Amazon S3 User Guide</i>.</p>
    */
   Name?: FilterRuleName | string;
 
@@ -5704,7 +5704,7 @@ export namespace FilterRule {
 export interface S3KeyFilter {
   /**
    * <p>A list of containers for the key-value pair that defines the criteria for the filter
-   *          rule.</p>
+   * rule.</p>
    */
   FilterRules?: FilterRule[];
 }
@@ -5720,8 +5720,8 @@ export namespace S3KeyFilter {
 
 /**
  * <p>Specifies object key name filtering rules. For information about key name filtering, see
- *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring
- *             Event Notifications</a> in the <i>Amazon S3 User Guide</i>.</p>
+ *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring
+ *    Event Notifications</a> in the <i>Amazon S3 User Guide</i>.</p>
  */
 export interface NotificationConfigurationFilter {
   /**
@@ -5745,27 +5745,27 @@ export namespace NotificationConfigurationFilter {
 export interface LambdaFunctionConfiguration {
   /**
    * <p>An optional unique identifier for configurations in a notification configuration. If you
-   *          don't provide one, Amazon S3 will assign an ID.</p>
+   * don't provide one, Amazon S3 will assign an ID.</p>
    */
   Id?: string;
 
   /**
    * <p>The Amazon Resource Name (ARN) of the Lambda function that Amazon S3 invokes when the
-   *          specified event type occurs.</p>
+   * specified event type occurs.</p>
    */
   LambdaFunctionArn: string | undefined;
 
   /**
    * <p>The Amazon S3 bucket event for which to invoke the Lambda function. For more information,
-   *          see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Supported
-   *             Event Types</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Supported
+   *    Event Types</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Events: (Event | string)[] | undefined;
 
   /**
    * <p>Specifies object key name filtering rules. For information about key name filtering, see
-   *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring
-   *             Event Notifications</a> in the <i>Amazon S3 User Guide</i>.</p>
+   *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring
+   *    Event Notifications</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Filter?: NotificationConfigurationFilter;
 }
@@ -5781,18 +5781,18 @@ export namespace LambdaFunctionConfiguration {
 
 /**
  * <p>Specifies the configuration for publishing messages to an Amazon Simple Queue Service
- *          (Amazon SQS) queue when Amazon S3 detects specified events.</p>
+ * (Amazon SQS) queue when Amazon S3 detects specified events.</p>
  */
 export interface QueueConfiguration {
   /**
    * <p>An optional unique identifier for configurations in a notification configuration. If you
-   *          don't provide one, Amazon S3 will assign an ID.</p>
+   * don't provide one, Amazon S3 will assign an ID.</p>
    */
   Id?: string;
 
   /**
    * <p>The Amazon Resource Name (ARN) of the Amazon SQS queue to which Amazon S3 publishes a message
-   *          when it detects events of the specified type.</p>
+   * when it detects events of the specified type.</p>
    */
   QueueArn: string | undefined;
 
@@ -5803,8 +5803,8 @@ export interface QueueConfiguration {
 
   /**
    * <p>Specifies object key name filtering rules. For information about key name filtering, see
-   *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring
-   *             Event Notifications</a> in the <i>Amazon S3 User Guide</i>.</p>
+   *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring
+   *    Event Notifications</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Filter?: NotificationConfigurationFilter;
 }
@@ -5820,32 +5820,32 @@ export namespace QueueConfiguration {
 
 /**
  * <p>A container for specifying the configuration for publication of messages to an Amazon
- *          Simple Notification Service (Amazon SNS) topic when Amazon S3 detects specified events.</p>
+ * Simple Notification Service (Amazon SNS) topic when Amazon S3 detects specified events.</p>
  */
 export interface TopicConfiguration {
   /**
    * <p>An optional unique identifier for configurations in a notification configuration. If you
-   *          don't provide one, Amazon S3 will assign an ID.</p>
+   * don't provide one, Amazon S3 will assign an ID.</p>
    */
   Id?: string;
 
   /**
    * <p>The Amazon Resource Name (ARN) of the Amazon SNS topic to which Amazon S3 publishes a message
-   *          when it detects events of the specified type.</p>
+   * when it detects events of the specified type.</p>
    */
   TopicArn: string | undefined;
 
   /**
    * <p>The Amazon S3 bucket event about which to send notifications. For more information, see
-   *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Supported
-   *             Event Types</a> in the <i>Amazon S3 User Guide</i>.</p>
+   *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Supported
+   *    Event Types</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Events: (Event | string)[] | undefined;
 
   /**
    * <p>Specifies object key name filtering rules. For information about key name filtering, see
-   *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring
-   *             Event Notifications</a> in the <i>Amazon S3 User Guide</i>.</p>
+   *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Configuring
+   *    Event Notifications</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Filter?: NotificationConfigurationFilter;
 }
@@ -5861,24 +5861,24 @@ export namespace TopicConfiguration {
 
 /**
  * <p>A container for specifying the notification configuration of the bucket. If this element
- *          is empty, notifications are turned off for the bucket.</p>
+ * is empty, notifications are turned off for the bucket.</p>
  */
 export interface NotificationConfiguration {
   /**
    * <p>The topic to which notifications are sent and the events for which notifications are
-   *          generated.</p>
+   * generated.</p>
    */
   TopicConfigurations?: TopicConfiguration[];
 
   /**
    * <p>The Amazon Simple Queue Service queues to publish messages to and the events for which
-   *          to publish messages.</p>
+   * to publish messages.</p>
    */
   QueueConfigurations?: QueueConfiguration[];
 
   /**
    * <p>Describes the Lambda functions to invoke and the events for which to invoke
-   *          them.</p>
+   * them.</p>
    */
   LambdaFunctionConfigurations?: LambdaFunctionConfiguration[];
 }
@@ -5900,11 +5900,11 @@ export type ObjectOwnership = "BucketOwnerPreferred" | "ObjectWriter";
 export interface OwnershipControlsRule {
   /**
    * <p>The container element for object ownership for a bucket's ownership controls.</p>
-   *          <p>BucketOwnerPreferred - Objects uploaded to the bucket change ownership to the bucket
-   *          owner if the objects are uploaded with the <code>bucket-owner-full-control</code> canned
-   *          ACL.</p>
-   *          <p>ObjectWriter - The uploading account will own the object if the object is uploaded with
-   *          the <code>bucket-owner-full-control</code> canned ACL.</p>
+   * <p>BucketOwnerPreferred - Objects uploaded to the bucket change ownership to the bucket
+   * owner if the objects are uploaded with the <code>bucket-owner-full-control</code> canned
+   * ACL.</p>
+   * <p>ObjectWriter - The uploading account will own the object if the object is uploaded with
+   * the <code>bucket-owner-full-control</code> canned ACL.</p>
    */
   ObjectOwnership: ObjectOwnership | string | undefined;
 }
@@ -5940,7 +5940,7 @@ export namespace OwnershipControls {
 export interface GetBucketOwnershipControlsOutput {
   /**
    * <p>The <code>OwnershipControls</code> (BucketOwnerPreferred or ObjectWriter) currently in
-   *          effect for this Amazon S3 bucket.</p>
+   * effect for this Amazon S3 bucket.</p>
    */
   OwnershipControls?: OwnershipControls;
 }
@@ -6019,7 +6019,7 @@ export namespace GetBucketPolicyRequest {
 export interface PolicyStatus {
   /**
    * <p>The policy status for this bucket. <code>TRUE</code> indicates that this bucket is
-   *          public. <code>FALSE</code> indicates that the bucket is not public.</p>
+   * public. <code>FALSE</code> indicates that the bucket is not public.</p>
    */
   IsPublic?: boolean;
 }
@@ -6074,24 +6074,24 @@ export type DeleteMarkerReplicationStatus = "Disabled" | "Enabled";
 
 /**
  * <p>Specifies whether Amazon S3 replicates delete markers. If you specify a <code>Filter</code>
- *          in your replication configuration, you must also include a
- *             <code>DeleteMarkerReplication</code> element. If your <code>Filter</code> includes a
- *             <code>Tag</code> element, the <code>DeleteMarkerReplication</code>
- *             <code>Status</code> must be set to Disabled, because Amazon S3 does not support replicating
- *          delete markers for tag-based rules. For an example configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-config-min-rule-config">Basic Rule Configuration</a>. </p>
- *          <p>For more information about delete marker replication, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/delete-marker-replication.html">Basic Rule
- *             Configuration</a>. </p>
- *          <note>
- *             <p>If you are using an earlier version of the replication configuration, Amazon S3 handles
- *             replication of delete markers differently. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-backward-compat-considerations">Backward Compatibility</a>.</p>
- *          </note>
+ * in your replication configuration, you must also include a
+ *    <code>DeleteMarkerReplication</code> element. If your <code>Filter</code> includes a
+ *    <code>Tag</code> element, the <code>DeleteMarkerReplication</code>
+ *    <code>Status</code> must be set to Disabled, because Amazon S3 does not support replicating
+ * delete markers for tag-based rules. For an example configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-config-min-rule-config">Basic Rule Configuration</a>. </p>
+ * <p>For more information about delete marker replication, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/delete-marker-replication.html">Basic Rule
+ *    Configuration</a>. </p>
+ * <note>
+ *    <p>If you are using an earlier version of the replication configuration, Amazon S3 handles
+ *    replication of delete markers differently. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-backward-compat-considerations">Backward Compatibility</a>.</p>
+ * </note>
  */
 export interface DeleteMarkerReplication {
   /**
    * <p>Indicates whether to replicate delete markers.</p>
-   *          <note>
-   *             <p>Indicates whether to replicate delete markers.</p>
-   *          </note>
+   * <note>
+   *    <p>Indicates whether to replicate delete markers.</p>
+   * </note>
    */
   Status?: DeleteMarkerReplicationStatus | string;
 }
@@ -6107,15 +6107,15 @@ export namespace DeleteMarkerReplication {
 
 /**
  * <p>Specifies encryption-related information for an Amazon S3 bucket that is a destination for
- *          replicated objects.</p>
+ * replicated objects.</p>
  */
 export interface EncryptionConfiguration {
   /**
    * <p>Specifies the ID (Key ARN or Alias ARN) of the customer managed Amazon Web Services KMS key
-   *          stored in Amazon Web Services Key Management Service (KMS) for the destination bucket. Amazon S3 uses
-   *          this key to encrypt replica objects. Amazon S3 only supports symmetric, customer managed KMS keys.
-   *          For more information, see <a href="https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html">Using symmetric and
-   *             asymmetric keys</a> in the <i>Amazon Web Services Key Management Service Developer Guide</i>.</p>
+   * stored in Amazon Web Services Key Management Service (KMS) for the destination bucket. Amazon S3 uses
+   * this key to encrypt replica objects. Amazon S3 only supports symmetric, customer managed KMS keys.
+   * For more information, see <a href="https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html">Using symmetric and
+   *    asymmetric keys</a> in the <i>Amazon Web Services Key Management Service Developer Guide</i>.</p>
    */
   ReplicaKmsKeyID?: string;
 }
@@ -6131,12 +6131,12 @@ export namespace EncryptionConfiguration {
 
 /**
  * <p> A container specifying the time value for S3 Replication Time Control (S3 RTC) and replication metrics
- *             <code>EventThreshold</code>. </p>
+ *    <code>EventThreshold</code>. </p>
  */
 export interface ReplicationTimeValue {
   /**
    * <p> Contains an integer specifying time in minutes. </p>
-   *          <p> Valid value: 15</p>
+   * <p> Valid value: 15</p>
    */
   Minutes?: number;
 }
@@ -6154,7 +6154,7 @@ export type MetricsStatus = "Disabled" | "Enabled";
 
 /**
  * <p> A container specifying replication metrics-related settings enabling replication
- *          metrics and events.</p>
+ * metrics and events.</p>
  */
 export interface Metrics {
   /**
@@ -6164,7 +6164,7 @@ export interface Metrics {
 
   /**
    * <p> A container specifying the time threshold for emitting the
-   *             <code>s3:Replication:OperationMissedThreshold</code> event. </p>
+   *    <code>s3:Replication:OperationMissedThreshold</code> event. </p>
    */
   EventThreshold?: ReplicationTimeValue;
 }
@@ -6182,8 +6182,8 @@ export type ReplicationTimeStatus = "Disabled" | "Enabled";
 
 /**
  * <p> A container specifying S3 Replication Time Control (S3 RTC) related information, including whether S3 RTC is
- *          enabled and the time when all objects and operations on objects must be replicated. Must be
- *          specified together with a <code>Metrics</code> block. </p>
+ * enabled and the time when all objects and operations on objects must be replicated. Must be
+ * specified together with a <code>Metrics</code> block. </p>
  */
 export interface ReplicationTime {
   /**
@@ -6193,7 +6193,7 @@ export interface ReplicationTime {
 
   /**
    * <p> A container specifying the time by which replication should be complete for all objects
-   *          and operations on objects. </p>
+   * and operations on objects. </p>
    */
   Time: ReplicationTimeValue | undefined;
 }
@@ -6209,7 +6209,7 @@ export namespace ReplicationTime {
 
 /**
  * <p>Specifies information about where to publish analysis or configuration results for an
- *          Amazon S3 bucket and S3 Replication Time Control (S3 RTC).</p>
+ * Amazon S3 bucket and S3 Replication Time Control (S3 RTC).</p>
  */
 export interface Destination {
   /**
@@ -6219,46 +6219,46 @@ export interface Destination {
 
   /**
    * <p>Destination bucket owner account ID. In a cross-account scenario, if you direct Amazon S3 to
-   *          change replica ownership to the Amazon Web Services account that owns the destination bucket by specifying
-   *          the <code>AccessControlTranslation</code> property, this is the account ID of the
-   *          destination bucket owner. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-change-owner.html">Replication Additional
-   *             Configuration: Changing the Replica Owner</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * change replica ownership to the Amazon Web Services account that owns the destination bucket by specifying
+   * the <code>AccessControlTranslation</code> property, this is the account ID of the
+   * destination bucket owner. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-change-owner.html">Replication Additional
+   *    Configuration: Changing the Replica Owner</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Account?: string;
 
   /**
    * <p> The storage class to use when replicating objects, such as S3 Standard or reduced
-   *          redundancy. By default, Amazon S3 uses the storage class of the source object to create the
-   *          object replica. </p>
-   *          <p>For valid values, see the <code>StorageClass</code> element of the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTreplication.html">PUT Bucket
-   *             replication</a> action in the <i>Amazon S3 API Reference</i>.</p>
+   * redundancy. By default, Amazon S3 uses the storage class of the source object to create the
+   * object replica. </p>
+   * <p>For valid values, see the <code>StorageClass</code> element of the <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTreplication.html">PUT Bucket
+   *    replication</a> action in the <i>Amazon S3 API Reference</i>.</p>
    */
   StorageClass?: StorageClass | string;
 
   /**
    * <p>Specify this only in a cross-account scenario (where source and destination bucket
-   *          owners are not the same), and you want to change replica ownership to the Amazon Web Services account that
-   *          owns the destination bucket. If this is not specified in the replication configuration, the
-   *          replicas are owned by same Amazon Web Services account that owns the source object.</p>
+   * owners are not the same), and you want to change replica ownership to the Amazon Web Services account that
+   * owns the destination bucket. If this is not specified in the replication configuration, the
+   * replicas are owned by same Amazon Web Services account that owns the source object.</p>
    */
   AccessControlTranslation?: AccessControlTranslation;
 
   /**
    * <p>A container that provides information about encryption. If
-   *             <code>SourceSelectionCriteria</code> is specified, you must specify this element.</p>
+   *    <code>SourceSelectionCriteria</code> is specified, you must specify this element.</p>
    */
   EncryptionConfiguration?: EncryptionConfiguration;
 
   /**
    * <p> A container specifying S3 Replication Time Control (S3 RTC), including whether S3 RTC is enabled and the time
-   *          when all objects and operations on objects must be replicated. Must be specified together
-   *          with a <code>Metrics</code> block. </p>
+   * when all objects and operations on objects must be replicated. Must be specified together
+   * with a <code>Metrics</code> block. </p>
    */
   ReplicationTime?: ReplicationTime;
 
   /**
    * <p> A container specifying replication metrics-related settings enabling replication
-   *          metrics and events. </p>
+   * metrics and events. </p>
    */
   Metrics?: Metrics;
 }
@@ -6276,7 +6276,7 @@ export type ExistingObjectReplicationStatus = "Disabled" | "Enabled";
 
 /**
  * <p>Optional configuration to replicate existing source bucket objects. For more
- *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-what-is-isnot-replicated.html#existing-object-replication">Replicating Existing Objects</a> in the <i>Amazon S3 User Guide</i>.
+ * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-what-is-isnot-replicated.html#existing-object-replication">Replicating Existing Objects</a> in the <i>Amazon S3 User Guide</i>.
  *       </p>
  */
 export interface ExistingObjectReplication {
@@ -6297,23 +6297,23 @@ export namespace ExistingObjectReplication {
 
 /**
  * <p>A container for specifying rule filters. The filters determine the subset of objects to
- *          which the rule applies. This element is required only if you specify more than one filter. </p>
- *          <p>For example:</p>
- *          <ul>
- *             <li>
- *                <p>If you specify both a <code>Prefix</code> and a <code>Tag</code> filter, wrap
- *                these filters in an <code>And</code> tag. </p>
- *             </li>
- *             <li>
- *                <p>If you specify a filter based on multiple tags, wrap the <code>Tag</code> elements
- *                in an <code>And</code> tag.</p>
- *             </li>
- *          </ul>
+ * which the rule applies. This element is required only if you specify more than one filter. </p>
+ * <p>For example:</p>
+ * <ul>
+ *    <li>
+ *       <p>If you specify both a <code>Prefix</code> and a <code>Tag</code> filter, wrap
+ *       these filters in an <code>And</code> tag. </p>
+ *    </li>
+ *    <li>
+ *       <p>If you specify a filter based on multiple tags, wrap the <code>Tag</code> elements
+ *       in an <code>And</code> tag.</p>
+ *    </li>
+ * </ul>
  */
 export interface ReplicationRuleAndOperator {
   /**
    * <p>An object key name prefix that identifies the subset of objects to which the rule
-   *          applies.</p>
+   * applies.</p>
    */
   Prefix?: string;
 
@@ -6334,8 +6334,8 @@ export namespace ReplicationRuleAndOperator {
 
 /**
  * <p>A filter that identifies the subset of objects to which the replication rule applies. A
- *             <code>Filter</code> must specify exactly one <code>Prefix</code>, <code>Tag</code>, or
- *          an <code>And</code> child element.</p>
+ *    <code>Filter</code> must specify exactly one <code>Prefix</code>, <code>Tag</code>, or
+ * an <code>And</code> child element.</p>
  */
 export type ReplicationRuleFilter =
   | ReplicationRuleFilter.AndMember
@@ -6346,12 +6346,12 @@ export type ReplicationRuleFilter =
 export namespace ReplicationRuleFilter {
   /**
    * <p>An object key name prefix that identifies the subset of objects to which the rule
-   *          applies.</p>
-   *          <important>
-   *             <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
-   *          XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
-   *             XML related object key constraints</a>.</p>
-   *          </important>
+   * applies.</p>
+   * <important>
+   *    <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
+   * XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
+   *    XML related object key constraints</a>.</p>
+   * </important>
    */
   export interface PrefixMember {
     Prefix: string;
@@ -6362,7 +6362,7 @@ export namespace ReplicationRuleFilter {
 
   /**
    * <p>A container for specifying a tag key and value. </p>
-   *          <p>The rule applies only to objects that have the tag in their tag set.</p>
+   * <p>The rule applies only to objects that have the tag in their tag set.</p>
    */
   export interface TagMember {
     Prefix?: never;
@@ -6373,18 +6373,18 @@ export namespace ReplicationRuleFilter {
 
   /**
    * <p>A container for specifying rule filters. The filters determine the subset of objects to
-   *          which the rule applies. This element is required only if you specify more than one filter.
-   *          For example: </p>
-   *          <ul>
-   *             <li>
-   *                <p>If you specify both a <code>Prefix</code> and a <code>Tag</code> filter, wrap
-   *                these filters in an <code>And</code> tag.</p>
-   *             </li>
-   *             <li>
-   *                <p>If you specify a filter based on multiple tags, wrap the <code>Tag</code> elements
-   *                in an <code>And</code> tag.</p>
-   *             </li>
-   *          </ul>
+   * which the rule applies. This element is required only if you specify more than one filter.
+   * For example: </p>
+   * <ul>
+   *    <li>
+   *       <p>If you specify both a <code>Prefix</code> and a <code>Tag</code> filter, wrap
+   *       these filters in an <code>And</code> tag.</p>
+   *    </li>
+   *    <li>
+   *       <p>If you specify a filter based on multiple tags, wrap the <code>Tag</code> elements
+   *       in an <code>And</code> tag.</p>
+   *    </li>
+   * </ul>
    */
   export interface AndMember {
     Prefix?: never;
@@ -6429,14 +6429,14 @@ export type ReplicaModificationsStatus = "Disabled" | "Enabled";
 
 /**
  * <p>A filter that you can specify for selection for modifications on replicas. Amazon S3 doesn't
- *          replicate replica modifications by default. In the latest version of replication
- *          configuration (when <code>Filter</code> is specified), you can specify this element and set
- *          the status to <code>Enabled</code> to replicate modifications on replicas. </p>
- *          <note>
- *             <p> If you don't specify the <code>Filter</code> element, Amazon S3 assumes that the
- *             replication configuration is the earlier version, V1. In the earlier version, this
- *             element is not allowed.</p>
- *          </note>
+ * replicate replica modifications by default. In the latest version of replication
+ * configuration (when <code>Filter</code> is specified), you can specify this element and set
+ * the status to <code>Enabled</code> to replicate modifications on replicas. </p>
+ * <note>
+ *    <p> If you don't specify the <code>Filter</code> element, Amazon S3 assumes that the
+ *    replication configuration is the earlier version, V1. In the earlier version, this
+ *    element is not allowed.</p>
+ * </note>
  */
 export interface ReplicaModifications {
   /**
@@ -6458,12 +6458,12 @@ export type SseKmsEncryptedObjectsStatus = "Disabled" | "Enabled";
 
 /**
  * <p>A container for filter information for the selection of S3 objects encrypted with Amazon Web Services
- *          KMS.</p>
+ * KMS.</p>
  */
 export interface SseKmsEncryptedObjects {
   /**
    * <p>Specifies whether Amazon S3 replicates objects created with server-side encryption using an
-   *          Amazon Web Services KMS key stored in Amazon Web Services Key Management Service.</p>
+   * Amazon Web Services KMS key stored in Amazon Web Services Key Management Service.</p>
    */
   Status: SseKmsEncryptedObjectsStatus | string | undefined;
 }
@@ -6479,29 +6479,29 @@ export namespace SseKmsEncryptedObjects {
 
 /**
  * <p>A container that describes additional filters for identifying the source objects that
- *          you want to replicate. You can choose to enable or disable the replication of these
- *          objects. Currently, Amazon S3 supports only the filter that you can specify for objects created
- *          with server-side encryption using a customer master key (CMK) stored in Amazon Web Services Key Management
- *          Service (SSE-KMS).</p>
+ * you want to replicate. You can choose to enable or disable the replication of these
+ * objects. Currently, Amazon S3 supports only the filter that you can specify for objects created
+ * with server-side encryption using a customer master key (CMK) stored in Amazon Web Services Key Management
+ * Service (SSE-KMS).</p>
  */
 export interface SourceSelectionCriteria {
   /**
    * <p> A container for filter information for the selection of Amazon S3 objects encrypted with Amazon Web Services
-   *          KMS. If you include <code>SourceSelectionCriteria</code> in the replication configuration,
-   *          this element is required. </p>
+   * KMS. If you include <code>SourceSelectionCriteria</code> in the replication configuration,
+   * this element is required. </p>
    */
   SseKmsEncryptedObjects?: SseKmsEncryptedObjects;
 
   /**
    * <p>A filter that you can specify for selections for modifications on replicas. Amazon S3 doesn't
-   *          replicate replica modifications by default. In the latest version of replication
-   *          configuration (when <code>Filter</code> is specified), you can specify this element and set
-   *          the status to <code>Enabled</code> to replicate modifications on replicas. </p>
-   *          <note>
-   *             <p> If you don't specify the <code>Filter</code> element, Amazon S3 assumes that the
-   *             replication configuration is the earlier version, V1. In the earlier version, this
-   *             element is not allowed</p>
-   *          </note>
+   * replicate replica modifications by default. In the latest version of replication
+   * configuration (when <code>Filter</code> is specified), you can specify this element and set
+   * the status to <code>Enabled</code> to replicate modifications on replicas. </p>
+   * <note>
+   *    <p> If you don't specify the <code>Filter</code> element, Amazon S3 assumes that the
+   *    replication configuration is the earlier version, V1. In the earlier version, this
+   *    element is not allowed</p>
+   * </note>
    */
   ReplicaModifications?: ReplicaModifications;
 }
@@ -6528,12 +6528,12 @@ export interface ReplicationRule {
 
   /**
    * <p>The priority indicates which rule has precedence whenever two or more replication rules
-   *          conflict. Amazon S3 will attempt to replicate objects according to all replication rules.
-   *          However, if there are two or more rules with the same destination bucket, then objects will
-   *          be replicated according to the rule with the highest priority. The higher the number, the
-   *          higher the priority. </p>
-   *          <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html">Replication</a> in the
-   *             <i>Amazon S3 User Guide</i>.</p>
+   * conflict. Amazon S3 will attempt to replicate objects according to all replication rules.
+   * However, if there are two or more rules with the same destination bucket, then objects will
+   * be replicated according to the rule with the highest priority. The higher the number, the
+   * higher the priority. </p>
+   * <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html">Replication</a> in the
+   *    <i>Amazon S3 User Guide</i>.</p>
    */
   Priority?: number;
 
@@ -6541,20 +6541,20 @@ export interface ReplicationRule {
    * @deprecated
    *
    * <p>An object key name prefix that identifies the object or objects to which the rule
-   *          applies. The maximum prefix length is 1,024 characters. To include all objects in a bucket,
-   *          specify an empty string. </p>
-   *          <important>
-   *             <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
-   *          XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
-   *             XML related object key constraints</a>.</p>
-   *          </important>
+   * applies. The maximum prefix length is 1,024 characters. To include all objects in a bucket,
+   * specify an empty string. </p>
+   * <important>
+   *    <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
+   * XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
+   *    XML related object key constraints</a>.</p>
+   * </important>
    */
   Prefix?: string;
 
   /**
    * <p>A filter that identifies the subset of objects to which the replication rule applies. A
-   *             <code>Filter</code> must specify exactly one <code>Prefix</code>, <code>Tag</code>, or
-   *          an <code>And</code> child element.</p>
+   *    <code>Filter</code> must specify exactly one <code>Prefix</code>, <code>Tag</code>, or
+   * an <code>And</code> child element.</p>
    */
   Filter?: ReplicationRuleFilter;
 
@@ -6565,10 +6565,10 @@ export interface ReplicationRule {
 
   /**
    * <p>A container that describes additional filters for identifying the source objects that
-   *          you want to replicate. You can choose to enable or disable the replication of these
-   *          objects. Currently, Amazon S3 supports only the filter that you can specify for objects created
-   *          with server-side encryption using a customer master key (CMK) stored in Amazon Web Services Key Management
-   *          Service (SSE-KMS).</p>
+   * you want to replicate. You can choose to enable or disable the replication of these
+   * objects. Currently, Amazon S3 supports only the filter that you can specify for objects created
+   * with server-side encryption using a customer master key (CMK) stored in Amazon Web Services Key Management
+   * Service (SSE-KMS).</p>
    */
   SourceSelectionCriteria?: SourceSelectionCriteria;
 
@@ -6579,23 +6579,23 @@ export interface ReplicationRule {
 
   /**
    * <p>A container for information about the replication destination and its configurations
-   *          including enabling the S3 Replication Time Control (S3 RTC).</p>
+   * including enabling the S3 Replication Time Control (S3 RTC).</p>
    */
   Destination: Destination | undefined;
 
   /**
    * <p>Specifies whether Amazon S3 replicates delete markers. If you specify a <code>Filter</code>
-   *          in your replication configuration, you must also include a
-   *             <code>DeleteMarkerReplication</code> element. If your <code>Filter</code> includes a
-   *             <code>Tag</code> element, the <code>DeleteMarkerReplication</code>
-   *             <code>Status</code> must be set to Disabled, because Amazon S3 does not support replicating
-   *          delete markers for tag-based rules. For an example configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-config-min-rule-config">Basic Rule Configuration</a>. </p>
-   *          <p>For more information about delete marker replication, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/delete-marker-replication.html">Basic Rule
-   *             Configuration</a>. </p>
-   *          <note>
-   *             <p>If you are using an earlier version of the replication configuration, Amazon S3 handles
-   *             replication of delete markers differently. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-backward-compat-considerations">Backward Compatibility</a>.</p>
-   *          </note>
+   * in your replication configuration, you must also include a
+   *    <code>DeleteMarkerReplication</code> element. If your <code>Filter</code> includes a
+   *    <code>Tag</code> element, the <code>DeleteMarkerReplication</code>
+   *    <code>Status</code> must be set to Disabled, because Amazon S3 does not support replicating
+   * delete markers for tag-based rules. For an example configuration, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-config-min-rule-config">Basic Rule Configuration</a>. </p>
+   * <p>For more information about delete marker replication, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/delete-marker-replication.html">Basic Rule
+   *    Configuration</a>. </p>
+   * <note>
+   *    <p>If you are using an earlier version of the replication configuration, Amazon S3 handles
+   *    replication of delete markers differently. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-backward-compat-considerations">Backward Compatibility</a>.</p>
+   * </note>
    */
   DeleteMarkerReplication?: DeleteMarkerReplication;
 }
@@ -6612,19 +6612,19 @@ export namespace ReplicationRule {
 
 /**
  * <p>A container for replication rules. You can add up to 1,000 rules. The maximum size of a
- *          replication configuration is 2 MB.</p>
+ * replication configuration is 2 MB.</p>
  */
 export interface ReplicationConfiguration {
   /**
    * <p>The Amazon Resource Name (ARN) of the Identity and Access Management (IAM) role that
-   *          Amazon S3 assumes when replicating objects. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-how-setup.html">How to Set Up
-   *             Replication</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * Amazon S3 assumes when replicating objects. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-how-setup.html">How to Set Up
+   *    Replication</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Role: string | undefined;
 
   /**
    * <p>A container for one or more replication rules. A replication configuration must have at
-   *          least one rule and can contain a maximum of 1,000 rules. </p>
+   * least one rule and can contain a maximum of 1,000 rules. </p>
    */
   Rules: ReplicationRule[] | undefined;
 }
@@ -6642,7 +6642,7 @@ export namespace ReplicationConfiguration {
 export interface GetBucketReplicationOutput {
   /**
    * <p>A container for replication rules. You can add up to 1,000 rules. The maximum size of a
-   *          replication configuration is 2 MB.</p>
+   * replication configuration is 2 MB.</p>
    */
   ReplicationConfiguration?: ReplicationConfiguration;
 }
@@ -6768,8 +6768,8 @@ export interface GetBucketVersioningOutput {
 
   /**
    * <p>Specifies whether MFA delete is enabled in the bucket versioning configuration. This
-   *          element is only returned if the bucket has been configured with MFA delete. If the bucket
-   *          has never been so configured, this element is not returned.</p>
+   * element is only returned if the bucket has been configured with MFA delete. If the bucket
+   * has never been so configured, this element is not returned.</p>
    */
   MFADelete?: MFADeleteStatus | string;
 }
@@ -6810,11 +6810,11 @@ export namespace GetBucketVersioningRequest {
 export interface ErrorDocument {
   /**
    * <p>The object key name to use when a 4XX class error occurs.</p>
-   *          <important>
-   *             <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
-   *          XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
-   *             XML related object key constraints</a>.</p>
-   *          </important>
+   * <important>
+   *    <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
+   * XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
+   *    XML related object key constraints</a>.</p>
+   * </important>
    */
   Key: string | undefined;
 }
@@ -6834,14 +6834,14 @@ export namespace ErrorDocument {
 export interface IndexDocument {
   /**
    * <p>A suffix that is appended to a request that is for a directory on the website endpoint
-   *          (for example,if the suffix is index.html and you make a request to samplebucket/images/ the
-   *          data that is returned will be for the object with the key name images/index.html) The
-   *          suffix must not be empty and must not include a slash character.</p>
-   *          <important>
-   *             <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
-   *          XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
-   *             XML related object key constraints</a>.</p>
-   *          </important>
+   * (for example,if the suffix is index.html and you make a request to samplebucket/images/ the
+   * data that is returned will be for the object with the key name images/index.html) The
+   * suffix must not be empty and must not include a slash character.</p>
+   * <important>
+   *    <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
+   * XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
+   *    XML related object key constraints</a>.</p>
+   * </important>
    */
   Suffix: string | undefined;
 }
@@ -6859,7 +6859,7 @@ export type Protocol = "http" | "https";
 
 /**
  * <p>Specifies the redirect behavior of all requests to a website endpoint of an Amazon S3
- *          bucket.</p>
+ * bucket.</p>
  */
 export interface RedirectAllRequestsTo {
   /**
@@ -6869,7 +6869,7 @@ export interface RedirectAllRequestsTo {
 
   /**
    * <p>Protocol to use when redirecting requests. The default is the protocol that is used in
-   *          the original request.</p>
+   * the original request.</p>
    */
   Protocol?: Protocol | string;
 }
@@ -6885,34 +6885,34 @@ export namespace RedirectAllRequestsTo {
 
 /**
  * <p>A container for describing a condition that must be met for the specified redirect to
- *          apply. For example, 1. If request is for pages in the <code>/docs</code> folder, redirect
- *          to the <code>/documents</code> folder. 2. If request results in HTTP error 4xx, redirect
- *          request to another host where you might process the error.</p>
+ * apply. For example, 1. If request is for pages in the <code>/docs</code> folder, redirect
+ * to the <code>/documents</code> folder. 2. If request results in HTTP error 4xx, redirect
+ * request to another host where you might process the error.</p>
  */
 export interface Condition {
   /**
    * <p>The HTTP error code when the redirect is applied. In the event of an error, if the error
-   *          code equals this value, then the specified redirect is applied. Required when parent
-   *          element <code>Condition</code> is specified and sibling <code>KeyPrefixEquals</code> is not
-   *          specified. If both are specified, then both must be true for the redirect to be
-   *          applied.</p>
+   * code equals this value, then the specified redirect is applied. Required when parent
+   * element <code>Condition</code> is specified and sibling <code>KeyPrefixEquals</code> is not
+   * specified. If both are specified, then both must be true for the redirect to be
+   * applied.</p>
    */
   HttpErrorCodeReturnedEquals?: string;
 
   /**
    * <p>The object key name prefix when the redirect is applied. For example, to redirect
-   *          requests for <code>ExamplePage.html</code>, the key prefix will be
-   *             <code>ExamplePage.html</code>. To redirect request for all pages with the prefix
-   *             <code>docs/</code>, the key prefix will be <code>/docs</code>, which identifies all
-   *          objects in the <code>docs/</code> folder. Required when the parent element
-   *             <code>Condition</code> is specified and sibling <code>HttpErrorCodeReturnedEquals</code>
-   *          is not specified. If both conditions are specified, both must be true for the redirect to
-   *          be applied.</p>
-   *          <important>
-   *             <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
-   *          XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
-   *             XML related object key constraints</a>.</p>
-   *          </important>
+   * requests for <code>ExamplePage.html</code>, the key prefix will be
+   *    <code>ExamplePage.html</code>. To redirect request for all pages with the prefix
+   *    <code>docs/</code>, the key prefix will be <code>/docs</code>, which identifies all
+   * objects in the <code>docs/</code> folder. Required when the parent element
+   *    <code>Condition</code> is specified and sibling <code>HttpErrorCodeReturnedEquals</code>
+   * is not specified. If both conditions are specified, both must be true for the redirect to
+   * be applied.</p>
+   * <important>
+   *    <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
+   * XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
+   *    XML related object key constraints</a>.</p>
+   * </important>
    */
   KeyPrefixEquals?: string;
 }
@@ -6928,7 +6928,7 @@ export namespace Condition {
 
 /**
  * <p>Specifies how requests are redirected. In the event of an error, you can specify a
- *          different error code to return.</p>
+ * different error code to return.</p>
  */
 export interface Redirect {
   /**
@@ -6938,40 +6938,40 @@ export interface Redirect {
 
   /**
    * <p>The HTTP redirect code to use on the response. Not required if one of the siblings is
-   *          present.</p>
+   * present.</p>
    */
   HttpRedirectCode?: string;
 
   /**
    * <p>Protocol to use when redirecting requests. The default is the protocol that is used in
-   *          the original request.</p>
+   * the original request.</p>
    */
   Protocol?: Protocol | string;
 
   /**
    * <p>The object key prefix to use in the redirect request. For example, to redirect requests
-   *          for all pages with prefix <code>docs/</code> (objects in the <code>docs/</code> folder) to
-   *             <code>documents/</code>, you can set a condition block with <code>KeyPrefixEquals</code>
-   *          set to <code>docs/</code> and in the Redirect set <code>ReplaceKeyPrefixWith</code> to
-   *             <code>/documents</code>. Not required if one of the siblings is present. Can be present
-   *          only if <code>ReplaceKeyWith</code> is not provided.</p>
-   *          <important>
-   *             <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
-   *          XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
-   *             XML related object key constraints</a>.</p>
-   *          </important>
+   * for all pages with prefix <code>docs/</code> (objects in the <code>docs/</code> folder) to
+   *    <code>documents/</code>, you can set a condition block with <code>KeyPrefixEquals</code>
+   * set to <code>docs/</code> and in the Redirect set <code>ReplaceKeyPrefixWith</code> to
+   *    <code>/documents</code>. Not required if one of the siblings is present. Can be present
+   * only if <code>ReplaceKeyWith</code> is not provided.</p>
+   * <important>
+   *    <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
+   * XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
+   *    XML related object key constraints</a>.</p>
+   * </important>
    */
   ReplaceKeyPrefixWith?: string;
 
   /**
    * <p>The specific object key to use in the redirect request. For example, redirect request to
-   *             <code>error.html</code>. Not required if one of the siblings is present. Can be present
-   *          only if <code>ReplaceKeyPrefixWith</code> is not provided.</p>
-   *          <important>
-   *             <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
-   *          XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
-   *             XML related object key constraints</a>.</p>
-   *          </important>
+   *    <code>error.html</code>. Not required if one of the siblings is present. Can be present
+   * only if <code>ReplaceKeyPrefixWith</code> is not provided.</p>
+   * <important>
+   *    <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using
+   * XML requests. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints">
+   *    XML related object key constraints</a>.</p>
+   * </important>
    */
   ReplaceKeyWith?: string;
 }
@@ -6987,22 +6987,22 @@ export namespace Redirect {
 
 /**
  * <p>Specifies the redirect behavior and when a redirect is applied. For more information
- *          about routing rules, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html#advanced-conditional-redirects">Configuring advanced conditional redirects</a> in the
- *             <i>Amazon S3 User Guide</i>.</p>
+ * about routing rules, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html#advanced-conditional-redirects">Configuring advanced conditional redirects</a> in the
+ *    <i>Amazon S3 User Guide</i>.</p>
  */
 export interface RoutingRule {
   /**
    * <p>A container for describing a condition that must be met for the specified redirect to
-   *          apply. For example, 1. If request is for pages in the <code>/docs</code> folder, redirect
-   *          to the <code>/documents</code> folder. 2. If request results in HTTP error 4xx, redirect
-   *          request to another host where you might process the error.</p>
+   * apply. For example, 1. If request is for pages in the <code>/docs</code> folder, redirect
+   * to the <code>/documents</code> folder. 2. If request results in HTTP error 4xx, redirect
+   * request to another host where you might process the error.</p>
    */
   Condition?: Condition;
 
   /**
    * <p>Container for redirect information. You can redirect requests to another host, to
-   *          another page, or with another protocol. In the event of an error, you can specify a
-   *          different error code to return.</p>
+   * another page, or with another protocol. In the event of an error, you can specify a
+   * different error code to return.</p>
    */
   Redirect: Redirect | undefined;
 }
@@ -7019,13 +7019,13 @@ export namespace RoutingRule {
 export interface GetBucketWebsiteOutput {
   /**
    * <p>Specifies the redirect behavior of all requests to a website endpoint of an Amazon S3
-   *          bucket.</p>
+   * bucket.</p>
    */
   RedirectAllRequestsTo?: RedirectAllRequestsTo;
 
   /**
    * <p>The name of the index document for the website (for example
-   *          <code>index.html</code>).</p>
+   * <code>index.html</code>).</p>
    */
   IndexDocument?: IndexDocument;
 
@@ -7080,7 +7080,7 @@ export interface GetObjectOutput {
 
   /**
    * <p>Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If
-   *          false, this response header does not appear in the response.</p>
+   * false, this response header does not appear in the response.</p>
    */
   DeleteMarker?: boolean;
 
@@ -7091,14 +7091,14 @@ export interface GetObjectOutput {
 
   /**
    * <p>If the object expiration is configured (see PUT Bucket lifecycle), the response includes
-   *          this header. It includes the expiry-date and rule-id key-value pairs providing object
-   *          expiration information. The value of the rule-id is URL encoded.</p>
+   * this header. It includes the expiry-date and rule-id key-value pairs providing object
+   * expiration information. The value of the rule-id is URL encoded.</p>
    */
   Expiration?: string;
 
   /**
    * <p>Provides information about object restoration action and expiration time of the
-   *          restored object copy.</p>
+   * restored object copy.</p>
    */
   Restore?: string;
 
@@ -7114,15 +7114,15 @@ export interface GetObjectOutput {
 
   /**
    * <p>An ETag is an opaque identifier assigned by a web server to a specific version of a
-   *          resource found at a URL.</p>
+   * resource found at a URL.</p>
    */
   ETag?: string;
 
   /**
    * <p>This is set to the number of metadata entries not returned in <code>x-amz-meta</code>
-   *          headers. This can happen if you create metadata using an API like SOAP that supports more
-   *          flexible metadata than the REST API. For example, using SOAP, you can create metadata whose
-   *          values are not legal HTTP headers.</p>
+   * headers. This can happen if you create metadata using an API like SOAP that supports more
+   * flexible metadata than the REST API. For example, using SOAP, you can create metadata whose
+   * values are not legal HTTP headers.</p>
    */
   MissingMeta?: number;
 
@@ -7143,8 +7143,8 @@ export interface GetObjectOutput {
 
   /**
    * <p>Specifies what content encodings have been applied to the object and thus what decoding
-   *          mechanisms must be applied to obtain the media-type referenced by the Content-Type header
-   *          field.</p>
+   * mechanisms must be applied to obtain the media-type referenced by the Content-Type header
+   * field.</p>
    */
   ContentEncoding?: string;
 
@@ -7170,14 +7170,14 @@ export interface GetObjectOutput {
 
   /**
    * <p>If the bucket is configured as a website, redirects requests for this object to another
-   *          object in the same bucket or to an external URL. Amazon S3 stores the value of this header in
-   *          the object metadata.</p>
+   * object in the same bucket or to an external URL. Amazon S3 stores the value of this header in
+   * the object metadata.</p>
    */
   WebsiteRedirectLocation?: string;
 
   /**
    * <p>The server-side encryption algorithm used when storing this object in Amazon S3 (for example,
-   *          AES256, aws:kms).</p>
+   * AES256, aws:kms).</p>
    */
   ServerSideEncryption?: ServerSideEncryption | string;
 
@@ -7188,20 +7188,20 @@ export interface GetObjectOutput {
 
   /**
    * <p>If server-side encryption with a customer-provided encryption key was requested, the
-   *          response will include this header confirming the encryption algorithm used.</p>
+   * response will include this header confirming the encryption algorithm used.</p>
    */
   SSECustomerAlgorithm?: string;
 
   /**
    * <p>If server-side encryption with a customer-provided encryption key was requested, the
-   *          response will include this header to provide round-trip message integrity verification of
-   *          the customer-provided encryption key.</p>
+   * response will include this header to provide round-trip message integrity verification of
+   * the customer-provided encryption key.</p>
    */
   SSECustomerKeyMD5?: string;
 
   /**
    * <p>If present, specifies the ID of the Amazon Web Services Key Management Service (Amazon Web Services KMS) symmetric
-   *          customer managed customer master key (CMK) that was used for the object.</p>
+   * customer managed customer master key (CMK) that was used for the object.</p>
    */
   SSEKMSKeyId?: string;
 
@@ -7212,19 +7212,19 @@ export interface GetObjectOutput {
 
   /**
    * <p>Provides storage class information of the object. Amazon S3 returns this header for all
-   *          objects except for S3 Standard storage class objects.</p>
+   * objects except for S3 Standard storage class objects.</p>
    */
   StorageClass?: StorageClass | string;
 
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 
   /**
    * <p>Amazon S3 can return this if your request involves a bucket that is either a source or
-   *          destination in a replication rule.</p>
+   * destination in a replication rule.</p>
    */
   ReplicationStatus?: ReplicationStatus | string;
 
@@ -7250,7 +7250,7 @@ export interface GetObjectOutput {
 
   /**
    * <p>Indicates whether this object has an active legal hold. This field is only returned if
-   *          you have permission to view an object's legal hold status. </p>
+   * you have permission to view an object's legal hold status. </p>
    */
   ObjectLockLegalHoldStatus?: ObjectLockLegalHoldStatus | string;
 }
@@ -7268,32 +7268,32 @@ export namespace GetObjectOutput {
 export interface GetObjectRequest {
   /**
    * <p>The bucket name containing the object. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
   /**
    * <p>Return the object only if its entity tag (ETag) is the same as the one specified,
-   *          otherwise return a 412 (precondition failed).</p>
+   * otherwise return a 412 (precondition failed).</p>
    */
   IfMatch?: string;
 
   /**
    * <p>Return the object only if it has been modified since the specified time, otherwise
-   *          return a 304 (not modified).</p>
+   * return a 304 (not modified).</p>
    */
   IfModifiedSince?: Date;
 
   /**
    * <p>Return the object only if its entity tag (ETag) is different from the one specified,
-   *          otherwise return a 304 (not modified).</p>
+   * otherwise return a 304 (not modified).</p>
    */
   IfNoneMatch?: string;
 
   /**
    * <p>Return the object only if it has not been modified since the specified time, otherwise
-   *          return a 412 (precondition failed).</p>
+   * return a 412 (precondition failed).</p>
    */
   IfUnmodifiedSince?: Date;
 
@@ -7304,11 +7304,11 @@ export interface GetObjectRequest {
 
   /**
    * <p>Downloads the specified range bytes of an object. For more information about the HTTP
-   *          Range header, see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35">https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35</a>.</p>
-   *          <note>
-   *             <p>Amazon S3 doesn't support retrieving multiple ranges of data per <code>GET</code>
-   *             request.</p>
-   *          </note>
+   * Range header, see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35">https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35</a>.</p>
+   * <note>
+   *    <p>Amazon S3 doesn't support retrieving multiple ranges of data per <code>GET</code>
+   *    request.</p>
+   * </note>
    */
   Range?: string;
 
@@ -7349,37 +7349,37 @@ export interface GetObjectRequest {
 
   /**
    * <p>Specifies the algorithm to use to when decrypting the object (for example,
-   *          AES256).</p>
+   * AES256).</p>
    */
   SSECustomerAlgorithm?: string;
 
   /**
    * <p>Specifies the customer-provided encryption key for Amazon S3 used to encrypt the data. This
-   *          value is used to decrypt the object when recovering it and must match the one used when
-   *          storing the data. The key must be appropriate for use with the algorithm specified in the
-   *             <code>x-amz-server-side-encryption-customer-algorithm</code> header.</p>
+   * value is used to decrypt the object when recovering it and must match the one used when
+   * storing the data. The key must be appropriate for use with the algorithm specified in the
+   *    <code>x-amz-server-side-encryption-customer-algorithm</code> header.</p>
    */
   SSECustomerKey?: string;
 
   /**
    * <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses
-   *          this header for a message integrity check to ensure that the encryption key was transmitted
-   *          without error.</p>
+   * this header for a message integrity check to ensure that the encryption key was transmitted
+   * without error.</p>
    */
   SSECustomerKeyMD5?: string;
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
   /**
    * <p>Part number of the object being read. This is a positive integer between 1 and 10,000.
-   *          Effectively performs a 'ranged' GET request for the part specified. Useful for downloading
-   *          just a part of an object.</p>
+   * Effectively performs a 'ranged' GET request for the part specified. Useful for downloading
+   * just a part of an object.</p>
    */
   PartNumber?: number;
 
@@ -7448,7 +7448,7 @@ export interface GetObjectAclOutput {
 
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -7465,7 +7465,7 @@ export namespace GetObjectAclOutput {
 export interface GetObjectAclRequest {
   /**
    * <p>The bucket name that contains the object for which to get the ACL information. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -7481,9 +7481,9 @@ export interface GetObjectAclRequest {
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -7540,7 +7540,7 @@ export namespace GetObjectLegalHoldOutput {
 export interface GetObjectLegalHoldRequest {
   /**
    * <p>The bucket name containing the object whose Legal Hold status you want to retrieve. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -7556,9 +7556,9 @@ export interface GetObjectLegalHoldRequest {
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -7583,37 +7583,37 @@ export type ObjectLockRetentionMode = "COMPLIANCE" | "GOVERNANCE";
 
 /**
  * <p>The container element for specifying the default Object Lock retention settings for new
- *          objects placed in the specified bucket.</p>
- *          <note>
- *             <ul>
- *                <li>
- *                   <p>The <code>DefaultRetention</code> settings require both a mode and a
- *                period.</p>
- *                </li>
- *                <li>
- *                   <p>The <code>DefaultRetention</code> period can be either <code>Days</code>
- *                or <code>Years</code> but you must select one. You cannot specify <code>Days</code>
- *                and <code>Years</code> at the same time.</p>
- *                </li>
- *             </ul>
- *          </note>
+ * objects placed in the specified bucket.</p>
+ * <note>
+ *    <ul>
+ *       <li>
+ *          <p>The <code>DefaultRetention</code> settings require both a mode and a
+ *       period.</p>
+ *       </li>
+ *       <li>
+ *          <p>The <code>DefaultRetention</code> period can be either <code>Days</code>
+ *       or <code>Years</code> but you must select one. You cannot specify <code>Days</code>
+ *       and <code>Years</code> at the same time.</p>
+ *       </li>
+ *    </ul>
+ * </note>
  */
 export interface DefaultRetention {
   /**
    * <p>The default Object Lock retention mode you want to apply to new objects placed in the
-   *          specified bucket. Must be used with either <code>Days</code> or <code>Years</code>.</p>
+   * specified bucket. Must be used with either <code>Days</code> or <code>Years</code>.</p>
    */
   Mode?: ObjectLockRetentionMode | string;
 
   /**
    * <p>The number of days that you want to specify for the default retention period. Must be
-   *          used with <code>Mode</code>.</p>
+   * used with <code>Mode</code>.</p>
    */
   Days?: number;
 
   /**
    * <p>The number of years that you want to specify for the default retention period. Must be
-   *          used with <code>Mode</code>.</p>
+   * used with <code>Mode</code>.</p>
    */
   Years?: number;
 }
@@ -7633,9 +7633,9 @@ export namespace DefaultRetention {
 export interface ObjectLockRule {
   /**
    * <p>The default Object Lock retention mode and period that you want to apply to new objects
-   *          placed in the specified bucket. Bucket settings require both a mode and a period.
-   *          The period can be either <code>Days</code> or <code>Years</code> but you must select one.
-   *          You cannot specify <code>Days</code> and <code>Years</code> at the same time.</p>
+   * placed in the specified bucket. Bucket settings require both a mode and a period.
+   * The period can be either <code>Days</code> or <code>Years</code> but you must select one.
+   * You cannot specify <code>Days</code> and <code>Years</code> at the same time.</p>
    */
   DefaultRetention?: DefaultRetention;
 }
@@ -7655,16 +7655,16 @@ export namespace ObjectLockRule {
 export interface ObjectLockConfiguration {
   /**
    * <p>Indicates whether this bucket has an Object Lock configuration enabled.
-   *          Enable <code>ObjectLockEnabled</code> when you apply <code>ObjectLockConfiguration</code>
-   *          to a bucket. </p>
+   * Enable <code>ObjectLockEnabled</code> when you apply <code>ObjectLockConfiguration</code>
+   * to a bucket. </p>
    */
   ObjectLockEnabled?: ObjectLockEnabled | string;
 
   /**
    * <p>Specifies the Object Lock rule for the specified object. Enable the this rule when you apply
-   *          <code>ObjectLockConfiguration</code> to a bucket. Bucket settings require both a mode and a period.
-   *          The period can be either <code>Days</code> or <code>Years</code> but you must select one.
-   *          You cannot specify <code>Days</code> and <code>Years</code> at the same time.</p>
+   * <code>ObjectLockConfiguration</code> to a bucket. Bucket settings require both a mode and a period.
+   * The period can be either <code>Days</code> or <code>Years</code> but you must select one.
+   * You cannot specify <code>Days</code> and <code>Years</code> at the same time.</p>
    */
   Rule?: ObjectLockRule;
 }
@@ -7697,7 +7697,7 @@ export namespace GetObjectLockConfigurationOutput {
 export interface GetObjectLockConfigurationRequest {
   /**
    * <p>The bucket whose Object Lock configuration you want to retrieve.</p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -7759,7 +7759,7 @@ export namespace GetObjectRetentionOutput {
 export interface GetObjectRetentionRequest {
   /**
    * <p>The bucket name containing the object whose retention settings you want to retrieve. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -7775,9 +7775,9 @@ export interface GetObjectRetentionRequest {
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -7820,8 +7820,8 @@ export namespace GetObjectTaggingOutput {
 export interface GetObjectTaggingRequest {
   /**
    * <p>The bucket name containing the object for which to get the tagging information. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -7842,9 +7842,9 @@ export interface GetObjectTaggingRequest {
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 }
@@ -7866,7 +7866,7 @@ export interface GetObjectTorrentOutput {
 
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -7893,9 +7893,9 @@ export interface GetObjectTorrentRequest {
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -7916,55 +7916,55 @@ export namespace GetObjectTorrentRequest {
 
 /**
  * <p>The PublicAccessBlock configuration that you want to apply to this Amazon S3 bucket. You can
- *          enable the configuration options in any combination. For more information about when Amazon S3
- *          considers a bucket or object public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a> in the <i>Amazon S3 User Guide</i>. </p>
+ * enable the configuration options in any combination. For more information about when Amazon S3
+ * considers a bucket or object public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a> in the <i>Amazon S3 User Guide</i>. </p>
  */
 export interface PublicAccessBlockConfiguration {
   /**
    * <p>Specifies whether Amazon S3 should block public access control lists (ACLs) for this bucket
-   *          and objects in this bucket. Setting this element to <code>TRUE</code> causes the following
-   *          behavior:</p>
-   *          <ul>
-   *             <li>
-   *                <p>PUT Bucket acl and PUT Object acl calls fail if the specified ACL is
-   *                public.</p>
-   *             </li>
-   *             <li>
-   *                <p>PUT Object calls fail if the request includes a public ACL.</p>
-   *             </li>
-   *             <li>
-   *                <p>PUT Bucket calls fail if the request includes a public ACL.</p>
-   *             </li>
-   *          </ul>
-   *          <p>Enabling this setting doesn't affect existing policies or ACLs.</p>
+   * and objects in this bucket. Setting this element to <code>TRUE</code> causes the following
+   * behavior:</p>
+   * <ul>
+   *    <li>
+   *       <p>PUT Bucket acl and PUT Object acl calls fail if the specified ACL is
+   *       public.</p>
+   *    </li>
+   *    <li>
+   *       <p>PUT Object calls fail if the request includes a public ACL.</p>
+   *    </li>
+   *    <li>
+   *       <p>PUT Bucket calls fail if the request includes a public ACL.</p>
+   *    </li>
+   * </ul>
+   * <p>Enabling this setting doesn't affect existing policies or ACLs.</p>
    */
   BlockPublicAcls?: boolean;
 
   /**
    * <p>Specifies whether Amazon S3 should ignore public ACLs for this bucket and objects in this
-   *          bucket. Setting this element to <code>TRUE</code> causes Amazon S3 to ignore all public ACLs on
-   *          this bucket and objects in this bucket.</p>
-   *          <p>Enabling this setting doesn't affect the persistence of any existing ACLs and doesn't
-   *          prevent new public ACLs from being set.</p>
+   * bucket. Setting this element to <code>TRUE</code> causes Amazon S3 to ignore all public ACLs on
+   * this bucket and objects in this bucket.</p>
+   * <p>Enabling this setting doesn't affect the persistence of any existing ACLs and doesn't
+   * prevent new public ACLs from being set.</p>
    */
   IgnorePublicAcls?: boolean;
 
   /**
    * <p>Specifies whether Amazon S3 should block public bucket policies for this bucket. Setting this
-   *          element to <code>TRUE</code> causes Amazon S3 to reject calls to PUT Bucket policy if the
-   *          specified bucket policy allows public access. </p>
-   *          <p>Enabling this setting doesn't affect existing bucket policies.</p>
+   * element to <code>TRUE</code> causes Amazon S3 to reject calls to PUT Bucket policy if the
+   * specified bucket policy allows public access. </p>
+   * <p>Enabling this setting doesn't affect existing bucket policies.</p>
    */
   BlockPublicPolicy?: boolean;
 
   /**
    * <p>Specifies whether Amazon S3 should restrict public bucket policies for this bucket. Setting
-   *          this element to <code>TRUE</code> restricts access to this bucket to only Amazon Web Service
-   *          principals and authorized users within this account if the bucket has a public
-   *          policy.</p>
-   *          <p>Enabling this setting doesn't affect previously stored bucket policies, except that
-   *          public and cross-account access within any public bucket policy, including non-public
-   *          delegation to specific accounts, is blocked.</p>
+   * this element to <code>TRUE</code> restricts access to this bucket to only Amazon Web Service
+   * principals and authorized users within this account if the bucket has a public
+   * policy.</p>
+   * <p>Enabling this setting doesn't affect previously stored bucket policies, except that
+   * public and cross-account access within any public bucket policy, including non-public
+   * delegation to specific accounts, is blocked.</p>
    */
   RestrictPublicBuckets?: boolean;
 }
@@ -7981,7 +7981,7 @@ export namespace PublicAccessBlockConfiguration {
 export interface GetPublicAccessBlockOutput {
   /**
    * <p>The <code>PublicAccessBlock</code> configuration currently in effect for this Amazon S3
-   *          bucket.</p>
+   * bucket.</p>
    */
   PublicAccessBlockConfiguration?: PublicAccessBlockConfiguration;
 }
@@ -7998,7 +7998,7 @@ export namespace GetPublicAccessBlockOutput {
 export interface GetPublicAccessBlockRequest {
   /**
    * <p>The name of the Amazon S3 bucket whose <code>PublicAccessBlock</code> configuration you want
-   *          to retrieve. </p>
+   * to retrieve. </p>
    */
   Bucket: string | undefined;
 
@@ -8020,8 +8020,8 @@ export namespace GetPublicAccessBlockRequest {
 export interface HeadBucketRequest {
   /**
    * <p>The bucket name.</p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -8062,7 +8062,7 @@ export type ArchiveStatus = "ARCHIVE_ACCESS" | "DEEP_ARCHIVE_ACCESS";
 export interface HeadObjectOutput {
   /**
    * <p>Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If
-   *          false, this response header does not appear in the response.</p>
+   * false, this response header does not appear in the response.</p>
    */
   DeleteMarker?: boolean;
 
@@ -8073,27 +8073,27 @@ export interface HeadObjectOutput {
 
   /**
    * <p>If the object expiration is configured (see PUT Bucket lifecycle), the response includes
-   *          this header. It includes the expiry-date and rule-id key-value pairs providing object
-   *          expiration information. The value of the rule-id is URL encoded.</p>
+   * this header. It includes the expiry-date and rule-id key-value pairs providing object
+   * expiration information. The value of the rule-id is URL encoded.</p>
    */
   Expiration?: string;
 
   /**
    * <p>If the object is an archived object (an object whose storage class is GLACIER), the
-   *          response includes this header if either the archive restoration is in progress (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a> or an archive copy is already restored.</p>
+   * response includes this header if either the archive restoration is in progress (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a> or an archive copy is already restored.</p>
    *
-   *          <p> If an archive copy is already restored, the header value indicates when Amazon S3 is
-   *          scheduled to delete the object copy. For example:</p>
+   * <p> If an archive copy is already restored, the header value indicates when Amazon S3 is
+   * scheduled to delete the object copy. For example:</p>
    *
-   *          <p>
-   *             <code>x-amz-restore: ongoing-request="false", expiry-date="Fri, 21 Dec 2012 00:00:00
-   *             GMT"</code>
-   *          </p>
+   * <p>
+   *    <code>x-amz-restore: ongoing-request="false", expiry-date="Fri, 21 Dec 2012 00:00:00
+   *    GMT"</code>
+   * </p>
    *
-   *          <p>If the object restoration is in progress, the header returns the value
-   *             <code>ongoing-request="true"</code>.</p>
+   * <p>If the object restoration is in progress, the header returns the value
+   *    <code>ongoing-request="true"</code>.</p>
    *
-   *          <p>For more information about archiving objects, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html#lifecycle-transition-general-considerations">Transitioning Objects: General Considerations</a>.</p>
+   * <p>For more information about archiving objects, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html#lifecycle-transition-general-considerations">Transitioning Objects: General Considerations</a>.</p>
    */
   Restore?: string;
 
@@ -8114,15 +8114,15 @@ export interface HeadObjectOutput {
 
   /**
    * <p>An ETag is an opaque identifier assigned by a web server to a specific version of a
-   *          resource found at a URL.</p>
+   * resource found at a URL.</p>
    */
   ETag?: string;
 
   /**
    * <p>This is set to the number of metadata entries not returned in <code>x-amz-meta</code>
-   *          headers. This can happen if you create metadata using an API like SOAP that supports more
-   *          flexible metadata than the REST API. For example, using SOAP, you can create metadata whose
-   *          values are not legal HTTP headers.</p>
+   * headers. This can happen if you create metadata using an API like SOAP that supports more
+   * flexible metadata than the REST API. For example, using SOAP, you can create metadata whose
+   * values are not legal HTTP headers.</p>
    */
   MissingMeta?: number;
 
@@ -8143,8 +8143,8 @@ export interface HeadObjectOutput {
 
   /**
    * <p>Specifies what content encodings have been applied to the object and thus what decoding
-   *          mechanisms must be applied to obtain the media-type referenced by the Content-Type header
-   *          field.</p>
+   * mechanisms must be applied to obtain the media-type referenced by the Content-Type header
+   * field.</p>
    */
   ContentEncoding?: string;
 
@@ -8165,16 +8165,16 @@ export interface HeadObjectOutput {
 
   /**
    * <p>If the bucket is configured as a website, redirects requests for this object to another
-   *          object in the same bucket or to an external URL. Amazon S3 stores the value of this header in
-   *          the object metadata.</p>
+   * object in the same bucket or to an external URL. Amazon S3 stores the value of this header in
+   * the object metadata.</p>
    */
   WebsiteRedirectLocation?: string;
 
   /**
    * <p>If the object is stored using server-side encryption either with an Amazon Web Services KMS customer
-   *          master key (CMK) or an Amazon S3-managed encryption key, the response includes this header with
-   *          the value of the server-side encryption algorithm used when storing this object in Amazon
-   *          S3 (for example, AES256, aws:kms).</p>
+   * master key (CMK) or an Amazon S3-managed encryption key, the response includes this header with
+   * the value of the server-side encryption algorithm used when storing this object in Amazon
+   * S3 (for example, AES256, aws:kms).</p>
    */
   ServerSideEncryption?: ServerSideEncryption | string;
 
@@ -8185,20 +8185,20 @@ export interface HeadObjectOutput {
 
   /**
    * <p>If server-side encryption with a customer-provided encryption key was requested, the
-   *          response will include this header confirming the encryption algorithm used.</p>
+   * response will include this header confirming the encryption algorithm used.</p>
    */
   SSECustomerAlgorithm?: string;
 
   /**
    * <p>If server-side encryption with a customer-provided encryption key was requested, the
-   *          response will include this header to provide round-trip message integrity verification of
-   *          the customer-provided encryption key.</p>
+   * response will include this header to provide round-trip message integrity verification of
+   * the customer-provided encryption key.</p>
    */
   SSECustomerKeyMD5?: string;
 
   /**
    * <p>If present, specifies the ID of the Amazon Web Services Key Management Service (Amazon Web Services KMS) symmetric
-   *          customer managed customer master key (CMK) that was used for the object.</p>
+   * customer managed customer master key (CMK) that was used for the object.</p>
    */
   SSEKMSKeyId?: string;
 
@@ -8209,58 +8209,58 @@ export interface HeadObjectOutput {
 
   /**
    * <p>Provides storage class information of the object. Amazon S3 returns this header for all
-   *          objects except for S3 Standard storage class objects.</p>
+   * objects except for S3 Standard storage class objects.</p>
    *
-   *          <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage
-   *             Classes</a>.</p>
+   * <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage
+   *    Classes</a>.</p>
    */
   StorageClass?: StorageClass | string;
 
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 
   /**
    * <p>Amazon S3 can return this header if your request involves a bucket that is either a source or
-   *          a destination in a replication rule.</p>
+   * a destination in a replication rule.</p>
    *
-   *          <p>In replication, you have a source bucket on which you configure replication and
-   *          destination bucket or buckets where Amazon S3 stores object replicas. When you request an object
-   *             (<code>GetObject</code>) or object metadata (<code>HeadObject</code>) from these
-   *          buckets, Amazon S3 will return the <code>x-amz-replication-status</code> header in the response
-   *          as follows:</p>
-   *          <ul>
-   *             <li>
-   *                <p>If requesting an object from the source bucket — Amazon S3 will return the
-   *                   <code>x-amz-replication-status</code> header if the object in your request is
-   *                eligible for replication.</p>
-   *                <p> For example, suppose that in your replication configuration, you specify object
-   *                prefix <code>TaxDocs</code> requesting Amazon S3 to replicate objects with key prefix
-   *                   <code>TaxDocs</code>. Any objects you upload with this key name prefix, for
-   *                example <code>TaxDocs/document1.pdf</code>, are eligible for replication. For any
-   *                object request with this key name prefix, Amazon S3 will return the
-   *                   <code>x-amz-replication-status</code> header with value PENDING, COMPLETED or
-   *                FAILED indicating object replication status.</p>
-   *             </li>
-   *             <li>
-   *                <p>If requesting an object from a destination bucket — Amazon S3 will return the
-   *                   <code>x-amz-replication-status</code> header with value REPLICA if the object in
-   *                your request is a replica that Amazon S3 created and there is no replica modification
-   *                replication in progress.</p>
-   *             </li>
-   *             <li>
-   *                <p>When replicating objects to multiple destination buckets the
-   *                   <code>x-amz-replication-status</code> header acts differently. The header of the
-   *                source object will only return a value of COMPLETED when replication is successful to
-   *                all destinations. The header will remain at value PENDING until replication has
-   *                completed for all destinations. If one or more destinations fails replication the
-   *                header will return FAILED. </p>
-   *             </li>
-   *          </ul>
+   * <p>In replication, you have a source bucket on which you configure replication and
+   * destination bucket or buckets where Amazon S3 stores object replicas. When you request an object
+   *    (<code>GetObject</code>) or object metadata (<code>HeadObject</code>) from these
+   * buckets, Amazon S3 will return the <code>x-amz-replication-status</code> header in the response
+   * as follows:</p>
+   * <ul>
+   *    <li>
+   *       <p>If requesting an object from the source bucket — Amazon S3 will return the
+   *          <code>x-amz-replication-status</code> header if the object in your request is
+   *       eligible for replication.</p>
+   *       <p> For example, suppose that in your replication configuration, you specify object
+   *       prefix <code>TaxDocs</code> requesting Amazon S3 to replicate objects with key prefix
+   *          <code>TaxDocs</code>. Any objects you upload with this key name prefix, for
+   *       example <code>TaxDocs/document1.pdf</code>, are eligible for replication. For any
+   *       object request with this key name prefix, Amazon S3 will return the
+   *          <code>x-amz-replication-status</code> header with value PENDING, COMPLETED or
+   *       FAILED indicating object replication status.</p>
+   *    </li>
+   *    <li>
+   *       <p>If requesting an object from a destination bucket — Amazon S3 will return the
+   *          <code>x-amz-replication-status</code> header with value REPLICA if the object in
+   *       your request is a replica that Amazon S3 created and there is no replica modification
+   *       replication in progress.</p>
+   *    </li>
+   *    <li>
+   *       <p>When replicating objects to multiple destination buckets the
+   *          <code>x-amz-replication-status</code> header acts differently. The header of the
+   *       source object will only return a value of COMPLETED when replication is successful to
+   *       all destinations. The header will remain at value PENDING until replication has
+   *       completed for all destinations. If one or more destinations fails replication the
+   *       header will return FAILED. </p>
+   *    </li>
+   * </ul>
    *
-   *          <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Replication</a>.</p>
+   * <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html">Replication</a>.</p>
    */
   ReplicationStatus?: ReplicationStatus | string;
 
@@ -8271,23 +8271,23 @@ export interface HeadObjectOutput {
 
   /**
    * <p>The Object Lock mode, if any, that's in effect for this object. This header is only
-   *          returned if the requester has the <code>s3:GetObjectRetention</code> permission. For more
-   *          information about S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Object
-   *             Lock</a>. </p>
+   * returned if the requester has the <code>s3:GetObjectRetention</code> permission. For more
+   * information about S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Object
+   *    Lock</a>. </p>
    */
   ObjectLockMode?: ObjectLockMode | string;
 
   /**
    * <p>The date and time when the Object Lock retention period expires. This header is only
-   *          returned if the requester has the <code>s3:GetObjectRetention</code> permission.</p>
+   * returned if the requester has the <code>s3:GetObjectRetention</code> permission.</p>
    */
   ObjectLockRetainUntilDate?: Date;
 
   /**
    * <p>Specifies whether a legal hold is in effect for this object. This header is only
-   *          returned if the requester has the <code>s3:GetObjectLegalHold</code> permission. This
-   *          header is not returned if the specified version of this object has never had a legal hold
-   *          applied. For more information about S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Object Lock</a>.</p>
+   * returned if the requester has the <code>s3:GetObjectLegalHold</code> permission. This
+   * header is not returned if the specified version of this object has never had a legal hold
+   * applied. For more information about S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Object Lock</a>.</p>
    */
   ObjectLockLegalHoldStatus?: ObjectLockLegalHoldStatus | string;
 }
@@ -8305,32 +8305,32 @@ export namespace HeadObjectOutput {
 export interface HeadObjectRequest {
   /**
    * <p>The name of the bucket containing the object.</p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
   /**
    * <p>Return the object only if its entity tag (ETag) is the same as the one specified,
-   *          otherwise return a 412 (precondition failed).</p>
+   * otherwise return a 412 (precondition failed).</p>
    */
   IfMatch?: string;
 
   /**
    * <p>Return the object only if it has been modified since the specified time, otherwise
-   *          return a 304 (not modified).</p>
+   * return a 304 (not modified).</p>
    */
   IfModifiedSince?: Date;
 
   /**
    * <p>Return the object only if its entity tag (ETag) is different from the one specified,
-   *          otherwise return a 304 (not modified).</p>
+   * otherwise return a 304 (not modified).</p>
    */
   IfNoneMatch?: string;
 
   /**
    * <p>Return the object only if it has not been modified since the specified time, otherwise
-   *          return a 412 (precondition failed).</p>
+   * return a 412 (precondition failed).</p>
    */
   IfUnmodifiedSince?: Date;
 
@@ -8341,11 +8341,11 @@ export interface HeadObjectRequest {
 
   /**
    * <p>Downloads the specified range bytes of an object. For more information about the HTTP
-   *          Range header, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35">http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35</a>.</p>
-   *          <note>
-   *             <p>Amazon S3 doesn't support retrieving multiple ranges of data per <code>GET</code>
-   *             request.</p>
-   *          </note>
+   * Range header, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35">http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35</a>.</p>
+   * <note>
+   *    <p>Amazon S3 doesn't support retrieving multiple ranges of data per <code>GET</code>
+   *    request.</p>
+   * </note>
    */
   Range?: string;
 
@@ -8356,37 +8356,37 @@ export interface HeadObjectRequest {
 
   /**
    * <p>Specifies the algorithm to use to when encrypting the object (for example,
-   *          AES256).</p>
+   * AES256).</p>
    */
   SSECustomerAlgorithm?: string;
 
   /**
    * <p>Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This
-   *          value is used to store the object and then it is discarded; Amazon S3 does not store the
-   *          encryption key. The key must be appropriate for use with the algorithm specified in the
-   *             <code>x-amz-server-side-encryption-customer-algorithm</code> header.</p>
+   * value is used to store the object and then it is discarded; Amazon S3 does not store the
+   * encryption key. The key must be appropriate for use with the algorithm specified in the
+   *    <code>x-amz-server-side-encryption-customer-algorithm</code> header.</p>
    */
   SSECustomerKey?: string;
 
   /**
    * <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses
-   *          this header for a message integrity check to ensure that the encryption key was transmitted
-   *          without error.</p>
+   * this header for a message integrity check to ensure that the encryption key was transmitted
+   * without error.</p>
    */
   SSECustomerKeyMD5?: string;
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
   /**
    * <p>Part number of the object being read. This is a positive integer between 1 and 10,000.
-   *          Effectively performs a 'ranged' HEAD request for the part specified. Useful querying about
-   *          the size of the part and the number of parts in this object.</p>
+   * Effectively performs a 'ranged' HEAD request for the part specified. Useful querying about
+   * the size of the part and the number of parts in this object.</p>
    */
   PartNumber?: number;
 
@@ -8409,23 +8409,23 @@ export namespace HeadObjectRequest {
 export interface ListBucketAnalyticsConfigurationsOutput {
   /**
    * <p>Indicates whether the returned list of analytics configurations is complete. A value of
-   *          true indicates that the list is not complete and the NextContinuationToken will be provided
-   *          for a subsequent request.</p>
+   * true indicates that the list is not complete and the NextContinuationToken will be provided
+   * for a subsequent request.</p>
    */
   IsTruncated?: boolean;
 
   /**
    * <p>The marker that is used as a starting point for this analytics configuration list
-   *          response. This value is present if it was sent in the request.</p>
+   * response. This value is present if it was sent in the request.</p>
    */
   ContinuationToken?: string;
 
   /**
    * <p>
-   *             <code>NextContinuationToken</code> is sent when <code>isTruncated</code> is true, which
-   *          indicates that there are more analytics configurations to list. The next request must
-   *          include this <code>NextContinuationToken</code>. The token is obfuscated and is not a
-   *          usable value.</p>
+   *    <code>NextContinuationToken</code> is sent when <code>isTruncated</code> is true, which
+   * indicates that there are more analytics configurations to list. The next request must
+   * include this <code>NextContinuationToken</code>. The token is obfuscated and is not a
+   * usable value.</p>
    */
   NextContinuationToken?: string;
 
@@ -8457,7 +8457,7 @@ export interface ListBucketAnalyticsConfigurationsRequest {
 
   /**
    * <p>The ContinuationToken that represents a placeholder from where this request should
-   *          begin.</p>
+   * begin.</p>
    */
   ContinuationToken?: string;
 
@@ -8479,21 +8479,21 @@ export namespace ListBucketAnalyticsConfigurationsRequest {
 export interface ListBucketIntelligentTieringConfigurationsOutput {
   /**
    * <p>Indicates whether the returned list of analytics configurations is complete. A value of
-   *          true indicates that the list is not complete and the NextContinuationToken will be provided
-   *          for a subsequent request.</p>
+   * true indicates that the list is not complete and the NextContinuationToken will be provided
+   * for a subsequent request.</p>
    */
   IsTruncated?: boolean;
 
   /**
    * <p>The ContinuationToken that represents a placeholder from where this request should
-   *          begin.</p>
+   * begin.</p>
    */
   ContinuationToken?: string;
 
   /**
    * <p>The marker used to continue this inventory configuration listing. Use the
-   *             <code>NextContinuationToken</code> from this response to continue the listing in a
-   *          subsequent request. The continuation token is an opaque value that Amazon S3 understands.</p>
+   *    <code>NextContinuationToken</code> from this response to continue the listing in a
+   * subsequent request. The continuation token is an opaque value that Amazon S3 understands.</p>
    */
   NextContinuationToken?: string;
 
@@ -8520,7 +8520,7 @@ export interface ListBucketIntelligentTieringConfigurationsRequest {
 
   /**
    * <p>The ContinuationToken that represents a placeholder from where this request should
-   *          begin.</p>
+   * begin.</p>
    */
   ContinuationToken?: string;
 }
@@ -8537,7 +8537,7 @@ export namespace ListBucketIntelligentTieringConfigurationsRequest {
 export interface ListBucketInventoryConfigurationsOutput {
   /**
    * <p>If sent in the request, the marker that is used as a starting point for this inventory
-   *          configuration list response.</p>
+   * configuration list response.</p>
    */
   ContinuationToken?: string;
 
@@ -8548,15 +8548,15 @@ export interface ListBucketInventoryConfigurationsOutput {
 
   /**
    * <p>Tells whether the returned list of inventory configurations is complete. A value of true
-   *          indicates that the list is not complete and the NextContinuationToken is provided for a
-   *          subsequent request.</p>
+   * indicates that the list is not complete and the NextContinuationToken is provided for a
+   * subsequent request.</p>
    */
   IsTruncated?: boolean;
 
   /**
    * <p>The marker used to continue this inventory configuration listing. Use the
-   *             <code>NextContinuationToken</code> from this response to continue the listing in a
-   *          subsequent request. The continuation token is an opaque value that Amazon S3 understands.</p>
+   *    <code>NextContinuationToken</code> from this response to continue the listing in a
+   * subsequent request. The continuation token is an opaque value that Amazon S3 understands.</p>
    */
   NextContinuationToken?: string;
 }
@@ -8583,8 +8583,8 @@ export interface ListBucketInventoryConfigurationsRequest {
 
   /**
    * <p>The marker used to continue an inventory configuration listing that has been truncated.
-   *          Use the NextContinuationToken from a previously truncated list response to continue the
-   *          listing. The continuation token is an opaque value that Amazon S3 understands.</p>
+   * Use the NextContinuationToken from a previously truncated list response to continue the
+   * listing. The continuation token is an opaque value that Amazon S3 understands.</p>
    */
   ContinuationToken?: string;
 
@@ -8606,22 +8606,22 @@ export namespace ListBucketInventoryConfigurationsRequest {
 export interface ListBucketMetricsConfigurationsOutput {
   /**
    * <p>Indicates whether the returned list of metrics configurations is complete. A value of
-   *          true indicates that the list is not complete and the NextContinuationToken will be provided
-   *          for a subsequent request.</p>
+   * true indicates that the list is not complete and the NextContinuationToken will be provided
+   * for a subsequent request.</p>
    */
   IsTruncated?: boolean;
 
   /**
    * <p>The marker that is used as a starting point for this metrics configuration list
-   *          response. This value is present if it was sent in the request.</p>
+   * response. This value is present if it was sent in the request.</p>
    */
   ContinuationToken?: string;
 
   /**
    * <p>The marker used to continue a metrics configuration listing that has been truncated. Use
-   *          the <code>NextContinuationToken</code> from a previously truncated list response to
-   *          continue the listing. The continuation token is an opaque value that Amazon S3
-   *          understands.</p>
+   * the <code>NextContinuationToken</code> from a previously truncated list response to
+   * continue the listing. The continuation token is an opaque value that Amazon S3
+   * understands.</p>
    */
   NextContinuationToken?: string;
 
@@ -8653,9 +8653,9 @@ export interface ListBucketMetricsConfigurationsRequest {
 
   /**
    * <p>The marker that is used to continue a metrics configuration listing that has been
-   *          truncated. Use the NextContinuationToken from a previously truncated list response to
-   *          continue the listing. The continuation token is an opaque value that Amazon S3
-   *          understands.</p>
+   * truncated. Use the NextContinuationToken from a previously truncated list response to
+   * continue the listing. The continuation token is an opaque value that Amazon S3
+   * understands.</p>
    */
   ContinuationToken?: string;
 
@@ -8676,7 +8676,7 @@ export namespace ListBucketMetricsConfigurationsRequest {
 
 /**
  * <p> In terms of implementation, a Bucket is a resource. An Amazon S3 bucket name is globally
- *          unique, and the namespace is shared by all Amazon Web Services accounts. </p>
+ * unique, and the namespace is shared by all Amazon Web Services accounts. </p>
  */
 export interface Bucket {
   /**
@@ -8722,9 +8722,9 @@ export namespace ListBucketsOutput {
 
 /**
  * <p>Container for all (if there are any) keys between Prefix and the next occurrence of the
- *          string specified by a delimiter. CommonPrefixes lists keys that act like subdirectories in
- *          the directory specified by Prefix. For example, if the prefix is notes/ and the delimiter
- *          is a slash (/) as in notes/summer/july, the common prefix is notes/summer/. </p>
+ * string specified by a delimiter. CommonPrefixes lists keys that act like subdirectories in
+ * the directory specified by Prefix. For example, if the prefix is notes/ and the delimiter
+ * is a slash (/) as in notes/summer/july, the common prefix is notes/summer/. </p>
  */
 export interface CommonPrefix {
   /**
@@ -8750,7 +8750,7 @@ export type EncodingType = "url";
 export interface Initiator {
   /**
    * <p>If the principal is an Amazon Web Services account, it provides the Canonical User ID. If the principal
-   *          is an IAM User, it provides a user ARN value.</p>
+   * is an IAM User, it provides a user ARN value.</p>
    */
   ID?: string;
 
@@ -8831,63 +8831,63 @@ export interface ListMultipartUploadsOutput {
 
   /**
    * <p>When a list is truncated, this element specifies the value that should be used for the
-   *          key-marker request parameter in a subsequent request.</p>
+   * key-marker request parameter in a subsequent request.</p>
    */
   NextKeyMarker?: string;
 
   /**
    * <p>When a prefix is provided in the request, this field contains the specified prefix. The
-   *          result contains only keys starting with the specified prefix.</p>
+   * result contains only keys starting with the specified prefix.</p>
    */
   Prefix?: string;
 
   /**
    * <p>Contains the delimiter you specified in the request. If you don't specify a delimiter in
-   *          your request, this element is absent from the response.</p>
+   * your request, this element is absent from the response.</p>
    */
   Delimiter?: string;
 
   /**
    * <p>When a list is truncated, this element specifies the value that should be used for the
-   *             <code>upload-id-marker</code> request parameter in a subsequent request.</p>
+   *    <code>upload-id-marker</code> request parameter in a subsequent request.</p>
    */
   NextUploadIdMarker?: string;
 
   /**
    * <p>Maximum number of multipart uploads that could have been included in the
-   *          response.</p>
+   * response.</p>
    */
   MaxUploads?: number;
 
   /**
    * <p>Indicates whether the returned list of multipart uploads is truncated. A value of true
-   *          indicates that the list was truncated. The list can be truncated if the number of multipart
-   *          uploads exceeds the limit allowed or specified by max uploads.</p>
+   * indicates that the list was truncated. The list can be truncated if the number of multipart
+   * uploads exceeds the limit allowed or specified by max uploads.</p>
    */
   IsTruncated?: boolean;
 
   /**
    * <p>Container for elements related to a particular multipart upload. A response can contain
-   *          zero or more <code>Upload</code> elements.</p>
+   * zero or more <code>Upload</code> elements.</p>
    */
   Uploads?: MultipartUpload[];
 
   /**
    * <p>If you specify a delimiter in the request, then the result returns each distinct key
-   *          prefix containing the delimiter in a <code>CommonPrefixes</code> element. The distinct key
-   *          prefixes are returned in the <code>Prefix</code> child element.</p>
+   * prefix containing the delimiter in a <code>CommonPrefixes</code> element. The distinct key
+   * prefixes are returned in the <code>Prefix</code> child element.</p>
    */
   CommonPrefixes?: CommonPrefix[];
 
   /**
    * <p>Encoding type used by Amazon S3 to encode object keys in the response.</p>
-   *          <p>If you specify <code>encoding-type</code> request parameter, Amazon S3 includes this element
-   *          in the response, and returns encoded key name values in the following response
-   *          elements:</p>
+   * <p>If you specify <code>encoding-type</code> request parameter, Amazon S3 includes this element
+   * in the response, and returns encoded key name values in the following response
+   * elements:</p>
    *
-   *          <p>
-   *             <code>Delimiter</code>, <code>KeyMarker</code>, <code>Prefix</code>,
-   *             <code>NextKeyMarker</code>, <code>Key</code>.</p>
+   * <p>
+   *    <code>Delimiter</code>, <code>KeyMarker</code>, <code>Prefix</code>,
+   *    <code>NextKeyMarker</code>, <code>Key</code>.</p>
    */
   EncodingType?: EncodingType | string;
 }
@@ -8904,63 +8904,63 @@ export namespace ListMultipartUploadsOutput {
 export interface ListMultipartUploadsRequest {
   /**
    * <p>The name of the bucket to which the multipart upload was initiated. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
   /**
    * <p>Character you use to group keys.</p>
-   *          <p>All keys that contain the same string between the prefix, if specified, and the first
-   *          occurrence of the delimiter after the prefix are grouped under a single result element,
-   *             <code>CommonPrefixes</code>. If you don't specify the prefix parameter, then the
-   *          substring starts at the beginning of the key. The keys that are grouped under
-   *             <code>CommonPrefixes</code> result element are not returned elsewhere in the
-   *          response.</p>
+   * <p>All keys that contain the same string between the prefix, if specified, and the first
+   * occurrence of the delimiter after the prefix are grouped under a single result element,
+   *    <code>CommonPrefixes</code>. If you don't specify the prefix parameter, then the
+   * substring starts at the beginning of the key. The keys that are grouped under
+   *    <code>CommonPrefixes</code> result element are not returned elsewhere in the
+   * response.</p>
    */
   Delimiter?: string;
 
   /**
    * <p>Requests Amazon S3 to encode the object keys in the response and specifies the encoding
-   *          method to use. An object key may contain any Unicode character; however, XML 1.0 parser
-   *          cannot parse some characters, such as characters with an ASCII value from 0 to 10. For
-   *          characters that are not supported in XML 1.0, you can add this parameter to request that
-   *          Amazon S3 encode the keys in the response.</p>
+   * method to use. An object key may contain any Unicode character; however, XML 1.0 parser
+   * cannot parse some characters, such as characters with an ASCII value from 0 to 10. For
+   * characters that are not supported in XML 1.0, you can add this parameter to request that
+   * Amazon S3 encode the keys in the response.</p>
    */
   EncodingType?: EncodingType | string;
 
   /**
    * <p>Together with upload-id-marker, this parameter specifies the multipart upload after
-   *          which listing should begin.</p>
-   *          <p>If <code>upload-id-marker</code> is not specified, only the keys lexicographically
-   *          greater than the specified <code>key-marker</code> will be included in the list.</p>
+   * which listing should begin.</p>
+   * <p>If <code>upload-id-marker</code> is not specified, only the keys lexicographically
+   * greater than the specified <code>key-marker</code> will be included in the list.</p>
    *
-   *          <p>If <code>upload-id-marker</code> is specified, any multipart uploads for a key equal to
-   *          the <code>key-marker</code> might also be included, provided those multipart uploads have
-   *          upload IDs lexicographically greater than the specified
-   *          <code>upload-id-marker</code>.</p>
+   * <p>If <code>upload-id-marker</code> is specified, any multipart uploads for a key equal to
+   * the <code>key-marker</code> might also be included, provided those multipart uploads have
+   * upload IDs lexicographically greater than the specified
+   * <code>upload-id-marker</code>.</p>
    */
   KeyMarker?: string;
 
   /**
    * <p>Sets the maximum number of multipart uploads, from 1 to 1,000, to return in the response
-   *          body. 1,000 is the maximum number of uploads that can be returned in a response.</p>
+   * body. 1,000 is the maximum number of uploads that can be returned in a response.</p>
    */
   MaxUploads?: number;
 
   /**
    * <p>Lists in-progress uploads only for those keys that begin with the specified prefix. You
-   *          can use prefixes to separate a bucket into different grouping of keys. (You can think of
-   *          using prefix to make groups in the same way you'd use a folder in a file system.)</p>
+   * can use prefixes to separate a bucket into different grouping of keys. (You can think of
+   * using prefix to make groups in the same way you'd use a folder in a file system.)</p>
    */
   Prefix?: string;
 
   /**
    * <p>Together with key-marker, specifies the multipart upload after which listing should
-   *          begin. If key-marker is not specified, the upload-id-marker parameter is ignored.
-   *          Otherwise, any multipart uploads for a key equal to the key-marker might be included in the
-   *          list only if they have an upload ID lexicographically greater than the specified
-   *             <code>upload-id-marker</code>.</p>
+   * begin. If key-marker is not specified, the upload-id-marker parameter is ignored.
+   * Otherwise, any multipart uploads for a key equal to the key-marker might be included in the
+   * list only if they have an upload ID lexicographically greater than the specified
+   *    <code>upload-id-marker</code>.</p>
    */
   UploadIdMarker?: string;
 
@@ -8995,7 +8995,7 @@ export type ObjectStorageClass =
 export interface _Object {
   /**
    * <p>The name that you assign to an object. You use the object key to retrieve the
-   *          object.</p>
+   * object.</p>
    */
   Key?: string;
 
@@ -9006,25 +9006,25 @@ export interface _Object {
 
   /**
    * <p>The entity tag is a hash of the object. The ETag reflects changes only to the contents
-   *          of an object, not its metadata. The ETag may or may not be an MD5 digest of the object
-   *          data. Whether or not it is depends on how the object was created and how it is encrypted as
-   *          described below:</p>
-   *          <ul>
-   *             <li>
-   *                <p>Objects created by the PUT Object, POST Object, or Copy operation, or through the
-   *                Amazon Web Services Management Console, and are encrypted by SSE-S3 or plaintext, have ETags that are
-   *                an MD5 digest of their object data.</p>
-   *             </li>
-   *             <li>
-   *                <p>Objects created by the PUT Object, POST Object, or Copy operation, or through the
-   *                Amazon Web Services Management Console, and are encrypted by SSE-C or SSE-KMS, have ETags that are
-   *                not an MD5 digest of their object data.</p>
-   *             </li>
-   *             <li>
-   *                <p>If an object is created by either the Multipart Upload or Part Copy operation, the
-   *                ETag is not an MD5 digest, regardless of the method of encryption.</p>
-   *             </li>
-   *          </ul>
+   * of an object, not its metadata. The ETag may or may not be an MD5 digest of the object
+   * data. Whether or not it is depends on how the object was created and how it is encrypted as
+   * described below:</p>
+   * <ul>
+   *    <li>
+   *       <p>Objects created by the PUT Object, POST Object, or Copy operation, or through the
+   *       Amazon Web Services Management Console, and are encrypted by SSE-S3 or plaintext, have ETags that are
+   *       an MD5 digest of their object data.</p>
+   *    </li>
+   *    <li>
+   *       <p>Objects created by the PUT Object, POST Object, or Copy operation, or through the
+   *       Amazon Web Services Management Console, and are encrypted by SSE-C or SSE-KMS, have ETags that are
+   *       not an MD5 digest of their object data.</p>
+   *    </li>
+   *    <li>
+   *       <p>If an object is created by either the Multipart Upload or Part Copy operation, the
+   *       ETag is not an MD5 digest, regardless of the method of encryption.</p>
+   *    </li>
+   * </ul>
    */
   ETag?: string;
 
@@ -9056,23 +9056,23 @@ export namespace _Object {
 export interface ListObjectsOutput {
   /**
    * <p>A flag that indicates whether Amazon S3 returned all of the results that satisfied the search
-   *          criteria.</p>
+   * criteria.</p>
    */
   IsTruncated?: boolean;
 
   /**
    * <p>Indicates where in the bucket listing begins. Marker is included in the response if it
-   *          was sent with the request.</p>
+   * was sent with the request.</p>
    */
   Marker?: string;
 
   /**
    * <p>When response is truncated (the IsTruncated element value in the response is true), you
-   *          can use the key name in this field as marker in the subsequent request to get next set of
-   *          objects. Amazon S3 lists objects in alphabetical order Note: This element is returned only if
-   *          you have delimiter request parameter specified. If response does not include the NextMarker
-   *          and it is truncated, you can use the value of the last Key in the response as the marker in
-   *          the subsequent request to get the next set of object keys.</p>
+   * can use the key name in this field as marker in the subsequent request to get next set of
+   * objects. Amazon S3 lists objects in alphabetical order Note: This element is returned only if
+   * you have delimiter request parameter specified. If response does not include the NextMarker
+   * and it is truncated, you can use the value of the last Key in the response as the marker in
+   * the subsequent request to get the next set of object keys.</p>
    */
   NextMarker?: string;
 
@@ -9093,10 +9093,10 @@ export interface ListObjectsOutput {
 
   /**
    * <p>Causes keys that contain the same string between the prefix and the first occurrence of
-   *          the delimiter to be rolled up into a single result element in the
-   *             <code>CommonPrefixes</code> collection. These rolled-up keys are not returned elsewhere
-   *          in the response. Each rolled-up result counts as only one return against the
-   *             <code>MaxKeys</code> value.</p>
+   * the delimiter to be rolled up into a single result element in the
+   *    <code>CommonPrefixes</code> collection. These rolled-up keys are not returned elsewhere
+   * in the response. Each rolled-up result counts as only one return against the
+   *    <code>MaxKeys</code> value.</p>
    */
   Delimiter?: string;
 
@@ -9107,19 +9107,19 @@ export interface ListObjectsOutput {
 
   /**
    * <p>All of the keys (up to 1,000) rolled up in a common prefix count as a single return when calculating
-   *          the number of returns. </p>
+   * the number of returns. </p>
    *
-   *          <p>A response can contain CommonPrefixes only if you specify a delimiter.</p>
+   * <p>A response can contain CommonPrefixes only if you specify a delimiter.</p>
    *
-   *          <p>CommonPrefixes contains all (if there are any) keys between Prefix and the next
-   *          occurrence of the string specified by the delimiter.</p>
+   * <p>CommonPrefixes contains all (if there are any) keys between Prefix and the next
+   * occurrence of the string specified by the delimiter.</p>
    *
-   *          <p> CommonPrefixes lists keys that act like subdirectories in the directory specified by
-   *          Prefix.</p>
+   * <p> CommonPrefixes lists keys that act like subdirectories in the directory specified by
+   * Prefix.</p>
    *
-   *          <p>For example, if the prefix is notes/ and the delimiter is a slash (/) as in
-   *          notes/summer/july, the common prefix is notes/summer/. All of the keys that roll up into a
-   *          common prefix count as a single return when calculating the number of returns.</p>
+   * <p>For example, if the prefix is notes/ and the delimiter is a slash (/) as in
+   * notes/summer/july, the common prefix is notes/summer/. All of the keys that roll up into a
+   * common prefix count as a single return when calculating the number of returns.</p>
    */
   CommonPrefixes?: CommonPrefix[];
 
@@ -9141,8 +9141,8 @@ export namespace ListObjectsOutput {
 export interface ListObjectsRequest {
   /**
    * <p>The name of the bucket containing the objects.</p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -9153,22 +9153,22 @@ export interface ListObjectsRequest {
 
   /**
    * <p>Requests Amazon S3 to encode the object keys in the response and specifies the encoding
-   *          method to use. An object key may contain any Unicode character; however, XML 1.0 parser
-   *          cannot parse some characters, such as characters with an ASCII value from 0 to 10. For
-   *          characters that are not supported in XML 1.0, you can add this parameter to request that
-   *          Amazon S3 encode the keys in the response.</p>
+   * method to use. An object key may contain any Unicode character; however, XML 1.0 parser
+   * cannot parse some characters, such as characters with an ASCII value from 0 to 10. For
+   * characters that are not supported in XML 1.0, you can add this parameter to request that
+   * Amazon S3 encode the keys in the response.</p>
    */
   EncodingType?: EncodingType | string;
 
   /**
    * <p>Marker is where you want Amazon S3 to start listing from. Amazon S3 starts listing after
-   *           this specified key. Marker can be any key in the bucket.</p>
+   *  this specified key. Marker can be any key in the bucket.</p>
    */
   Marker?: string;
 
   /**
    * <p>Sets the maximum number of keys returned in the response. By default the action returns up
-   *          to 1,000 key names. The response might contain fewer keys but will never contain more.
+   * to 1,000 key names. The response might contain fewer keys but will never contain more.
    *       </p>
    */
   MaxKeys?: number;
@@ -9180,7 +9180,7 @@ export interface ListObjectsRequest {
 
   /**
    * <p>Confirms that the requester knows that she or he will be charged for the list objects
-   *          request. Bucket owners need not specify this parameter in their requests.</p>
+   * request. Bucket owners need not specify this parameter in their requests.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -9219,8 +9219,8 @@ export namespace NoSuchBucket {
 export interface ListObjectsV2Output {
   /**
    * <p>Set to false if all of the results were returned. Set to true if more keys are available
-   *          to return. If the number of results exceeds that specified by MaxKeys, all of the results
-   *          might not be returned.</p>
+   * to return. If the number of results exceeds that specified by MaxKeys, all of the results
+   * might not be returned.</p>
    */
   IsTruncated?: boolean;
 
@@ -9231,8 +9231,8 @@ export interface ListObjectsV2Output {
 
   /**
    * <p>The bucket name.</p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Name?: string;
 
@@ -9243,57 +9243,57 @@ export interface ListObjectsV2Output {
 
   /**
    * <p>Causes keys that contain the same string between the prefix and the first occurrence of
-   *          the delimiter to be rolled up into a single result element in the CommonPrefixes
-   *          collection. These rolled-up keys are not returned elsewhere in the response. Each rolled-up
-   *          result counts as only one return against the <code>MaxKeys</code> value.</p>
+   * the delimiter to be rolled up into a single result element in the CommonPrefixes
+   * collection. These rolled-up keys are not returned elsewhere in the response. Each rolled-up
+   * result counts as only one return against the <code>MaxKeys</code> value.</p>
    */
   Delimiter?: string;
 
   /**
    * <p>Sets the maximum number of keys returned in the response. By default the action returns up
-   *          to 1,000 key names. The response might contain fewer keys but will never contain
-   *          more.</p>
+   * to 1,000 key names. The response might contain fewer keys but will never contain
+   * more.</p>
    */
   MaxKeys?: number;
 
   /**
    * <p>All of the keys (up to 1,000) rolled up into a common prefix count as a single return when calculating
-   *          the number of returns.</p>
+   * the number of returns.</p>
    *
-   *          <p>A response can contain <code>CommonPrefixes</code> only if you specify a
-   *          delimiter.</p>
+   * <p>A response can contain <code>CommonPrefixes</code> only if you specify a
+   * delimiter.</p>
    *
-   *          <p>
-   *             <code>CommonPrefixes</code> contains all (if there are any) keys between
-   *             <code>Prefix</code> and the next occurrence of the string specified by a
-   *          delimiter.</p>
+   * <p>
+   *    <code>CommonPrefixes</code> contains all (if there are any) keys between
+   *    <code>Prefix</code> and the next occurrence of the string specified by a
+   * delimiter.</p>
    *
-   *          <p>
-   *             <code>CommonPrefixes</code> lists keys that act like subdirectories in the directory
-   *          specified by <code>Prefix</code>.</p>
+   * <p>
+   *    <code>CommonPrefixes</code> lists keys that act like subdirectories in the directory
+   * specified by <code>Prefix</code>.</p>
    *
-   *          <p>For example, if the prefix is <code>notes/</code> and the delimiter is a slash
-   *             (<code>/</code>) as in <code>notes/summer/july</code>, the common prefix is
-   *             <code>notes/summer/</code>. All of the keys that roll up into a common prefix count as a
-   *          single return when calculating the number of returns. </p>
+   * <p>For example, if the prefix is <code>notes/</code> and the delimiter is a slash
+   *    (<code>/</code>) as in <code>notes/summer/july</code>, the common prefix is
+   *    <code>notes/summer/</code>. All of the keys that roll up into a common prefix count as a
+   * single return when calculating the number of returns. </p>
    */
   CommonPrefixes?: CommonPrefix[];
 
   /**
    * <p>Encoding type used by Amazon S3 to encode object key names in the XML response.</p>
    *
-   *          <p>If you specify the encoding-type request parameter, Amazon S3 includes this element in the
-   *          response, and returns encoded key name values in the following response elements:</p>
+   * <p>If you specify the encoding-type request parameter, Amazon S3 includes this element in the
+   * response, and returns encoded key name values in the following response elements:</p>
    *
-   *          <p>
-   *             <code>Delimiter, Prefix, Key,</code> and <code>StartAfter</code>.</p>
+   * <p>
+   *    <code>Delimiter, Prefix, Key,</code> and <code>StartAfter</code>.</p>
    */
   EncodingType?: EncodingType | string;
 
   /**
    * <p>KeyCount is the number of keys returned with this request. KeyCount will always be less
-   *          than or equals to MaxKeys field. Say you ask for 50 keys, your result will include less than
-   *          equals 50 keys </p>
+   * than or equals to MaxKeys field. Say you ask for 50 keys, your result will include less than
+   * equals 50 keys </p>
    */
   KeyCount?: number;
 
@@ -9304,10 +9304,10 @@ export interface ListObjectsV2Output {
 
   /**
    * <p>
-   *             <code>NextContinuationToken</code> is sent when <code>isTruncated</code> is true, which
-   *          means there are more keys in the bucket that can be listed. The next list requests to Amazon S3
-   *          can be continued with this <code>NextContinuationToken</code>.
-   *             <code>NextContinuationToken</code> is obfuscated and is not a real key</p>
+   *    <code>NextContinuationToken</code> is sent when <code>isTruncated</code> is true, which
+   * means there are more keys in the bucket that can be listed. The next list requests to Amazon S3
+   * can be continued with this <code>NextContinuationToken</code>.
+   *    <code>NextContinuationToken</code> is obfuscated and is not a real key</p>
    */
   NextContinuationToken?: string;
 
@@ -9329,8 +9329,8 @@ export namespace ListObjectsV2Output {
 export interface ListObjectsV2Request {
   /**
    * <p>Bucket name to list. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -9346,8 +9346,8 @@ export interface ListObjectsV2Request {
 
   /**
    * <p>Sets the maximum number of keys returned in the response. By default the action returns up
-   *          to 1,000 key names. The response might contain fewer keys but will never contain
-   *          more.</p>
+   * to 1,000 key names. The response might contain fewer keys but will never contain
+   * more.</p>
    */
   MaxKeys?: number;
 
@@ -9358,26 +9358,26 @@ export interface ListObjectsV2Request {
 
   /**
    * <p>ContinuationToken indicates Amazon S3 that the list is being continued on this bucket with a
-   *          token. ContinuationToken is obfuscated and is not a real key.</p>
+   * token. ContinuationToken is obfuscated and is not a real key.</p>
    */
   ContinuationToken?: string;
 
   /**
    * <p>The owner field is not present in listV2 by default, if you want to return owner field
-   *          with each key in the result then set the fetch owner field to true.</p>
+   * with each key in the result then set the fetch owner field to true.</p>
    */
   FetchOwner?: boolean;
 
   /**
    * <p>StartAfter is where you want Amazon S3 to start listing from. Amazon S3 starts listing after this
-   *          specified key. StartAfter can be any key in the bucket.</p>
+   * specified key. StartAfter can be any key in the bucket.</p>
    */
   StartAfter?: string;
 
   /**
    * <p>Confirms that the requester knows that she or he will be charged for the list objects
-   *          request in V2 style. Bucket owners need not specify this parameter in their
-   *          requests.</p>
+   * request in V2 style. Bucket owners need not specify this parameter in their
+   * requests.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -9417,7 +9417,7 @@ export interface DeleteMarkerEntry {
 
   /**
    * <p>Specifies whether the object is (true) or is not (false) the latest version of an
-   *          object.</p>
+   * object.</p>
    */
   IsLatest?: boolean;
 
@@ -9469,7 +9469,7 @@ export interface ObjectVersion {
 
   /**
    * <p>Specifies whether the object is (true) or is not (false) the latest version of an
-   *          object.</p>
+   * object.</p>
    */
   IsLatest?: boolean;
 
@@ -9496,9 +9496,9 @@ export namespace ObjectVersion {
 export interface ListObjectVersionsOutput {
   /**
    * <p>A flag that indicates whether Amazon S3 returned all of the results that satisfied the search
-   *          criteria. If your results were truncated, you can make a follow-up paginated request using
-   *          the NextKeyMarker and NextVersionIdMarker response parameters as a starting place in
-   *          another request to return the rest of the results.</p>
+   * criteria. If your results were truncated, you can make a follow-up paginated request using
+   * the NextKeyMarker and NextVersionIdMarker response parameters as a starting place in
+   * another request to return the rest of the results.</p>
    */
   IsTruncated?: boolean;
 
@@ -9514,17 +9514,17 @@ export interface ListObjectVersionsOutput {
 
   /**
    * <p>When the number of responses exceeds the value of <code>MaxKeys</code>,
-   *             <code>NextKeyMarker</code> specifies the first key not returned that satisfies the
-   *          search criteria. Use this value for the key-marker request parameter in a subsequent
-   *          request.</p>
+   *    <code>NextKeyMarker</code> specifies the first key not returned that satisfies the
+   * search criteria. Use this value for the key-marker request parameter in a subsequent
+   * request.</p>
    */
   NextKeyMarker?: string;
 
   /**
    * <p>When the number of responses exceeds the value of <code>MaxKeys</code>,
-   *             <code>NextVersionIdMarker</code> specifies the first object version not returned that
-   *          satisfies the search criteria. Use this value for the version-id-marker request parameter
-   *          in a subsequent request.</p>
+   *    <code>NextVersionIdMarker</code> specifies the first object version not returned that
+   * satisfies the search criteria. Use this value for the version-id-marker request parameter
+   * in a subsequent request.</p>
    */
   NextVersionIdMarker?: string;
 
@@ -9550,10 +9550,10 @@ export interface ListObjectVersionsOutput {
 
   /**
    * <p>The delimiter grouping the included keys. A delimiter is a character that you specify to
-   *          group keys. All keys that contain the same string between the prefix and the first
-   *          occurrence of the delimiter are grouped under a single result element in
-   *             <code>CommonPrefixes</code>. These groups are counted as one result against the max-keys
-   *          limitation. These keys are not returned elsewhere in the response.</p>
+   * group keys. All keys that contain the same string between the prefix and the first
+   * occurrence of the delimiter are grouped under a single result element in
+   *    <code>CommonPrefixes</code>. These groups are counted as one result against the max-keys
+   * limitation. These keys are not returned elsewhere in the response.</p>
    */
   Delimiter?: string;
 
@@ -9564,18 +9564,18 @@ export interface ListObjectVersionsOutput {
 
   /**
    * <p>All of the keys rolled up into a common prefix count as a single return when calculating
-   *          the number of returns.</p>
+   * the number of returns.</p>
    */
   CommonPrefixes?: CommonPrefix[];
 
   /**
    * <p> Encoding type used by Amazon S3 to encode object key names in the XML response.</p>
    *
-   *          <p>If you specify encoding-type request parameter, Amazon S3 includes this element in the
-   *          response, and returns encoded key name values in the following response elements:</p>
+   * <p>If you specify encoding-type request parameter, Amazon S3 includes this element in the
+   * response, and returns encoded key name values in the following response elements:</p>
    *
-   *          <p>
-   *             <code>KeyMarker, NextKeyMarker, Prefix, Key</code>, and <code>Delimiter</code>.</p>
+   * <p>
+   *    <code>KeyMarker, NextKeyMarker, Prefix, Key</code>, and <code>Delimiter</code>.</p>
    */
   EncodingType?: EncodingType | string;
 }
@@ -9597,19 +9597,19 @@ export interface ListObjectVersionsRequest {
 
   /**
    * <p>A delimiter is a character that you specify to group keys. All keys that contain the
-   *          same string between the <code>prefix</code> and the first occurrence of the delimiter are
-   *          grouped under a single result element in CommonPrefixes. These groups are counted as one
-   *          result against the max-keys limitation. These keys are not returned elsewhere in the
-   *          response.</p>
+   * same string between the <code>prefix</code> and the first occurrence of the delimiter are
+   * grouped under a single result element in CommonPrefixes. These groups are counted as one
+   * result against the max-keys limitation. These keys are not returned elsewhere in the
+   * response.</p>
    */
   Delimiter?: string;
 
   /**
    * <p>Requests Amazon S3 to encode the object keys in the response and specifies the encoding
-   *          method to use. An object key may contain any Unicode character; however, XML 1.0 parser
-   *          cannot parse some characters, such as characters with an ASCII value from 0 to 10. For
-   *          characters that are not supported in XML 1.0, you can add this parameter to request that
-   *          Amazon S3 encode the keys in the response.</p>
+   * method to use. An object key may contain any Unicode character; however, XML 1.0 parser
+   * cannot parse some characters, such as characters with an ASCII value from 0 to 10. For
+   * characters that are not supported in XML 1.0, you can add this parameter to request that
+   * Amazon S3 encode the keys in the response.</p>
    */
   EncodingType?: EncodingType | string;
 
@@ -9620,19 +9620,19 @@ export interface ListObjectVersionsRequest {
 
   /**
    * <p>Sets the maximum number of keys returned in the response. By default the action returns up
-   *          to 1,000 key names. The response might contain fewer keys but will never contain more. If
-   *          additional keys satisfy the search criteria, but were not returned because max-keys was
-   *          exceeded, the response contains <isTruncated>true</isTruncated>. To return the
-   *          additional keys, see key-marker and version-id-marker.</p>
+   * to 1,000 key names. The response might contain fewer keys but will never contain more. If
+   * additional keys satisfy the search criteria, but were not returned because max-keys was
+   * exceeded, the response contains <isTruncated>true</isTruncated>. To return the
+   * additional keys, see key-marker and version-id-marker.</p>
    */
   MaxKeys?: number;
 
   /**
    * <p>Use this parameter to select only those keys that begin with the specified prefix. You
-   *          can use prefixes to separate a bucket into different groupings of keys. (You can think of
-   *          using prefix to make groups in the same way you'd use a folder in a file system.) You can
-   *          use prefix with delimiter to roll up numerous objects into a single result under
-   *          CommonPrefixes. </p>
+   * can use prefixes to separate a bucket into different groupings of keys. (You can think of
+   * using prefix to make groups in the same way you'd use a folder in a file system.) You can
+   * use prefix with delimiter to roll up numerous objects into a single result under
+   * CommonPrefixes. </p>
    */
   Prefix?: string;
 
@@ -9662,7 +9662,7 @@ export namespace ListObjectVersionsRequest {
 export interface Part {
   /**
    * <p>Part number identifying the part. This is a positive integer between 1 and
-   *          10,000.</p>
+   * 10,000.</p>
    */
   PartNumber?: number;
 
@@ -9694,20 +9694,20 @@ export namespace Part {
 export interface ListPartsOutput {
   /**
    * <p>If the bucket has a lifecycle rule configured with an action to abort incomplete
-   *          multipart uploads and the prefix in the lifecycle rule matches the object name in the
-   *          request, then the response includes this header indicating when the initiated multipart
-   *          upload will become eligible for abort operation. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config">Aborting
-   *             Incomplete Multipart Uploads Using a Bucket Lifecycle Policy</a>.</p>
+   * multipart uploads and the prefix in the lifecycle rule matches the object name in the
+   * request, then the response includes this header indicating when the initiated multipart
+   * upload will become eligible for abort operation. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config">Aborting
+   *    Incomplete Multipart Uploads Using a Bucket Lifecycle Policy</a>.</p>
    *
-   *          <p>The response will also include the <code>x-amz-abort-rule-id</code> header that will
-   *          provide the ID of the lifecycle configuration rule that defines this action.</p>
+   * <p>The response will also include the <code>x-amz-abort-rule-id</code> header that will
+   * provide the ID of the lifecycle configuration rule that defines this action.</p>
    */
   AbortDate?: Date;
 
   /**
    * <p>This header is returned along with the <code>x-amz-abort-date</code> header. It
-   *          identifies applicable lifecycle configuration rule that defines the action to abort
-   *          incomplete multipart uploads.</p>
+   * identifies applicable lifecycle configuration rule that defines the action to abort
+   * incomplete multipart uploads.</p>
    */
   AbortRuleId?: string;
 
@@ -9728,15 +9728,15 @@ export interface ListPartsOutput {
 
   /**
    * <p>When a list is truncated, this element specifies the last part in the list, as well as
-   *          the value to use for the part-number-marker request parameter in a subsequent
-   *          request.</p>
+   * the value to use for the part-number-marker request parameter in a subsequent
+   * request.</p>
    */
   PartNumberMarker?: string;
 
   /**
    * <p>When a list is truncated, this element specifies the last part in the list, as well as
-   *          the value to use for the part-number-marker request parameter in a subsequent
-   *          request.</p>
+   * the value to use for the part-number-marker request parameter in a subsequent
+   * request.</p>
    */
   NextPartNumberMarker?: string;
 
@@ -9747,41 +9747,41 @@ export interface ListPartsOutput {
 
   /**
    * <p> Indicates whether the returned list of parts is truncated. A true value indicates that
-   *          the list was truncated. A list can be truncated if the number of parts exceeds the limit
-   *          returned in the MaxParts element.</p>
+   * the list was truncated. A list can be truncated if the number of parts exceeds the limit
+   * returned in the MaxParts element.</p>
    */
   IsTruncated?: boolean;
 
   /**
    * <p> Container for elements related to a particular part. A response can contain zero or
-   *          more <code>Part</code> elements.</p>
+   * more <code>Part</code> elements.</p>
    */
   Parts?: Part[];
 
   /**
    * <p>Container element that identifies who initiated the multipart upload. If the initiator
-   *          is an Amazon Web Services account, this element provides the same information as the <code>Owner</code>
-   *          element. If the initiator is an IAM User, this element provides the user ARN and display
-   *          name.</p>
+   * is an Amazon Web Services account, this element provides the same information as the <code>Owner</code>
+   * element. If the initiator is an IAM User, this element provides the user ARN and display
+   * name.</p>
    */
   Initiator?: Initiator;
 
   /**
    * <p> Container element that identifies the object owner, after the object is created. If
-   *          multipart upload is initiated by an IAM user, this element provides the parent account ID
-   *          and display name.</p>
+   * multipart upload is initiated by an IAM user, this element provides the parent account ID
+   * and display name.</p>
    */
   Owner?: Owner;
 
   /**
    * <p>Class of storage (STANDARD or REDUCED_REDUNDANCY) used to store the uploaded
-   *          object.</p>
+   * object.</p>
    */
   StorageClass?: StorageClass | string;
 
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -9798,8 +9798,8 @@ export namespace ListPartsOutput {
 export interface ListPartsRequest {
   /**
    * <p>The name of the bucket to which the parts are being uploaded. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -9815,7 +9815,7 @@ export interface ListPartsRequest {
 
   /**
    * <p>Specifies the part after which listing should begin. Only parts with higher part numbers
-   *          will be listed.</p>
+   * will be listed.</p>
    */
   PartNumberMarker?: string;
 
@@ -9826,9 +9826,9 @@ export interface ListPartsRequest {
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -9886,17 +9886,17 @@ export interface PutBucketAclRequest {
 
   /**
    * <p>The base64-encoded 128-bit MD5 digest of the data. This header must be used as a message
-   *          integrity check to verify that the request body was not corrupted in transit. For more
-   *          information, go to <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC
-   *          1864.</a>
-   *          </p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * integrity check to verify that the request body was not corrupted in transit. For more
+   * information, go to <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC
+   * 1864.</a>
+   * </p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
   /**
    * <p>Allows grantee the read, write, read ACP, and write ACP permissions on the
-   *          bucket.</p>
+   * bucket.</p>
    */
   GrantFullControl?: string;
 
@@ -9912,7 +9912,7 @@ export interface PutBucketAclRequest {
 
   /**
    * <p>Allows grantee to create new objects in the bucket.</p>
-   *          <p>For the bucket and object owners of existing objects, also allows deletions and overwrites of those objects.</p>
+   * <p>For the bucket and object owners of existing objects, also allows deletions and overwrites of those objects.</p>
    */
   GrantWrite?: string;
 
@@ -9977,13 +9977,13 @@ export namespace PutBucketAnalyticsConfigurationRequest {
 
 /**
  * <p>Describes the cross-origin access configuration for objects in an Amazon S3 bucket. For more
- *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html">Enabling
- *             Cross-Origin Resource Sharing</a> in the <i>Amazon S3 User Guide</i>.</p>
+ * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html">Enabling
+ *    Cross-Origin Resource Sharing</a> in the <i>Amazon S3 User Guide</i>.</p>
  */
 export interface CORSConfiguration {
   /**
    * <p>A set of origins and methods (cross-origin access that you want to allow). You can add
-   *          up to 100 rules to the configuration.</p>
+   * up to 100 rules to the configuration.</p>
    */
   CORSRules: CORSRule[] | undefined;
 }
@@ -10005,11 +10005,11 @@ export interface PutBucketCorsRequest {
 
   /**
    * <p>The base64-encoded 128-bit MD5 digest of the data. This header must be used as a message
-   *          integrity check to verify that the request body was not corrupted in transit. For more
-   *          information, go to <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC
-   *          1864.</a>
-   *          </p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * integrity check to verify that the request body was not corrupted in transit. For more
+   * information, go to <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC
+   * 1864.</a>
+   * </p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
@@ -10020,8 +10020,8 @@ export interface PutBucketCorsRequest {
 
   /**
    * <p>Describes the cross-origin access configuration for objects in an Amazon S3 bucket. For more
-   *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html">Enabling Cross-Origin Resource
-   *             Sharing</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html">Enabling Cross-Origin Resource
+   *    Sharing</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   CORSConfiguration: CORSConfiguration | undefined;
 }
@@ -10038,15 +10038,15 @@ export namespace PutBucketCorsRequest {
 export interface PutBucketEncryptionRequest {
   /**
    * <p>Specifies default encryption for a bucket using server-side encryption with Amazon S3-managed
-   *          keys (SSE-S3) or customer master keys stored in Amazon Web Services KMS (SSE-KMS). For information about
-   *          the Amazon S3 default encryption feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html">Amazon S3 Default Bucket Encryption</a>
-   *          in the <i>Amazon S3 User Guide</i>.</p>
+   * keys (SSE-S3) or customer master keys stored in Amazon Web Services KMS (SSE-KMS). For information about
+   * the Amazon S3 default encryption feature, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html">Amazon S3 Default Bucket Encryption</a>
+   * in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
   /**
    * <p>The base64-encoded 128-bit MD5 digest of the server-side encryption configuration.</p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
@@ -10137,8 +10137,8 @@ export namespace PutBucketInventoryConfigurationRequest {
 
 /**
  * <p>Specifies the lifecycle configuration for objects in an Amazon S3 bucket. For more
- *          information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Object Lifecycle Management</a>
- *          in the <i>Amazon S3 User Guide</i>.</p>
+ * information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html">Object Lifecycle Management</a>
+ * in the <i>Amazon S3 User Guide</i>.</p>
  */
 export interface BucketLifecycleConfiguration {
   /**
@@ -10192,8 +10192,8 @@ export namespace PutBucketLifecycleConfigurationRequest {
 export interface BucketLoggingStatus {
   /**
    * <p>Describes where logs are stored and the prefix that Amazon S3 assigns to all log object keys
-   *          for a bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlogging.html">PUT Bucket logging</a> in the
-   *             <i>Amazon S3 API Reference</i>.</p>
+   * for a bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlogging.html">PUT Bucket logging</a> in the
+   *    <i>Amazon S3 API Reference</i>.</p>
    */
   LoggingEnabled?: LoggingEnabled;
 }
@@ -10215,7 +10215,7 @@ export interface PutBucketLoggingRequest {
 
   /**
    * <p>The MD5 hash of the <code>PutBucketLogging</code> request body.</p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
@@ -10286,7 +10286,7 @@ export interface PutBucketNotificationConfigurationRequest {
 
   /**
    * <p>A container for specifying the notification configuration of the bucket. If this element
-   *          is empty, notifications are turned off for the bucket.</p>
+   * is empty, notifications are turned off for the bucket.</p>
    */
   NotificationConfiguration: NotificationConfiguration | undefined;
 }
@@ -10308,7 +10308,7 @@ export interface PutBucketOwnershipControlsRequest {
 
   /**
    * <p>The MD5 hash of the <code>OwnershipControls</code> request body. </p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
@@ -10319,7 +10319,7 @@ export interface PutBucketOwnershipControlsRequest {
 
   /**
    * <p>The <code>OwnershipControls</code> (BucketOwnerPreferred or ObjectWriter) that you want
-   *          to apply to this Amazon S3 bucket.</p>
+   * to apply to this Amazon S3 bucket.</p>
    */
   OwnershipControls: OwnershipControls | undefined;
 }
@@ -10341,13 +10341,13 @@ export interface PutBucketPolicyRequest {
 
   /**
    * <p>The MD5 hash of the request body.</p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
   /**
    * <p>Set this parameter to true to confirm that you want to remove your permissions to change
-   *          this bucket policy in the future.</p>
+   * this bucket policy in the future.</p>
    */
   ConfirmRemoveSelfBucketAccess?: boolean;
 
@@ -10379,9 +10379,9 @@ export interface PutBucketReplicationRequest {
 
   /**
    * <p>The base64-encoded 128-bit MD5 digest of the data. You must use this header as a message
-   *          integrity check to verify that the request body was not corrupted in transit. For more
-   *          information, see <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC 1864</a>.</p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * integrity check to verify that the request body was not corrupted in transit. For more
+   * information, see <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC 1864</a>.</p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
@@ -10397,7 +10397,7 @@ export interface PutBucketReplicationRequest {
 
   /**
    * <p>A container for replication rules. You can add up to 1,000 rules. The maximum size of a
-   *          replication configuration is 2 MB.</p>
+   * replication configuration is 2 MB.</p>
    */
   ReplicationConfiguration: ReplicationConfiguration | undefined;
 }
@@ -10441,10 +10441,10 @@ export interface PutBucketRequestPaymentRequest {
 
   /**
    * <p>The base64-encoded 128-bit MD5 digest of the data. You must use this header as a
-   *          message integrity check to verify that the request body was not corrupted in transit. For
-   *          more information, see <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC
-   *          1864</a>.</p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * message integrity check to verify that the request body was not corrupted in transit. For
+   * more information, see <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC
+   * 1864</a>.</p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
@@ -10495,9 +10495,9 @@ export interface PutBucketTaggingRequest {
 
   /**
    * <p>The base64-encoded 128-bit MD5 digest of the data. You must use this header as a message
-   *          integrity check to verify that the request body was not corrupted in transit. For more
-   *          information, see <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC 1864</a>.</p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * integrity check to verify that the request body was not corrupted in transit. For more
+   * information, see <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC 1864</a>.</p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
@@ -10525,13 +10525,13 @@ export type MFADelete = "Disabled" | "Enabled";
 
 /**
  * <p>Describes the versioning state of an Amazon S3 bucket. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTVersioningStatus.html">PUT
- *             Bucket versioning</a> in the <i>Amazon S3 API Reference</i>.</p>
+ *    Bucket versioning</a> in the <i>Amazon S3 API Reference</i>.</p>
  */
 export interface VersioningConfiguration {
   /**
    * <p>Specifies whether MFA delete is enabled in the bucket versioning configuration. This
-   *          element is only returned if the bucket has been configured with MFA delete. If the bucket
-   *          has never been so configured, this element is not returned.</p>
+   * element is only returned if the bucket has been configured with MFA delete. If the bucket
+   * has never been so configured, this element is not returned.</p>
    */
   MFADelete?: MFADelete | string;
 
@@ -10558,16 +10558,16 @@ export interface PutBucketVersioningRequest {
 
   /**
    * <p>>The base64-encoded 128-bit MD5 digest of the data. You must use this header as a
-   *          message integrity check to verify that the request body was not corrupted in transit. For
-   *          more information, see <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC
-   *          1864</a>.</p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * message integrity check to verify that the request body was not corrupted in transit. For
+   * more information, see <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC
+   * 1864</a>.</p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
   /**
    * <p>The concatenation of the authentication device's serial number, a space, and the value
-   *          that is displayed on your authentication device.</p>
+   * that is displayed on your authentication device.</p>
    */
   MFA?: string;
 
@@ -10607,9 +10607,9 @@ export interface WebsiteConfiguration {
 
   /**
    * <p>The redirect behavior for every request to this bucket's website endpoint.</p>
-   *          <important>
-   *             <p>If you specify this property, you can't specify any other property.</p>
-   *          </important>
+   * <important>
+   *    <p>If you specify this property, you can't specify any other property.</p>
+   * </important>
    */
   RedirectAllRequestsTo?: RedirectAllRequestsTo;
 
@@ -10636,9 +10636,9 @@ export interface PutBucketWebsiteRequest {
 
   /**
    * <p>The base64-encoded 128-bit MD5 digest of the data. You must use this header as a message
-   *          integrity check to verify that the request body was not corrupted in transit. For more
-   *          information, see <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC 1864</a>.</p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * integrity check to verify that the request body was not corrupted in transit. For more
+   * information, see <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC 1864</a>.</p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
@@ -10665,8 +10665,8 @@ export namespace PutBucketWebsiteRequest {
 export interface PutObjectOutput {
   /**
    * <p> If the expiration is configured for the object (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a>), the response includes this header. It
-   *          includes the expiry-date and rule-id key-value pairs that provide information about object
-   *          expiration. The value of the rule-id is URL encoded.</p>
+   * includes the expiry-date and rule-id key-value pairs that provide information about object
+   * expiration. The value of the rule-id is URL encoded.</p>
    */
   Expiration?: string;
 
@@ -10677,8 +10677,8 @@ export interface PutObjectOutput {
 
   /**
    * <p>If you specified server-side encryption either with an Amazon Web Services KMS customer master key (CMK)
-   *          or Amazon S3-managed encryption key in your PUT request, the response includes this header. It
-   *          confirms the encryption algorithm that Amazon S3 used to encrypt the object.</p>
+   * or Amazon S3-managed encryption key in your PUT request, the response includes this header. It
+   * confirms the encryption algorithm that Amazon S3 used to encrypt the object.</p>
    */
   ServerSideEncryption?: ServerSideEncryption | string;
 
@@ -10689,29 +10689,29 @@ export interface PutObjectOutput {
 
   /**
    * <p>If server-side encryption with a customer-provided encryption key was requested, the
-   *          response will include this header confirming the encryption algorithm used.</p>
+   * response will include this header confirming the encryption algorithm used.</p>
    */
   SSECustomerAlgorithm?: string;
 
   /**
    * <p>If server-side encryption with a customer-provided encryption key was requested, the
-   *          response will include this header to provide round-trip message integrity verification of
-   *          the customer-provided encryption key.</p>
+   * response will include this header to provide round-trip message integrity verification of
+   * the customer-provided encryption key.</p>
    */
   SSECustomerKeyMD5?: string;
 
   /**
    * <p>If <code>x-amz-server-side-encryption</code> is present and has the value of
-   *             <code>aws:kms</code>, this header specifies the ID of the Amazon Web Services Key Management Service
-   *          (Amazon Web Services KMS) symmetric customer managed customer master key (CMK) that was used for the
-   *          object. </p>
+   *    <code>aws:kms</code>, this header specifies the ID of the Amazon Web Services Key Management Service
+   * (Amazon Web Services KMS) symmetric customer managed customer master key (CMK) that was used for the
+   * object. </p>
    */
   SSEKMSKeyId?: string;
 
   /**
    * <p>If present, specifies the Amazon Web Services KMS Encryption Context to use for object encryption. The
-   *          value of this header is a base64-encoded UTF-8 string holding JSON with the encryption
-   *          context key-value pairs.</p>
+   * value of this header is a base64-encoded UTF-8 string holding JSON with the encryption
+   * context key-value pairs.</p>
    */
   SSEKMSEncryptionContext?: string;
 
@@ -10722,7 +10722,7 @@ export interface PutObjectOutput {
 
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -10742,7 +10742,7 @@ export interface PutObjectRequest {
   /**
    * <p>The canned ACL to apply to the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned
    *       ACL</a>.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   ACL?: ObjectCannedACL | string;
 
@@ -10753,14 +10753,14 @@ export interface PutObjectRequest {
 
   /**
    * <p>The bucket name to which the PUT action was initiated. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
   /**
    * <p> Can be used to specify caching behavior along the request/reply chain. For more
-   *          information, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9</a>.</p>
+   * information, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9</a>.</p>
    */
   CacheControl?: string;
 
@@ -10771,8 +10771,8 @@ export interface PutObjectRequest {
 
   /**
    * <p>Specifies what content encodings have been applied to the object and thus what decoding
-   *          mechanisms must be applied to obtain the media-type referenced by the Content-Type header
-   *          field. For more information, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>.</p>
+   * mechanisms must be applied to obtain the media-type referenced by the Content-Type header
+   * field. For more information, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>.</p>
    */
   ContentEncoding?: string;
 
@@ -10783,56 +10783,56 @@ export interface PutObjectRequest {
 
   /**
    * <p>Size of the body in bytes. This parameter is useful when the size of the body cannot be
-   *          determined automatically. For more information, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13</a>.</p>
+   * determined automatically. For more information, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13</a>.</p>
    */
   ContentLength?: number;
 
   /**
    * <p>The base64-encoded 128-bit MD5 digest of the message (without the headers) according to
-   *          RFC 1864. This header can be used as a message integrity check to verify that the data is
-   *          the same data that was originally sent. Although it is optional, we recommend using the
-   *          Content-MD5 mechanism as an end-to-end integrity check. For more information about REST
-   *          request authentication, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html">REST
-   *             Authentication</a>.</p>
+   * RFC 1864. This header can be used as a message integrity check to verify that the data is
+   * the same data that was originally sent. Although it is optional, we recommend using the
+   * Content-MD5 mechanism as an end-to-end integrity check. For more information about REST
+   * request authentication, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html">REST
+   *    Authentication</a>.</p>
    */
   ContentMD5?: string;
 
   /**
    * <p>A standard MIME type describing the format of the contents. For more information, see
-   *             <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>.</p>
+   *    <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>.</p>
    */
   ContentType?: string;
 
   /**
    * <p>The date and time at which the object is no longer cacheable. For more information, see
-   *             <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21">http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21</a>.</p>
+   *    <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21">http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21</a>.</p>
    */
   Expires?: Date;
 
   /**
    * <p>Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the
    *       object.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantFullControl?: string;
 
   /**
    * <p>Allows grantee to read the object data and its
    *       metadata.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantRead?: string;
 
   /**
    * <p>Allows grantee to read the object ACL.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantReadACP?: string;
 
   /**
    * <p>Allows grantee to write the ACL for the applicable
    *       object.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantWriteACP?: string;
 
@@ -10848,100 +10848,100 @@ export interface PutObjectRequest {
 
   /**
    * <p>The server-side encryption algorithm used when storing this object in Amazon S3 (for example,
-   *          AES256, aws:kms).</p>
+   * AES256, aws:kms).</p>
    */
   ServerSideEncryption?: ServerSideEncryption | string;
 
   /**
    * <p>By default, Amazon S3 uses the STANDARD Storage Class to store newly created objects. The
-   *          STANDARD storage class provides high durability and high availability. Depending on
-   *          performance needs, you can specify a different Storage Class. Amazon S3 on Outposts only uses
-   *          the OUTPOSTS Storage Class. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a> in the
-   *          <i>Amazon S3 User Guide</i>.</p>
+   * STANDARD storage class provides high durability and high availability. Depending on
+   * performance needs, you can specify a different Storage Class. Amazon S3 on Outposts only uses
+   * the OUTPOSTS Storage Class. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html">Storage Classes</a> in the
+   * <i>Amazon S3 User Guide</i>.</p>
    */
   StorageClass?: StorageClass | string;
 
   /**
    * <p>If the bucket is configured as a website, redirects requests for this object to another
-   *          object in the same bucket or to an external URL. Amazon S3 stores the value of this header in
-   *          the object metadata. For information about object metadata, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html">Object Key and Metadata</a>.</p>
+   * object in the same bucket or to an external URL. Amazon S3 stores the value of this header in
+   * the object metadata. For information about object metadata, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html">Object Key and Metadata</a>.</p>
    *
-   *          <p>In the following example, the request header sets the redirect to an object
-   *          (anotherPage.html) in the same bucket:</p>
+   * <p>In the following example, the request header sets the redirect to an object
+   * (anotherPage.html) in the same bucket:</p>
    *
-   *          <p>
-   *             <code>x-amz-website-redirect-location: /anotherPage.html</code>
-   *          </p>
+   * <p>
+   *    <code>x-amz-website-redirect-location: /anotherPage.html</code>
+   * </p>
    *
-   *          <p>In the following example, the request header sets the object redirect to another
-   *          website:</p>
+   * <p>In the following example, the request header sets the object redirect to another
+   * website:</p>
    *
-   *          <p>
-   *             <code>x-amz-website-redirect-location: http://www.example.com/</code>
-   *          </p>
+   * <p>
+   *    <code>x-amz-website-redirect-location: http://www.example.com/</code>
+   * </p>
    *
-   *          <p>For more information about website hosting in Amazon S3, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html">Hosting Websites on Amazon S3</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html">How to Configure Website Page
-   *             Redirects</a>. </p>
+   * <p>For more information about website hosting in Amazon S3, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html">Hosting Websites on Amazon S3</a> and <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html">How to Configure Website Page
+   *    Redirects</a>. </p>
    */
   WebsiteRedirectLocation?: string;
 
   /**
    * <p>Specifies the algorithm to use to when encrypting the object (for example,
-   *          AES256).</p>
+   * AES256).</p>
    */
   SSECustomerAlgorithm?: string;
 
   /**
    * <p>Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This
-   *          value is used to store the object and then it is discarded; Amazon S3 does not store the
-   *          encryption key. The key must be appropriate for use with the algorithm specified in the
-   *             <code>x-amz-server-side-encryption-customer-algorithm</code> header.</p>
+   * value is used to store the object and then it is discarded; Amazon S3 does not store the
+   * encryption key. The key must be appropriate for use with the algorithm specified in the
+   *    <code>x-amz-server-side-encryption-customer-algorithm</code> header.</p>
    */
   SSECustomerKey?: string;
 
   /**
    * <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses
-   *          this header for a message integrity check to ensure that the encryption key was transmitted
-   *          without error.</p>
+   * this header for a message integrity check to ensure that the encryption key was transmitted
+   * without error.</p>
    */
   SSECustomerKeyMD5?: string;
 
   /**
    * <p>If <code>x-amz-server-side-encryption</code> is present and has the value of
-   *          <code>aws:kms</code>, this header specifies the ID of the Amazon Web Services Key Management Service
-   *          (Amazon Web Services KMS) symmetrical customer managed customer master key (CMK) that was used for the
-   *          object. If you specify <code>x-amz-server-side-encryption:aws:kms</code>, but do not
-   *          provide<code> x-amz-server-side-encryption-aws-kms-key-id</code>, Amazon S3 uses the Amazon Web Services
-   *          managed CMK in Amazon Web Services to protect the data. If the KMS key does not exist in the same account
-   *          issuing the command, you must use the full ARN and not just the ID.
+   * <code>aws:kms</code>, this header specifies the ID of the Amazon Web Services Key Management Service
+   * (Amazon Web Services KMS) symmetrical customer managed customer master key (CMK) that was used for the
+   * object. If you specify <code>x-amz-server-side-encryption:aws:kms</code>, but do not
+   * provide<code> x-amz-server-side-encryption-aws-kms-key-id</code>, Amazon S3 uses the Amazon Web Services
+   * managed CMK in Amazon Web Services to protect the data. If the KMS key does not exist in the same account
+   * issuing the command, you must use the full ARN and not just the ID.
    *       </p>
    */
   SSEKMSKeyId?: string;
 
   /**
    * <p>Specifies the Amazon Web Services KMS Encryption Context to use for object encryption. The value of this
-   *          header is a base64-encoded UTF-8 string holding JSON with the encryption context key-value
-   *          pairs.</p>
+   * header is a base64-encoded UTF-8 string holding JSON with the encryption context key-value
+   * pairs.</p>
    */
   SSEKMSEncryptionContext?: string;
 
   /**
    * <p>Specifies whether Amazon S3 should use an S3 Bucket Key for object encryption with server-side encryption using AWS KMS (SSE-KMS). Setting this header to <code>true</code> causes Amazon S3 to use an S3 Bucket Key for object encryption with SSE-KMS.</p>
-   *          <p>Specifying this header with a PUT action doesn’t affect bucket-level settings for S3 Bucket Key.</p>
+   * <p>Specifying this header with a PUT action doesn’t affect bucket-level settings for S3 Bucket Key.</p>
    */
   BucketKeyEnabled?: boolean;
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
   /**
    * <p>The tag-set for the object. The tag-set must be encoded as URL Query parameters. (For
-   *          example, "Key1=Value1")</p>
+   * example, "Key1=Value1")</p>
    */
   Tagging?: string;
 
@@ -10952,14 +10952,14 @@ export interface PutObjectRequest {
 
   /**
    * <p>The date and time when you want this object's Object Lock to expire. Must be formatted
-   *          as a timestamp parameter.</p>
+   * as a timestamp parameter.</p>
    */
   ObjectLockRetainUntilDate?: Date;
 
   /**
    * <p>Specifies whether a legal hold will be applied to this object. For more information
-   *          about S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Object
-   *          Lock</a>.</p>
+   * about S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html">Object
+   * Lock</a>.</p>
    */
   ObjectLockLegalHoldStatus?: ObjectLockLegalHoldStatus | string;
 
@@ -10984,7 +10984,7 @@ export namespace PutObjectRequest {
 export interface PutObjectAclOutput {
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -11006,65 +11006,65 @@ export interface PutObjectAclRequest {
 
   /**
    * <p>The bucket name that contains the object to which you want to attach the ACL. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
   /**
    * <p>The base64-encoded 128-bit MD5 digest of the data. This header must be used as a message
-   *          integrity check to verify that the request body was not corrupted in transit. For more
-   *          information, go to <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC
-   *          1864.></a>
-   *          </p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * integrity check to verify that the request body was not corrupted in transit. For more
+   * information, go to <a href="http://www.ietf.org/rfc/rfc1864.txt">RFC
+   * 1864.></a>
+   * </p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
   /**
    * <p>Allows grantee the read, write, read ACP, and write ACP permissions on the
-   *          bucket.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * bucket.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantFullControl?: string;
 
   /**
    * <p>Allows grantee to list the objects in the
    *       bucket.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantRead?: string;
 
   /**
    * <p>Allows grantee to read the bucket ACL.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantReadACP?: string;
 
   /**
    * <p>Allows grantee to create new objects in the bucket.</p>
-   *          <p>For the bucket and object owners of existing objects, also allows deletions and overwrites of those objects.</p>
+   * <p>For the bucket and object owners of existing objects, also allows deletions and overwrites of those objects.</p>
    */
   GrantWrite?: string;
 
   /**
    * <p>Allows grantee to write the ACL for the applicable
    *       bucket.</p>
-   *          <p>This action is not supported by Amazon S3 on Outposts.</p>
+   * <p>This action is not supported by Amazon S3 on Outposts.</p>
    */
   GrantWriteACP?: string;
 
   /**
    * <p>Key for which the PUT action was initiated.</p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Key: string | undefined;
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -11096,7 +11096,7 @@ export namespace PutObjectAclRequest {
 export interface PutObjectLegalHoldOutput {
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -11113,7 +11113,7 @@ export namespace PutObjectLegalHoldOutput {
 export interface PutObjectLegalHoldRequest {
   /**
    * <p>The bucket name containing the object that you want to place a Legal Hold on. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -11124,9 +11124,9 @@ export interface PutObjectLegalHoldRequest {
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -11137,7 +11137,7 @@ export interface PutObjectLegalHoldRequest {
 
   /**
    * <p>The MD5 hash for the request body.</p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
@@ -11148,7 +11148,7 @@ export interface PutObjectLegalHoldRequest {
 
   /**
    * <p>Container element for the Legal Hold configuration you want to apply to the specified
-   *          object.</p>
+   * object.</p>
    */
   LegalHold?: ObjectLockLegalHold;
 }
@@ -11165,7 +11165,7 @@ export namespace PutObjectLegalHoldRequest {
 export interface PutObjectLockConfigurationOutput {
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -11187,9 +11187,9 @@ export interface PutObjectLockConfigurationRequest {
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -11200,7 +11200,7 @@ export interface PutObjectLockConfigurationRequest {
 
   /**
    * <p>The MD5 hash for the request body.</p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
@@ -11227,7 +11227,7 @@ export namespace PutObjectLockConfigurationRequest {
 export interface PutObjectRetentionOutput {
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -11244,28 +11244,28 @@ export namespace PutObjectRetentionOutput {
 export interface PutObjectRetentionRequest {
   /**
    * <p>The bucket name that contains the object you want to apply this Object Retention
-   *          configuration to. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * configuration to. </p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
   /**
    * <p>The key name for the object that you want to apply this Object Retention configuration
-   *          to.</p>
+   * to.</p>
    */
   Key: string | undefined;
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
   /**
    * <p>The version ID for the object that you want to apply this Object Retention configuration
-   *          to.</p>
+   * to.</p>
    */
   VersionId?: string;
 
@@ -11276,7 +11276,7 @@ export interface PutObjectRetentionRequest {
 
   /**
    * <p>The MD5 hash for the request body.</p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
@@ -11319,8 +11319,8 @@ export namespace PutObjectTaggingOutput {
 export interface PutObjectTaggingRequest {
   /**
    * <p>The bucket name containing the object. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -11336,7 +11336,7 @@ export interface PutObjectTaggingRequest {
 
   /**
    * <p>The MD5 hash for the request body.</p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
@@ -11347,9 +11347,9 @@ export interface PutObjectTaggingRequest {
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -11371,13 +11371,13 @@ export namespace PutObjectTaggingRequest {
 export interface PutPublicAccessBlockRequest {
   /**
    * <p>The name of the Amazon S3 bucket whose <code>PublicAccessBlock</code> configuration you want
-   *          to set.</p>
+   * to set.</p>
    */
   Bucket: string | undefined;
 
   /**
    * <p>The MD5 hash of the <code>PutPublicAccessBlock</code> request body. </p>
-   *          <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
+   * <p>For requests made using the Amazon Web Services Command Line Interface (CLI) or Amazon Web Services SDKs, this field is calculated automatically.</p>
    */
   ContentMD5?: string;
 
@@ -11388,8 +11388,8 @@ export interface PutPublicAccessBlockRequest {
 
   /**
    * <p>The <code>PublicAccessBlock</code> configuration that you want to apply to this Amazon S3
-   *          bucket. You can enable the configuration options in any combination. For more information
-   *          about when Amazon S3 considers a bucket or object public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * bucket. You can enable the configuration options in any combination. For more information
+   * about when Amazon S3 considers a bucket or object public, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status">The Meaning of "Public"</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   PublicAccessBlockConfiguration: PublicAccessBlockConfiguration | undefined;
 }
@@ -11423,13 +11423,13 @@ export namespace ObjectAlreadyInActiveTierError {
 export interface RestoreObjectOutput {
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 
   /**
    * <p>Indicates the path in the provided S3 output location where Select results will be
-   *          restored to.</p>
+   * restored to.</p>
    */
   RestoreOutputPath?: string;
 }

--- a/clients/client-s3/src/models/models_1.ts
+++ b/clients/client-s3/src/models/models_1.ts
@@ -21,21 +21,21 @@ import { Readable } from "stream";
 export interface Encryption {
   /**
    * <p>The server-side encryption algorithm used when storing job results in Amazon S3 (for example,
-   *          AES256, aws:kms).</p>
+   * AES256, aws:kms).</p>
    */
   EncryptionType: ServerSideEncryption | string | undefined;
 
   /**
    * <p>If the encryption type is <code>aws:kms</code>, this optional value specifies the ID of
-   *          the symmetric customer managed Amazon Web Services KMS CMK to use for encryption of job results. Amazon S3 only
-   *          supports symmetric CMKs. For more information, see <a href="https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html">Using symmetric and
-   *             asymmetric keys</a> in the <i>Amazon Web Services Key Management Service Developer Guide</i>.</p>
+   * the symmetric customer managed Amazon Web Services KMS CMK to use for encryption of job results. Amazon S3 only
+   * supports symmetric CMKs. For more information, see <a href="https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html">Using symmetric and
+   *    asymmetric keys</a> in the <i>Amazon Web Services Key Management Service Developer Guide</i>.</p>
    */
   KMSKeyId?: string;
 
   /**
    * <p>If the encryption type is <code>aws:kms</code>, this optional value can be used to
-   *          specify the encryption context for the restore results.</p>
+   * specify the encryption context for the restore results.</p>
    */
   KMSContext?: string;
 }
@@ -161,72 +161,72 @@ export enum FileHeaderInfo {
 
 /**
  * <p>Describes how an uncompressed comma-separated values (CSV)-formatted input object is
- *          formatted.</p>
+ * formatted.</p>
  */
 export interface CSVInput {
   /**
    * <p>Describes the first line of input. Valid values are:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <code>NONE</code>: First line is not a header.</p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>IGNORE</code>: First line is a header, but you can't use the header values
-   *                to indicate the column in an expression. You can use column position (such as _1, _2,
-   *                …) to indicate the column (<code>SELECT s._1 FROM OBJECT s</code>).</p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>Use</code>: First line is a header, and you can use the header value to
-   *                identify a column in an expression (<code>SELECT "name" FROM OBJECT</code>). </p>
-   *             </li>
-   *          </ul>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <code>NONE</code>: First line is not a header.</p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>IGNORE</code>: First line is a header, but you can't use the header values
+   *       to indicate the column in an expression. You can use column position (such as _1, _2,
+   *       …) to indicate the column (<code>SELECT s._1 FROM OBJECT s</code>).</p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>Use</code>: First line is a header, and you can use the header value to
+   *       identify a column in an expression (<code>SELECT "name" FROM OBJECT</code>). </p>
+   *    </li>
+   * </ul>
    */
   FileHeaderInfo?: FileHeaderInfo | string;
 
   /**
    * <p>A single character used to indicate that a row should be ignored when the character is
-   *          present at the start of that row. You can specify any character to indicate a comment
-   *          line.</p>
+   * present at the start of that row. You can specify any character to indicate a comment
+   * line.</p>
    */
   Comments?: string;
 
   /**
    * <p>A single character used for escaping the quotation mark character inside an already
-   *          escaped value. For example, the value """ a , b """ is parsed as " a , b ".</p>
+   * escaped value. For example, the value """ a , b """ is parsed as " a , b ".</p>
    */
   QuoteEscapeCharacter?: string;
 
   /**
    * <p>A single character used to separate individual records in the input. Instead of the
-   *          default value, you can specify an arbitrary delimiter.</p>
+   * default value, you can specify an arbitrary delimiter.</p>
    */
   RecordDelimiter?: string;
 
   /**
    * <p>A single character used to separate individual fields in a record. You can specify an
-   *          arbitrary delimiter.</p>
+   * arbitrary delimiter.</p>
    */
   FieldDelimiter?: string;
 
   /**
    * <p>A single character used for escaping when the field delimiter is part of the value. For
-   *          example, if the value is <code>a, b</code>, Amazon S3 wraps this field value in quotation marks,
-   *          as follows: <code>" a , b "</code>.</p>
-   *          <p>Type: String</p>
-   *          <p>Default: <code>"</code>
-   *          </p>
-   *          <p>Ancestors: <code>CSV</code>
-   *          </p>
+   * example, if the value is <code>a, b</code>, Amazon S3 wraps this field value in quotation marks,
+   * as follows: <code>" a , b "</code>.</p>
+   * <p>Type: String</p>
+   * <p>Default: <code>"</code>
+   * </p>
+   * <p>Ancestors: <code>CSV</code>
+   * </p>
    */
   QuoteCharacter?: string;
 
   /**
    * <p>Specifies that CSV field values may contain quoted record delimiters and such records
-   *          should be allowed. Default value is FALSE. Setting this value to TRUE may lower
-   *          performance.</p>
+   * should be allowed. Default value is FALSE. Setting this value to TRUE may lower
+   * performance.</p>
    */
   AllowQuotedRecordDelimiter?: boolean;
 }
@@ -289,7 +289,7 @@ export interface InputSerialization {
 
   /**
    * <p>Specifies object's compression format. Valid values: NONE, GZIP, BZIP2. Default Value:
-   *          NONE.</p>
+   * NONE.</p>
    */
   CompressionType?: CompressionType | string;
 
@@ -320,46 +320,46 @@ export enum QuoteFields {
 
 /**
  * <p>Describes how uncompressed comma-separated values (CSV)-formatted results are
- *          formatted.</p>
+ * formatted.</p>
  */
 export interface CSVOutput {
   /**
    * <p>Indicates whether to use quotation marks around output fields. </p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <code>ALWAYS</code>: Always use quotation marks for output fields.</p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code>ASNEEDED</code>: Use quotation marks for output fields when needed.</p>
-   *             </li>
-   *          </ul>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <code>ALWAYS</code>: Always use quotation marks for output fields.</p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code>ASNEEDED</code>: Use quotation marks for output fields when needed.</p>
+   *    </li>
+   * </ul>
    */
   QuoteFields?: QuoteFields | string;
 
   /**
    * <p>The single character used for escaping the quote character inside an already escaped
-   *          value.</p>
+   * value.</p>
    */
   QuoteEscapeCharacter?: string;
 
   /**
    * <p>A single character used to separate individual records in the output. Instead of the
-   *          default value, you can specify an arbitrary delimiter.</p>
+   * default value, you can specify an arbitrary delimiter.</p>
    */
   RecordDelimiter?: string;
 
   /**
    * <p>The value used to separate individual fields in a record. You can specify an arbitrary
-   *          delimiter.</p>
+   * delimiter.</p>
    */
   FieldDelimiter?: string;
 
   /**
    * <p>A single character used for escaping when the field delimiter is part of the value. For
-   *          example, if the value is <code>a, b</code>, Amazon S3 wraps this field value in quotation marks,
-   *          as follows: <code>" a , b "</code>.</p>
+   * example, if the value is <code>a, b</code>, Amazon S3 wraps this field value in quotation marks,
+   * as follows: <code>" a , b "</code>.</p>
    */
   QuoteCharacter?: string;
 }
@@ -379,7 +379,7 @@ export namespace CSVOutput {
 export interface JSONOutput {
   /**
    * <p>The value used to separate individual records in the output. If no value is specified,
-   *          Amazon S3 uses a newline character ('\n').</p>
+   * Amazon S3 uses a newline character ('\n').</p>
    */
   RecordDelimiter?: string;
 }
@@ -461,15 +461,15 @@ export enum RestoreRequestType {
 export interface RestoreRequest {
   /**
    * <p>Lifetime of the active copy in days. Do not use with restores that specify
-   *             <code>OutputLocation</code>.</p>
-   *          <p>The Days element is required for regular restores, and must not be provided for select
-   *          requests.</p>
+   *    <code>OutputLocation</code>.</p>
+   * <p>The Days element is required for regular restores, and must not be provided for select
+   * requests.</p>
    */
   Days?: number;
 
   /**
    * <p>S3 Glacier related parameters pertaining to this job. Do not use with restores that
-   *          specify <code>OutputLocation</code>.</p>
+   * specify <code>OutputLocation</code>.</p>
    */
   GlacierJobParameters?: GlacierJobParameters;
 
@@ -512,8 +512,8 @@ export namespace RestoreRequest {
 export interface RestoreObjectRequest {
   /**
    * <p>The bucket name containing the object to restore. </p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
@@ -529,9 +529,9 @@ export interface RestoreObjectRequest {
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -572,8 +572,8 @@ export namespace ContinuationEvent {
 
 /**
  * <p>A message that indicates the request is complete and no more messages will be sent. You
- *          should not assume that the request is complete until the client receives an
- *             <code>EndEvent</code>.</p>
+ * should not assume that the request is complete until the client receives an
+ *    <code>EndEvent</code>.</p>
  */
 export interface EndEvent {}
 
@@ -832,12 +832,12 @@ export namespace SelectObjectContentOutput {
 
 /**
  * <p>Container for specifying if periodic <code>QueryProgress</code> messages should be
- *          sent.</p>
+ * sent.</p>
  */
 export interface RequestProgress {
   /**
    * <p>Specifies whether periodic QueryProgress frames should be sent. Valid values: TRUE,
-   *          FALSE. Default value: FALSE.</p>
+   * FALSE. Default value: FALSE.</p>
    */
   Enabled?: boolean;
 }
@@ -853,27 +853,27 @@ export namespace RequestProgress {
 
 /**
  * <p>Specifies the byte range of the object to get the records from. A record is processed
- *          when its first byte is contained by the range. This parameter is optional, but when
- *          specified, it must not be empty. See RFC 2616, Section 14.35.1 about how to specify the
- *          start and end of the range.</p>
+ * when its first byte is contained by the range. This parameter is optional, but when
+ * specified, it must not be empty. See RFC 2616, Section 14.35.1 about how to specify the
+ * start and end of the range.</p>
  */
 export interface ScanRange {
   /**
    * <p>Specifies the start of the byte range. This parameter is optional. Valid values:
-   *          non-negative integers. The default value is 0. If only start is supplied, it means scan
-   *          from that point to the end of the file.For example;
-   *             <code><scanrange><start>50</start></scanrange></code> means scan
-   *          from byte 50 until the end of the file.</p>
+   * non-negative integers. The default value is 0. If only start is supplied, it means scan
+   * from that point to the end of the file.For example;
+   *    <code><scanrange><start>50</start></scanrange></code> means scan
+   * from byte 50 until the end of the file.</p>
    */
   Start?: number;
 
   /**
    * <p>Specifies the end of the byte range. This parameter is optional. Valid values:
-   *          non-negative integers. The default value is one less than the size of the object being
-   *          queried. If only the End parameter is supplied, it is interpreted to mean scan the last N
-   *          bytes of the file. For example,
-   *             <code><scanrange><end>50</end></scanrange></code> means scan the
-   *          last 50 bytes.</p>
+   * non-negative integers. The default value is one less than the size of the object being
+   * queried. If only the End parameter is supplied, it is interpreted to mean scan the last N
+   * bytes of the file. For example,
+   *    <code><scanrange><end>50</end></scanrange></code> means scan the
+   * last 50 bytes.</p>
    */
   End?: number;
 }
@@ -889,11 +889,11 @@ export namespace ScanRange {
 
 /**
  * <p>Request to filter the contents of an Amazon S3 object based on a simple Structured Query
- *          Language (SQL) statement. In the request, along with the SQL expression, you must specify a
- *          data serialization format (JSON or CSV) of the object. Amazon S3 uses this to parse object data
- *          into records. It returns only records that match the specified SQL expression. You must
- *          also specify the data serialization format for the response. For more information, see
- *             <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html">S3Select API Documentation</a>.</p>
+ * Language (SQL) statement. In the request, along with the SQL expression, you must specify a
+ * data serialization format (JSON or CSV) of the object. Amazon S3 uses this to parse object data
+ * into records. It returns only records that match the specified SQL expression. You must
+ * also specify the data serialization format for the response. For more information, see
+ *    <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html">S3Select API Documentation</a>.</p>
  */
 export interface SelectObjectContentRequest {
   /**
@@ -913,13 +913,13 @@ export interface SelectObjectContentRequest {
 
   /**
    * <p>The SSE Customer Key. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html">Server-Side Encryption
-   *             (Using Customer-Provided Encryption Keys</a>. </p>
+   *    (Using Customer-Provided Encryption Keys</a>. </p>
    */
   SSECustomerKey?: string;
 
   /**
    * <p>The SSE Customer Key MD5. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html">Server-Side Encryption
-   *             (Using Customer-Provided Encryption Keys</a>. </p>
+   *    (Using Customer-Provided Encryption Keys</a>. </p>
    */
   SSECustomerKeyMD5?: string;
 
@@ -950,29 +950,29 @@ export interface SelectObjectContentRequest {
 
   /**
    * <p>Specifies the byte range of the object to get the records from. A record is processed
-   *          when its first byte is contained by the range. This parameter is optional, but when
-   *          specified, it must not be empty. See RFC 2616, Section 14.35.1 about how to specify the
-   *          start and end of the range.</p>
-   *          <p>
-   *             <code>ScanRange</code>may be used in the following ways:</p>
-   *          <ul>
-   *             <li>
-   *                <p>
-   *                   <code><scanrange><start>50</start><end>100</end></scanrange></code>
-   *                - process only the records starting between the bytes 50 and 100 (inclusive, counting
-   *                from zero)</p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code><scanrange><start>50</start></scanrange></code> -
-   *                process only the records starting after the byte 50</p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <code><scanrange><end>50</end></scanrange></code> -
-   *                process only the records within the last 50 bytes of the file.</p>
-   *             </li>
-   *          </ul>
+   * when its first byte is contained by the range. This parameter is optional, but when
+   * specified, it must not be empty. See RFC 2616, Section 14.35.1 about how to specify the
+   * start and end of the range.</p>
+   * <p>
+   *    <code>ScanRange</code>may be used in the following ways:</p>
+   * <ul>
+   *    <li>
+   *       <p>
+   *          <code><scanrange><start>50</start><end>100</end></scanrange></code>
+   *       - process only the records starting between the bytes 50 and 100 (inclusive, counting
+   *       from zero)</p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code><scanrange><start>50</start></scanrange></code> -
+   *       process only the records starting after the byte 50</p>
+   *    </li>
+   *    <li>
+   *       <p>
+   *          <code><scanrange><end>50</end></scanrange></code> -
+   *       process only the records within the last 50 bytes of the file.</p>
+   *    </li>
+   * </ul>
    */
   ScanRange?: ScanRange;
 
@@ -995,7 +995,7 @@ export namespace SelectObjectContentRequest {
 export interface UploadPartOutput {
   /**
    * <p>The server-side encryption algorithm used when storing this object in Amazon S3 (for example,
-   *          AES256, aws:kms).</p>
+   * AES256, aws:kms).</p>
    */
   ServerSideEncryption?: ServerSideEncryption | string;
 
@@ -1006,20 +1006,20 @@ export interface UploadPartOutput {
 
   /**
    * <p>If server-side encryption with a customer-provided encryption key was requested, the
-   *          response will include this header confirming the encryption algorithm used.</p>
+   * response will include this header confirming the encryption algorithm used.</p>
    */
   SSECustomerAlgorithm?: string;
 
   /**
    * <p>If server-side encryption with a customer-provided encryption key was requested, the
-   *          response will include this header to provide round-trip message integrity verification of
-   *          the customer-provided encryption key.</p>
+   * response will include this header to provide round-trip message integrity verification of
+   * the customer-provided encryption key.</p>
    */
   SSECustomerKeyMD5?: string;
 
   /**
    * <p>If present, specifies the ID of the Amazon Web Services Key Management Service (Amazon Web Services KMS) symmetric
-   *          customer managed customer master key (CMK) was used for the object.</p>
+   * customer managed customer master key (CMK) was used for the object.</p>
    */
   SSEKMSKeyId?: string;
 
@@ -1030,7 +1030,7 @@ export interface UploadPartOutput {
 
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -1053,21 +1053,21 @@ export interface UploadPartRequest {
 
   /**
    * <p>The name of the bucket to which the multipart upload was initiated.</p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
   /**
    * <p>Size of the body in bytes. This parameter is useful when the size of the body cannot be
-   *          determined automatically.</p>
+   * determined automatically.</p>
    */
   ContentLength?: number;
 
   /**
    * <p>The base64-encoded 128-bit MD5 digest of the part data. This parameter is auto-populated
-   *          when using the command from the CLI. This parameter is required if object lock parameters
-   *          are specified.</p>
+   * when using the command from the CLI. This parameter is required if object lock parameters
+   * are specified.</p>
    */
   ContentMD5?: string;
 
@@ -1078,7 +1078,7 @@ export interface UploadPartRequest {
 
   /**
    * <p>Part number of part being uploaded. This is a positive integer between 1 and
-   *          10,000.</p>
+   * 10,000.</p>
    */
   PartNumber: number | undefined;
 
@@ -1089,31 +1089,31 @@ export interface UploadPartRequest {
 
   /**
    * <p>Specifies the algorithm to use to when encrypting the object (for example,
-   *          AES256).</p>
+   * AES256).</p>
    */
   SSECustomerAlgorithm?: string;
 
   /**
    * <p>Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This
-   *          value is used to store the object and then it is discarded; Amazon S3 does not store the
-   *          encryption key. The key must be appropriate for use with the algorithm specified in the
-   *             <code>x-amz-server-side-encryption-customer-algorithm header</code>. This must be the
-   *          same encryption key specified in the initiate multipart upload request.</p>
+   * value is used to store the object and then it is discarded; Amazon S3 does not store the
+   * encryption key. The key must be appropriate for use with the algorithm specified in the
+   *    <code>x-amz-server-side-encryption-customer-algorithm header</code>. This must be the
+   * same encryption key specified in the initiate multipart upload request.</p>
    */
   SSECustomerKey?: string;
 
   /**
    * <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses
-   *          this header for a message integrity check to ensure that the encryption key was transmitted
-   *          without error.</p>
+   * this header for a message integrity check to ensure that the encryption key was transmitted
+   * without error.</p>
    */
   SSECustomerKeyMD5?: string;
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -1160,7 +1160,7 @@ export namespace CopyPartResult {
 export interface UploadPartCopyOutput {
   /**
    * <p>The version of the source object that was copied, if you have enabled versioning on the
-   *          source bucket.</p>
+   * source bucket.</p>
    */
   CopySourceVersionId?: string;
 
@@ -1171,26 +1171,26 @@ export interface UploadPartCopyOutput {
 
   /**
    * <p>The server-side encryption algorithm used when storing this object in Amazon S3 (for example,
-   *          AES256, aws:kms).</p>
+   * AES256, aws:kms).</p>
    */
   ServerSideEncryption?: ServerSideEncryption | string;
 
   /**
    * <p>If server-side encryption with a customer-provided encryption key was requested, the
-   *          response will include this header confirming the encryption algorithm used.</p>
+   * response will include this header confirming the encryption algorithm used.</p>
    */
   SSECustomerAlgorithm?: string;
 
   /**
    * <p>If server-side encryption with a customer-provided encryption key was requested, the
-   *          response will include this header to provide round-trip message integrity verification of
-   *          the customer-provided encryption key.</p>
+   * response will include this header to provide round-trip message integrity verification of
+   * the customer-provided encryption key.</p>
    */
   SSECustomerKeyMD5?: string;
 
   /**
    * <p>If present, specifies the ID of the Amazon Web Services Key Management Service (Amazon Web Services KMS) symmetric
-   *          customer managed customer master key (CMK) that was used for the object.</p>
+   * customer managed customer master key (CMK) that was used for the object.</p>
    */
   SSEKMSKeyId?: string;
 
@@ -1201,7 +1201,7 @@ export interface UploadPartCopyOutput {
 
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 }
@@ -1219,36 +1219,36 @@ export namespace UploadPartCopyOutput {
 export interface UploadPartCopyRequest {
   /**
    * <p>The bucket name.</p>
-   *          <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
-   *          <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com. When using this action using S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html">Using S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   Bucket: string | undefined;
 
   /**
    * <p>Specifies the source object for the copy operation. You specify the value in one of two
-   *          formats, depending on whether you want to access the source object through an <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points.html">access point</a>:</p>
-   *          <ul>
-   *             <li>
-   *                <p>For objects not accessed through an access point, specify the name of the source
-   *                bucket and key of the source object, separated by a slash (/). For example, to copy
-   *                the object <code>reports/january.pdf</code> from the bucket
-   *                   <code>awsexamplebucket</code>, use
-   *                   <code>awsexamplebucket/reports/january.pdf</code>. The value must be URL
-   *                encoded.</p>
-   *             </li>
-   *             <li>
-   *                <p>For objects accessed through access points, specify the Amazon Resource Name (ARN) of the object as accessed through the access point, in the format <code>arn:aws:s3:<Region>:<account-id>:accesspoint/<access-point-name>/object/<key></code>. For example, to copy the object <code>reports/january.pdf</code> through access point <code>my-access-point</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3:us-west-2:123456789012:accesspoint/my-access-point/object/reports/january.pdf</code>. The value must be URL encoded.</p>
-   *                <note>
-   *                   <p>Amazon S3 supports copy operations using access points only when the source and destination buckets are in the same Amazon Web Services Region.</p>
-   *                </note>
-   *                <p>Alternatively, for objects accessed through Amazon S3 on Outposts, specify the ARN of the object as accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/object/<key></code>. For example, to copy the object <code>reports/january.pdf</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/object/reports/january.pdf</code>. The value must be URL encoded.  </p>
-   *             </li>
-   *          </ul>
-   *          <p>To copy a specific version of an object, append <code>?versionId=<version-id></code>
-   *          to the value (for example,
-   *             <code>awsexamplebucket/reports/january.pdf?versionId=QUpfdndhfd8438MNFDN93jdnJFkdmqnh893</code>).
-   *          If you don't specify a version ID, Amazon S3 copies the latest version of the source
-   *          object.</p>
+   * formats, depending on whether you want to access the source object through an <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points.html">access point</a>:</p>
+   * <ul>
+   *    <li>
+   *       <p>For objects not accessed through an access point, specify the name of the source
+   *       bucket and key of the source object, separated by a slash (/). For example, to copy
+   *       the object <code>reports/january.pdf</code> from the bucket
+   *          <code>awsexamplebucket</code>, use
+   *          <code>awsexamplebucket/reports/january.pdf</code>. The value must be URL
+   *       encoded.</p>
+   *    </li>
+   *    <li>
+   *       <p>For objects accessed through access points, specify the Amazon Resource Name (ARN) of the object as accessed through the access point, in the format <code>arn:aws:s3:<Region>:<account-id>:accesspoint/<access-point-name>/object/<key></code>. For example, to copy the object <code>reports/january.pdf</code> through access point <code>my-access-point</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3:us-west-2:123456789012:accesspoint/my-access-point/object/reports/january.pdf</code>. The value must be URL encoded.</p>
+   *       <note>
+   *          <p>Amazon S3 supports copy operations using access points only when the source and destination buckets are in the same Amazon Web Services Region.</p>
+   *       </note>
+   *       <p>Alternatively, for objects accessed through Amazon S3 on Outposts, specify the ARN of the object as accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/object/<key></code>. For example, to copy the object <code>reports/january.pdf</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/object/reports/january.pdf</code>. The value must be URL encoded.  </p>
+   *    </li>
+   * </ul>
+   * <p>To copy a specific version of an object, append <code>?versionId=<version-id></code>
+   * to the value (for example,
+   *    <code>awsexamplebucket/reports/january.pdf?versionId=QUpfdndhfd8438MNFDN93jdnJFkdmqnh893</code>).
+   * If you don't specify a version ID, Amazon S3 copies the latest version of the source
+   * object.</p>
    */
   CopySource: string | undefined;
 
@@ -1274,9 +1274,9 @@ export interface UploadPartCopyRequest {
 
   /**
    * <p>The range of bytes to copy from the source object. The range value must use the form
-   *          bytes=first-last, where the first and last are the zero-based byte offsets to copy. For
-   *          example, bytes=0-9 indicates that you want to copy the first 10 bytes of the source. You
-   *          can copy a range only if the source object is greater than 5 MB.</p>
+   * bytes=first-last, where the first and last are the zero-based byte offsets to copy. For
+   * example, bytes=0-9 indicates that you want to copy the first 10 bytes of the source. You
+   * can copy a range only if the source object is greater than 5 MB.</p>
    */
   CopySourceRange?: string;
 
@@ -1287,7 +1287,7 @@ export interface UploadPartCopyRequest {
 
   /**
    * <p>Part number of part being copied. This is a positive integer between 1 and
-   *          10,000.</p>
+   * 10,000.</p>
    */
   PartNumber: number | undefined;
 
@@ -1298,51 +1298,51 @@ export interface UploadPartCopyRequest {
 
   /**
    * <p>Specifies the algorithm to use to when encrypting the object (for example,
-   *          AES256).</p>
+   * AES256).</p>
    */
   SSECustomerAlgorithm?: string;
 
   /**
    * <p>Specifies the customer-provided encryption key for Amazon S3 to use in encrypting data. This
-   *          value is used to store the object and then it is discarded; Amazon S3 does not store the
-   *          encryption key. The key must be appropriate for use with the algorithm specified in the
-   *             <code>x-amz-server-side-encryption-customer-algorithm</code> header. This must be the
-   *          same encryption key specified in the initiate multipart upload request.</p>
+   * value is used to store the object and then it is discarded; Amazon S3 does not store the
+   * encryption key. The key must be appropriate for use with the algorithm specified in the
+   *    <code>x-amz-server-side-encryption-customer-algorithm</code> header. This must be the
+   * same encryption key specified in the initiate multipart upload request.</p>
    */
   SSECustomerKey?: string;
 
   /**
    * <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses
-   *          this header for a message integrity check to ensure that the encryption key was transmitted
-   *          without error.</p>
+   * this header for a message integrity check to ensure that the encryption key was transmitted
+   * without error.</p>
    */
   SSECustomerKeyMD5?: string;
 
   /**
    * <p>Specifies the algorithm to use when decrypting the source object (for example,
-   *          AES256).</p>
+   * AES256).</p>
    */
   CopySourceSSECustomerAlgorithm?: string;
 
   /**
    * <p>Specifies the customer-provided encryption key for Amazon S3 to use to decrypt the source
-   *          object. The encryption key provided in this header must be one that was used when the
-   *          source object was created.</p>
+   * object. The encryption key provided in this header must be one that was used when the
+   * source object was created.</p>
    */
   CopySourceSSECustomerKey?: string;
 
   /**
    * <p>Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321. Amazon S3 uses
-   *          this header for a message integrity check to ensure that the encryption key was transmitted
-   *          without error.</p>
+   * this header for a message integrity check to ensure that the encryption key was transmitted
+   * without error.</p>
    */
   CopySourceSSECustomerKeyMD5?: string;
 
   /**
    * <p>Confirms that the requester knows that they will be charged for the request. Bucket
-   *          owners need not specify this parameter in their requests. For information about downloading
-   *          objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
-   *             Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
+   * owners need not specify this parameter in their requests. For information about downloading
+   * objects from requester pays buckets, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html">Downloading Objects in
+   *    Requestor Pays Buckets</a> in the <i>Amazon S3 User Guide</i>.</p>
    */
   RequestPayer?: RequestPayer | string;
 
@@ -1376,7 +1376,7 @@ export interface WriteGetObjectResponseRequest {
 
   /**
    * <p>A single use encrypted token that maps <code>WriteGetObjectResponse</code> to the end
-   *          user <code>GetObject</code> request.</p>
+   * user <code>GetObject</code> request.</p>
    */
   RequestToken: string | undefined;
 
@@ -1387,98 +1387,98 @@ export interface WriteGetObjectResponseRequest {
 
   /**
    * <p>The integer status code for an HTTP response of a corresponding <code>GetObject</code>
-   *          request.</p>
-   *              <p class="title">
-   *             <b>Status Codes</b>
-   *          </p>
-   *          <ul>
-   *             <li>
-   *                    <p>
-   *                   <i>200 - OK</i>
-   *                </p>
-   *                 </li>
-   *             <li>
-   *                    <p>
-   *                   <i>206 - Partial Content</i>
-   *                </p>
-   *                 </li>
-   *             <li>
-   *                    <p>
-   *                   <i>304 - Not Modified</i>
-   *                </p>
-   *                 </li>
-   *             <li>
-   *                    <p>
-   *                   <i>400 - Bad Request</i>
-   *                    </p>
-   *                 </li>
-   *             <li>
-   *                    <p>
-   *                   <i>401 - Unauthorized</i>
-   *                    </p>
-   *                 </li>
-   *             <li>
-   *                    <p>
-   *                   <i>403 - Forbidden</i>
-   *                    </p>
-   *                 </li>
-   *             <li>
-   *                    <p>
-   *                   <i>404 - Not Found</i>
-   *                    </p>
-   *                 </li>
-   *             <li>
-   *                    <p>
-   *                   <i>405 - Method Not Allowed</i>
-   *                    </p>
-   *                 </li>
-   *             <li>
-   *                    <p>
-   *                   <i>409 - Conflict</i>
-   *                    </p>
-   *                 </li>
-   *             <li>
-   *                    <p>
-   *                   <i>411 - Length Required</i>
-   *                    </p>
-   *                 </li>
-   *             <li>
-   *                    <p>
-   *                   <i>412 - Precondition Failed</i>
-   *                    </p>
-   *                 </li>
-   *             <li>
-   *                    <p>
-   *                   <i>416 - Range Not Satisfiable</i>
-   *                    </p>
-   *                 </li>
-   *             <li>
-   *                    <p>
-   *                   <i>500 - Internal Server Error</i>
-   *                    </p>
-   *                 </li>
-   *             <li>
-   *                    <p>
-   *                   <i>503 - Service Unavailable</i>
-   *                    </p>
-   *                 </li>
-   *          </ul>
+   * request.</p>
+   *     <p class="title">
+   *    <b>Status Codes</b>
+   * </p>
+   * <ul>
+   *    <li>
+   *           <p>
+   *          <i>200 - OK</i>
+   *       </p>
+   *        </li>
+   *    <li>
+   *           <p>
+   *          <i>206 - Partial Content</i>
+   *       </p>
+   *        </li>
+   *    <li>
+   *           <p>
+   *          <i>304 - Not Modified</i>
+   *       </p>
+   *        </li>
+   *    <li>
+   *           <p>
+   *          <i>400 - Bad Request</i>
+   *           </p>
+   *        </li>
+   *    <li>
+   *           <p>
+   *          <i>401 - Unauthorized</i>
+   *           </p>
+   *        </li>
+   *    <li>
+   *           <p>
+   *          <i>403 - Forbidden</i>
+   *           </p>
+   *        </li>
+   *    <li>
+   *           <p>
+   *          <i>404 - Not Found</i>
+   *           </p>
+   *        </li>
+   *    <li>
+   *           <p>
+   *          <i>405 - Method Not Allowed</i>
+   *           </p>
+   *        </li>
+   *    <li>
+   *           <p>
+   *          <i>409 - Conflict</i>
+   *           </p>
+   *        </li>
+   *    <li>
+   *           <p>
+   *          <i>411 - Length Required</i>
+   *           </p>
+   *        </li>
+   *    <li>
+   *           <p>
+   *          <i>412 - Precondition Failed</i>
+   *           </p>
+   *        </li>
+   *    <li>
+   *           <p>
+   *          <i>416 - Range Not Satisfiable</i>
+   *           </p>
+   *        </li>
+   *    <li>
+   *           <p>
+   *          <i>500 - Internal Server Error</i>
+   *           </p>
+   *        </li>
+   *    <li>
+   *           <p>
+   *          <i>503 - Service Unavailable</i>
+   *           </p>
+   *        </li>
+   * </ul>
    */
   StatusCode?: number;
 
   /**
    * <p>A string that uniquely identifies an error condition. Returned in the <Code> tag
-   *          of the error XML response for a corresponding <code>GetObject</code> call. Cannot be used
-   *          with a successful <code>StatusCode</code> header or when the transformed object is provided
-   *           in the body. All error codes from S3 are sentence-cased. Regex value is "^[A-Z][a-zA-Z]+$".</p>
+   * of the error XML response for a corresponding <code>GetObject</code> call. Cannot be used
+   * with a successful <code>StatusCode</code> header or when the transformed object is provided
+   *  in the body. All error codes from S3 are sentence-cased. Regex value is "^[A-Z][a-zA-Z]+$".</p>
    */
   ErrorCode?: string;
 
   /**
    * <p>Contains a generic description of the error condition. Returned in the <Message>
-   *          tag of the error XML response for a corresponding <code>GetObject</code> call. Cannot be
-   *          used with a successful <code>StatusCode</code> header or when the transformed object is
-   *          provided in body.</p>
+   * tag of the error XML response for a corresponding <code>GetObject</code> call. Cannot be
+   * used with a successful <code>StatusCode</code> header or when the transformed object is
+   * provided in body.</p>
    */
   ErrorMessage?: string;
 
@@ -1499,8 +1499,8 @@ export interface WriteGetObjectResponseRequest {
 
   /**
    * <p>Specifies what content encodings have been applied to the object and thus what decoding
-   *           mechanisms must be applied to obtain the media-type referenced by the Content-Type header
-   *           field.</p>
+   *  mechanisms must be applied to obtain the media-type referenced by the Content-Type header
+   *  field.</p>
    */
   ContentEncoding?: string;
 
@@ -1526,13 +1526,13 @@ export interface WriteGetObjectResponseRequest {
 
   /**
    * <p>Specifies whether an object stored in Amazon S3 is (<code>true</code>) or is not
-   *             (<code>false</code>) a delete marker. </p>
+   *    (<code>false</code>) a delete marker. </p>
    */
   DeleteMarker?: boolean;
 
   /**
    * <p>An opaque identifier assigned by a web server to a specific version of a resource found
-   *          at a URL. </p>
+   * at a URL. </p>
    */
   ETag?: string;
 
@@ -1553,9 +1553,9 @@ export interface WriteGetObjectResponseRequest {
 
   /**
    * <p>Set to the number of metadata entries not returned in <code>x-amz-meta</code> headers.
-   *          This can happen if you create metadata using an API like SOAP that supports more flexible
-   *          metadata than the REST API. For example, using SOAP, you can create metadata whose values
-   *          are not legal HTTP headers.</p>
+   * This can happen if you create metadata using an API like SOAP that supports more flexible
+   * metadata than the REST API. For example, using SOAP, you can create metadata whose values
+   * are not legal HTTP headers.</p>
    */
   MissingMeta?: number;
 
@@ -1566,7 +1566,7 @@ export interface WriteGetObjectResponseRequest {
 
   /**
    * <p>Indicates whether an object stored in Amazon S3 has Object Lock enabled. For more
-   *           information about S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html">Object Lock</a>.</p>
+   *  information about S3 Object Lock, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html">Object Lock</a>.</p>
    */
   ObjectLockMode?: ObjectLockMode | string;
 
@@ -1587,19 +1587,19 @@ export interface WriteGetObjectResponseRequest {
 
   /**
    * <p>Indicates if request involves bucket that is either a source or destination in a Replication rule. For more
-   *           information about S3 Replication, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html">Replication</a>.</p>
+   *  information about S3 Replication, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html">Replication</a>.</p>
    */
   ReplicationStatus?: ReplicationStatus | string;
 
   /**
    * <p>If present, indicates that the requester was successfully charged for the
-   *          request.</p>
+   * request.</p>
    */
   RequestCharged?: RequestCharged | string;
 
   /**
    * <p>Provides information about object restoration operation and expiration time of the
-   *           restored object copy.</p>
+   *  restored object copy.</p>
    */
   Restore?: string;
 
@@ -1620,9 +1620,9 @@ export interface WriteGetObjectResponseRequest {
 
   /**
    * <p> 128-bit MD5 digest of customer-provided encryption key used in Amazon S3 to encrypt data
-   *          stored in S3. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html">Protecting data
-   *             using server-side encryption with customer-provided encryption keys
-   *          (SSE-C)</a>.</p>
+   * stored in S3. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html">Protecting data
+   *    using server-side encryption with customer-provided encryption keys
+   * (SSE-C)</a>.</p>
    */
   SSECustomerKeyMD5?: string;
 
@@ -1643,7 +1643,7 @@ export interface WriteGetObjectResponseRequest {
 
   /**
    * <p> Indicates whether the object stored in Amazon S3 uses an S3 bucket key for server-side
-   *          encryption with Amazon Web Services KMS (SSE-KMS).</p>
+   * encryption with Amazon Web Services KMS (SSE-KMS).</p>
    */
   BucketKeyEnabled?: boolean;
 }


### PR DESCRIPTION
## Issue #, if available:
Fixes: https://github.com/trivikr/temp-client-s3/issues/20

## Description of changes:
Removes unnecessary whitespace from beginning of the comments.

<details>
<summary>Before</summary>

```console
package size:  339.7 kB
unpacked size: 3.8 MB
total files:   448
```

</details>

<details>
<summary>After</summary>

```console
package size:  335.1 kB
unpacked size: 3.7 MB
total files:   448
```

</details>

## Testing

Can't test with VSCode as it doesn't render HTML markdown https://github.com/microsoft/vscode/issues/40607

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
