### PR TITLE
fix(client-s3): exclude declarationDir while emitting declarations

### DIFF
--- a/clients/client-s3/tsconfig.types.json
+++ b/clients/client-s3/tsconfig.types.json
@@ -6,5 +6,5 @@
     "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
-  "exclude": ["test/**/*", "src/**/*.spec.ts"]
+  "exclude": ["test/**/*", "src/**/*.spec.ts", "dist-types/**/*"]
 }


### PR DESCRIPTION
## Issue #, if available:
Refs: https://stackoverflow.com/a/48798945
Closes: https://github.com/trivikr/temp-client-s3/issues/17

## Description of changes:
Exclude declarationDir while emitting declarations

## Testing
Verified that types are created in `dist-types` folder:

```console
$ pwd
/Users/trivikr/workspace/temp-client-s3/clients/client-s3

$ rm -rf dist-types

$ yarn build:types

$ ls dist-types 
S3.d.ts                         protocols
S3Client.d.ts                   runtimeConfig.browser.d.ts
commands                        runtimeConfig.d.ts
endpoints.d.ts                  runtimeConfig.native.d.ts
index.d.ts                      runtimeConfig.shared.d.ts
models                          waiters
pagination
```

Verified that downleveled types are created in `ts3.4` folder:
```console
$ pwd 
/Users/trivikr/workspace/temp-client-s3

$ node scripts/build-downlevel-dts.js

$ ls clients/client-s3/dist-types/ts3.4
S3.d.ts                         protocols
S3Client.d.ts                   runtimeConfig.browser.d.ts
commands                        runtimeConfig.d.ts
endpoints.d.ts                  runtimeConfig.native.d.ts
index.d.ts                      runtimeConfig.shared.d.ts
models                          waiters
pagination
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
