### PR TITLE
fix: update error message when declarationDir doesn't exist

### DIFF
--- a/scripts/build-downlevel-dts.js
+++ b/scripts/build-downlevel-dts.js
@@ -44,8 +44,7 @@ packages
         if (!existsSync(declarationDir)) {
           throw new Error(
             `The types for "${workspaceName}" do not exist.\n` +
-              `Either "yarn build:types" is not run in workspace "${workspaceDir}" or` +
-              `types are not emitted in "${declarationDirname}" folder.`
+              `Please build types for workspace "${workspaceDir}" before running downlevel-dts script.`
           );
         }
 


### PR DESCRIPTION
### Issue
Follow-up to https://github.com/trivikr/temp-client-s3/pull/28

### Description
The error `"types are not emitted in "${declarationDirname}" folder"` is no longer valid, as we read declarationDir from `tsconfig.types.json`, and can be removed.

### Testing
```console
$ rm -rf clients/client-s3/dist-types

$ node scripts/build-downlevel-dts.js 
/Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:45
          throw new Error(
          ^

Error: The types for "client-s3" do not exist.
Please build types for workspace "clients/client-s3" before running downlevel-dts script.
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:45:17
    at Array.forEach (<anonymous>)
    at /Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:31:8
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/Users/trivikr/workspace/temp-client-s3/scripts/build-downlevel-dts.js:26:4)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32)
    at Function.Module._load (internal/modules/cjs/loader.js:778:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
