### PR TITLE
fix: error handling in build downlevel-dts script

### DIFF
--- a/scripts/build-downlevel-dts.js
+++ b/scripts/build-downlevel-dts.js
@@ -30,12 +30,11 @@ packages
       .map((dirent) => dirent.name)
       .forEach((workspaceName) => {
         const workspaceDir = join(workspacesDir, workspaceName);
-        const workspaceDirpath = join(process.cwd(), workspaceDir);
 
         const distTypesFolder = "dist-types";
         const downlevelTypesFolder = "ts3.4";
 
-        const workspaceDistTypesFolder = join(workspacesDir, workspaceName, distTypesFolder);
+        const workspaceDistTypesFolder = join(workspaceDir, distTypesFolder);
         if (!existsSync(workspaceDistTypesFolder)) {
           throw new Error(
             `The types for "${workspaceName}" do not exist.\n` +
@@ -58,10 +57,10 @@ packages
 
         // Process downlevel-dts folder if it exists
         if (existsSync(workspaceDistTypesDownlevelFolder)) {
-          const downlevelTypesDir = join(workspaceDirpath, distTypesFolder, downlevelTypesFolder);
+          const downlevelTypesDir = join(workspaceDir, distTypesFolder, downlevelTypesFolder);
 
           // Add typesVersions in package.json
-          const packageManifestPath = join(workspaceDirpath, "package.json");
+          const packageManifestPath = join(workspaceDir, "package.json");
           const packageManifest = JSON.parse(readFileSync(packageManifestPath).toString());
           packageManifest.typesVersions = {
             "<4.0": {

--- a/scripts/build-downlevel-dts.js
+++ b/scripts/build-downlevel-dts.js
@@ -30,7 +30,6 @@ packages
       .map((dirent) => dirent.name)
       .forEach((workspaceName) => {
         const workspaceDir = join(workspacesDir, workspaceName);
-
         const distTypesFolder = "dist-types";
         const downlevelTypesFolder = "ts3.4";
 

--- a/scripts/build-downlevel-dts.js
+++ b/scripts/build-downlevel-dts.js
@@ -46,11 +46,7 @@ packages
         // Create downlevel-dts folder if it doesn't exist
         if (!existsSync(workspaceDistTypesDownlevelFolder)) {
           execSync(
-            [
-              "./node_modules/.bin/downlevel-dts",
-              workspaceDistTypesFolder,
-              join(workspaceDistTypesFolder, downlevelTypesFolder),
-            ].join(" ")
+            ["./node_modules/.bin/downlevel-dts", workspaceDistTypesFolder, workspaceDistTypesDownlevelFolder].join(" ")
           );
         }
 

--- a/scripts/build-downlevel-dts.js
+++ b/scripts/build-downlevel-dts.js
@@ -30,7 +30,7 @@ packages
       .map((dirent) => dirent.name)
       .forEach((workspaceName) => {
         const workspaceDir = join(workspacesDir, workspaceName);
-        const workspaceDirPath = join(process.cwd(), workspaceDir);
+        const workspaceDirpath = join(process.cwd(), workspaceDir);
 
         const distTypesFolder = "dist-types";
         const downlevelTypesFolder = "ts3.4";
@@ -58,10 +58,10 @@ packages
 
         // Process downlevel-dts folder if it exists
         if (existsSync(workspaceDistTypesDownlevelFolder)) {
-          const downlevelTypesDir = join(workspaceDirPath, distTypesFolder, downlevelTypesFolder);
+          const downlevelTypesDir = join(workspaceDirpath, distTypesFolder, downlevelTypesFolder);
 
           // Add typesVersions in package.json
-          const packageManifestPath = join(workspaceDirPath, "package.json");
+          const packageManifestPath = join(workspaceDirpath, "package.json");
           const packageManifest = JSON.parse(readFileSync(packageManifestPath).toString());
           packageManifest.typesVersions = {
             "<4.0": {
@@ -77,7 +77,7 @@ packages
               writeFileSync(downlevelTypesFilepath, stripComments(content));
             } catch (error) {
               console.error(
-                `Error while stripping comments from ${downlevelTypesFilepath.replace(workspaceDistTypesFolder, "")}`
+                `Error while stripping comments from "${downlevelTypesFilepath.replace(process.cwd(), "")}"`
               );
               console.error(error);
             }

--- a/scripts/build-downlevel-dts.js
+++ b/scripts/build-downlevel-dts.js
@@ -56,7 +56,7 @@ packages
           );
         }
 
-        // Strip comments from downlevel-dts files if they exist
+        // Process downlevel-dts folder if it exists
         if (existsSync(workspaceDistTypesDownlevelFolder)) {
           const downlevelTypesDir = join(workspaceDirPath, distTypesFolder, downlevelTypesFolder);
 
@@ -72,8 +72,15 @@ packages
 
           getAllFiles(downlevelTypesDir).forEach((downlevelTypesFilepath) => {
             // Strip comments from downlevel-dts file
-            const content = readFileSync(downlevelTypesFilepath, "utf8");
-            writeFileSync(downlevelTypesFilepath, stripComments(content));
+            try {
+              const content = readFileSync(downlevelTypesFilepath, "utf8");
+              writeFileSync(downlevelTypesFilepath, stripComments(content));
+            } catch (error) {
+              console.error(
+                `Error while stripping comments from ${downlevelTypesFilepath.replace(workspaceDistTypesFolder, "")}`
+              );
+              console.error(error);
+            }
           });
         }
       });

--- a/scripts/build-downlevel-dts.js
+++ b/scripts/build-downlevel-dts.js
@@ -28,17 +28,19 @@ packages
     readdirSync(join(process.cwd(), workspacesDir), { withFileTypes: true })
       .filter((dirent) => dirent.isDirectory())
       .map((dirent) => dirent.name)
-      .forEach((workspaceDir) => {
-        const workspaceDirPath = join(process.cwd(), workspacesDir, workspaceDir);
+      .forEach((workspaceName) => {
+        const workspaceDirPath = join(process.cwd(), workspacesDir, workspaceName);
 
         const distTypesFolder = "dist-types";
         const downlevelTypesFolder = "ts3.4";
 
-        const workspaceDistTypesFolder = join(workspacesDir, workspaceDir, distTypesFolder);
+        const workspaceDistTypesFolder = join(workspacesDir, workspaceName, distTypesFolder);
         if (!existsSync(workspaceDistTypesFolder)) {
-          console.log(`The types for ${join(workspacesDir, workspaceDir)} does not exist.`);
-          console.log(`Folder checked: ${workspaceDistTypesFolder}`);
-          return;
+          throw new Error(
+            `The types for "${workspaceName}" do not exist.\n` +
+              `Either "yarn build:types" is not run in workspace "${join(workspacesDir, workspaceName)}" or` +
+              `types are not emitted in "${distTypesFolder}" folder.`
+          );
         }
 
         const workspaceDistTypesDownlevelFolder = join(workspaceDistTypesFolder, downlevelTypesFolder);


### PR DESCRIPTION
### Issue
Fixes: https://github.com/trivikr/temp-client-s3/issues/25

### Description
Enables error handling in downlevel-dts script.

### Testing

<details>
<summary>Verified that error is thrown when types folder is not present</summary>

```console
$ rm -rf clients/client-s3/dist-types

$ node scripts/build-downlevel-dts.js 
/Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:39
          throw new Error(
          ^

Error: The types for "client-s3" do not exist.
Either "yarn build:types" is not run in workspace "clients/client-s3" ortypes are not emitted in "dist-types" folder.
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:39:17
    at Array.forEach (<anonymous>)
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:31:8
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:26:4)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32)
    at Function.Module._load (internal/modules/cjs/loader.js:778:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
```

</details>

<details>
<summary>Verified that error is thrown when downlevel-dts script throws error</summary>

```console
$ (cd clients/client-s3 && yarn build:types)

$ rm -rf ./node_modules/.bin/downlevel-dts

$ node scripts/build-downlevel-dts.js
/bin/sh: ./node_modules/.bin/downlevel-dts: No such file or directory
child_process.js:836
    throw err;
    ^

Error: Command failed: ./node_modules/.bin/downlevel-dts clients/client-s3/dist-types clients/client-s3/dist-types/ts3.4
/bin/sh: ./node_modules/.bin/downlevel-dts: No such file or directory

    at checkExecSyncError (child_process.js:760:11)
    at execSync (child_process.js:833:15)
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:50:11
    at Array.forEach (<anonymous>)
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:31:8
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:26:4)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32) {
  status: 127,
  signal: null,
  output: [
    null,
    Buffer(0) [Uint8Array] [],
    Buffer(70) [Uint8Array] [
       47,  98, 105, 110,  47, 115, 104,  58,  32,  46,  47,
      110, 111, 100, 101,  95, 109, 111, 100, 117, 108, 101,
      115,  47,  46,  98, 105, 110,  47, 100, 111, 119, 110,
      108, 101, 118, 101, 108,  45, 100, 116, 115,  58,  32,
       78, 111,  32, 115, 117,  99, 104,  32, 102, 105, 108,
      101,  32, 111, 114,  32, 100, 105, 114, 101,  99, 116,
      111, 114, 121,  10
    ]
  ],
  pid: 25728,
  stdout: Buffer(0) [Uint8Array] [],
  stderr: Buffer(70) [Uint8Array] [
     47,  98, 105, 110,  47, 115, 104,  58,  32,  46,  47,
    110, 111, 100, 101,  95, 109, 111, 100, 117, 108, 101,
    115,  47,  46,  98, 105, 110,  47, 100, 111, 119, 110,
    108, 101, 118, 101, 108,  45, 100, 116, 115,  58,  32,
     78, 111,  32, 115, 117,  99, 104,  32, 102, 105, 108,
    101,  32, 111, 114,  32, 100, 105, 114, 101,  99, 116,
    111, 114, 121,  10
  ]
}
```

</details>

<details>
<summary>Verified that error is thrown is package.json read/write fails</summary>

```console
$ rm clients/client-s3/package.json

$ node scripts/build-downlevel-dts.js 
internal/fs/utils.js:314
    throw err;
    ^

Error: ENOENT: no such file or directory, open '/Users/trivikr/workspace/temp-client-s3/clients/client-s3/package.json'
    at Object.openSync (fs.js:498:3)
    at readFileSync (fs.js:394:35)
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:65:46
    at Array.forEach (<anonymous>)
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:31:8
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:26:4)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/Users/trivikr/workspace/temp-client-s3/clients/client-s3/package.json'
}

$ git checkout .
```

</details>

<details>
<summary>Verified that error is logged in console if stripComments fails</summary>

This was done by simulating failure by passing undefined to stripComments
```console
$ git diff
diff --git a/scripts/build-downlevel-dts.js b/scripts/build-downlevel-dts.js
index d4319ed..74d3b82 100644
--- a/scripts/build-downlevel-dts.js
+++ b/scripts/build-downlevel-dts.js
@@ -74,7 +74,7 @@ packages
             // Strip comments from downlevel-dts file
             try {
               const content = readFileSync(downlevelTypesFilepath, "utf8");
-              writeFileSync(downlevelTypesFilepath, stripComments(content));
+              writeFileSync(downlevelTypesFilepath, stripComments());
             } catch (error) {
               console.error(
                 `Error while stripping comments from "${downlevelTypesFilepath.replace(process.cwd(), "")}"`

$ node scripts/build-downlevel-dts.js
...
Error while stripping comments from "/clients/client-s3/dist-types/ts3.4/waiters/waitForObjectNotExists.d.ts"
TypeError: Expected input to be a string
    at parse (/Users/trivikr/workspace/temp-client-s3/node_modules/strip-comments/lib/parse.js:14:11)
    at module.exports (/Users/trivikr/workspace/temp-client-s3/node_modules/strip-comments/index.js:35:18)
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:77:53
    at Array.forEach (<anonymous>)
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:73:42
    at Array.forEach (<anonymous>)
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:31:8
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:26:4)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
