### PR TITLE
fix(e2e): use correct runtime config for webpack

### DIFF
--- a/clients/client-s3/karma.conf.js
+++ b/clients/client-s3/karma.conf.js
@@ -1,3 +1,5 @@
+const webpack = require("webpack");
+
 module.exports = function (config) {
   config.set({
     basePath: "",
@@ -33,6 +35,7 @@ module.exports = function (config) {
           },
         ],
       },
+      plugins: [new webpack.NormalModuleReplacementPlugin(/\.\/runtimeConfig$/, "./runtimeConfig.browser")],
       devtool: "inline-source-map",
     },
     envPreprocessor: ["AWS_SMOKE_TEST_REGION", "AWS_SMOKE_TEST_BUCKET"],


### PR DESCRIPTION
### Issue
Resolves: #13 

### Description
The `browser` entry in `package.json` is not `./runtimeConfig`, but `./dist-cjs/runtimeConfig` and `./dist-es/runtimeConfig`. Will fix it in separate PR.

```console
../../node_modules/karma/bin/karma start karma.conf.js
ℹ ｢wdm｣: Compiled successfully.
ℹ ｢wdm｣: Compiling...
ℹ ｢wdm｣:    402 modules
ℹ ｢wdm｣: Compiled successfully.
Chrome Headless 93.0.4577.82 (Mac OS 10.15.7): Executed 8 of 8 SUCCESS (3.79 secs / 2.909 secs)
Firefox 91.0 (Mac OS 10.15): Executed 8 of 8 SUCCESS (3.817 secs / 3.141 secs)
TOTAL: 16 SUCCESS
```



---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
