### PR TITLE
fix: use dist-es for browser and react-native config

### DIFF
--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -19,10 +19,10 @@
   "types": "./dist-types/index.d.ts",
   "module": "./dist-es/index.js",
   "browser": {
-    "./runtimeConfig": "./runtimeConfig.browser"
+    "./runtimeConfig": "./dist-es/runtimeConfig.browser"
   },
   "react-native": {
-    "./runtimeConfig": "./runtimeConfig.native"
+    "./runtimeConfig": "./dist-es/runtimeConfig.native"
   },
   "files": [
     "dist-*"


### PR DESCRIPTION
### Issue
Refs: https://github.com/aws-samples/aws-sdk-js-tests/pull/103#issuecomment-928130625

### Description
Use `dist-es` folder for browser and react-native config

### Testing
ToDo: Verify if it helps fix https://github.com/aws-samples/aws-sdk-js-tests/pull/103

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
