### PR TITLE
fix: read declarationDir from tsconfig.types.json

### DIFF
--- a/scripts/build-downlevel-dts.js
+++ b/scripts/build-downlevel-dts.js
@@ -37,10 +37,7 @@ packages
         const distTypesFolder = JSON.parse(readFileSync(tsTypesConfigPath).toString()).compilerOptions.declarationDir;
 
         if (!distTypesFolder) {
-          throw new Error(
-            `The declarationDir is not defined for "${workspaceName}" do not exist.\n` +
-              `Attempted to read "${tsTypesConfigPath}".`
-          );
+          throw new Error(`The declarationDir is not defined in "${tsTypesConfigPath}".`);
         }
 
         const workspaceDistTypesFolder = join(workspaceDir, distTypesFolder);

--- a/scripts/build-downlevel-dts.js
+++ b/scripts/build-downlevel-dts.js
@@ -32,8 +32,7 @@ packages
         const workspaceDir = join(workspacesDir, workspaceName);
         const downlevelTypesFolder = "ts3.4";
 
-        const tsTypeConfigFilename = "tsconfig.types.json";
-        const tsTypesConfigPath = join(workspaceDir, tsTypeConfigFilename);
+        const tsTypesConfigPath = join(workspaceDir, "tsconfig.types.json");
         const distTypesFolder = JSON.parse(readFileSync(tsTypesConfigPath).toString()).compilerOptions.declarationDir;
 
         if (!distTypesFolder) {

--- a/scripts/build-downlevel-dts.js
+++ b/scripts/build-downlevel-dts.js
@@ -30,8 +30,18 @@ packages
       .map((dirent) => dirent.name)
       .forEach((workspaceName) => {
         const workspaceDir = join(workspacesDir, workspaceName);
-        const distTypesFolder = "dist-types";
         const downlevelTypesFolder = "ts3.4";
+
+        const tsTypeConfigFilename = "tsconfig.types.json";
+        const tsTypesConfigPath = join(workspaceDir, tsTypeConfigFilename);
+        const distTypesFolder = JSON.parse(readFileSync(tsTypesConfigPath).toString()).compilerOptions.declarationDir;
+
+        if (!distTypesFolder) {
+          throw new Error(
+            `The declarationDir is not defined for "${workspaceName}" do not exist.\n` +
+              `Attempted to read "${tsTypesConfigPath}".`
+          );
+        }
 
         const workspaceDistTypesFolder = join(workspaceDir, distTypesFolder);
         if (!existsSync(workspaceDistTypesFolder)) {


### PR DESCRIPTION
### Issue
Fixes: https://github.com/trivikr/temp-client-s3/issues/27

### Description
Read declarationDir from `tsconfig.types.json`

### Testing

<details>
<summary>Verified that downlevel types are created</summary>

```console
$ rm -rf clients/client-s3/dist-types/ts3.4

$ node scripts/build-downlevel-dts.js

$ ls clients/client-s3/dist-types/ts3.4
S3.d.ts                         models                          runtimeConfig.native.d.ts
S3Client.d.ts                   pagination                      runtimeConfig.shared.d.ts
commands                        protocols                       waiters
endpoints.d.ts                  runtimeConfig.browser.d.ts
index.d.ts                      runtimeConfig.d.ts
```

</details>

<details>
<summary>Verified that script fails if tsconfig.types.json is not present</summary>

```console
$ rm -rf clients/client-s3/tsconfig.types.json

$ node scripts/build-downlevel-dts.js
internal/fs/utils.js:314
    throw err;
    ^

Error: ENOENT: no such file or directory, open 'clients/client-s3/tsconfig.types.json'
    at Object.openSync (fs.js:498:3)
    at readFileSync (fs.js:394:35)
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:37:44
    at Array.forEach (<anonymous>)
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:31:8
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:26:4)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: 'clients/client-s3/tsconfig.types.json'
}
```

</details>

<details>
<summary>Verified that script fails if declarationDir is not defined</summary>

```console
$ git diff
diff --git a/clients/client-s3/tsconfig.types.json b/clients/client-s3/tsconfig.types.json
index cef5e3b..98eb6dd 100644
--- a/clients/client-s3/tsconfig.types.json
+++ b/clients/client-s3/tsconfig.types.json
@@ -3,7 +3,6 @@
     "rootDir": "./src",
     "esModuleInterop": true,
     "declaration": true,
-    "declarationDir": "dist-types",
     "emitDeclarationOnly": true
   },
   "exclude": ["test/**/*", "src/**/*.spec.ts", "dist-types/**/*"]

$ node scripts/build-downlevel-dts.js
/Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:40
          throw new Error(
          ^

Error: The declarationDir is not defined in "clients/client-s3/tsconfig.types.json".
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:40:17
    at Array.forEach (<anonymous>)
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:31:8
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:26:4)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32)
    at Function.Module._load (internal/modules/cjs/loader.js:778:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
```

</details>

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
